### PR TITLE
Fix test/run

### DIFF
--- a/test/run
+++ b/test/run
@@ -3,22 +3,10 @@
 set -eu
 
 # run static code checks like pyflakes and pep8
-PYFILES=$(grep -lI '^#!.*python' `find -path ./make-checkout-workdir -prune -o -type f ! -name '.*'` 2>/dev/null || true)
-if python3 -m pyflakes $PYFILES >&2; then
-    echo "ok 1 pyflakes"
-else
-    echo "not ok 1 pyflakes"
-    fail=1
-fi
+PYFILES=$(grep -lI '^#!.*python' `find -path ./make-checkout-workdir -prune -o -type f ! -name '.*'` 2>/dev/null)
+python3 -m pyflakes $PYFILES
 
 # FIXME: Fix code for the warnings and re-enable them
-out=$(python3 -m pycodestyle --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md,test/run) || true
-if [ -n "$out" ]; then
-    echo "$out" >&2
-    echo "not ok 2 pycodestyle test"
-    fail=1
-else
-    echo "ok 2 pycodestyle test"
-fi
+# python3 -m pycodestyle --ignore E501,E265,E261,W504,W605 $PYFILES
 
 ./test-bots


### PR DESCRIPTION
pyflakes or pycodestyle failures didn't cause the test to fail, as that
merely set `fail=1` which was then ignored.

We don't need TAP output here, so greatly simplify the structure and
rely on our `set -e`.

pycodestyle was called without any actual files to check (this was
already the case in the cockpit repo, bots/ was not covered by
pycodestyle). Fix the invocation, but disable the test for now as it
currently has hundreds of PEP-8 failures.