### PR TITLE
vm-run: improve --quiet to exit on machine quit

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -476,6 +476,14 @@ class VirtMachine(Machine):
         finally:
             self._cleanup()
 
+    def wait_for_exit(self):
+        cmdline = ['virsh', 'event', '--event', 'lifecycle', '--domain', str(self._domain.ID())]
+        try:
+            while subprocess.call(cmdline, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL) == 0:
+                pass
+        except KeyboardInterrupt:
+            pass
+
     def pull(self, image):
         if "/" in image:
             image_file = os.path.abspath(image)

--- a/vm-run
+++ b/vm-run
@@ -20,7 +20,6 @@ import argparse
 import errno
 import os
 import re
-import signal
 import subprocess
 import sys
 
@@ -150,7 +149,7 @@ try:
 
     # else, just wait for a signal
     else:
-        signal.sigwait([signal.SIGTERM, signal.SIGINT, signal.SIGQUIT])
+        machine.wait_for_exit()
 
 except testvm.Failure as ex:
     sys.stderr.write("vm-run: %s\n" % ex)


### PR DESCRIPTION
vm-run would keep running even after the machine quit (from running
'shutdown' over ssh, for example).  Make it exit (and cleanup) when the
machine exits.