### PR TITLE
.tasks: Drop chance in tasks file

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -13,14 +13,5 @@
 
 set -ex
 
-# When run automated, randomize to minimize stampeding herd
-if [ -t 0 ]; then
-    chance=10
-else
-    chance=$(shuf -i 0-10 -n 1)
-fi
-
-if [ $chance -gt 9 ]; then
-    bots/image-trigger
-    bots/naughty-trigger
-fi
+bots/image-trigger
+bots/naughty-trigger


### PR DESCRIPTION
The task bots run the tasks file once per iteration rather than 30
times.