### PR TITLE
Fix issue-scan regression

### DIFF
--- a/issue-scan
+++ b/issue-scan
@@ -183,12 +183,18 @@ def output_task(command, issue, repo, verbose):
     checkout = "PRIORITY={priority:04d} "
     cmd = "bots/{name} --verbose --issue='{issue}' {context}"
 
+    # when working on bots, don't check out bots into itself
+    if repo == "cockpit-project/bots":
+        bots_ref = ""
+    else:
+        bots_ref = "--bots-ref master"
+
     # `--issues-data` should also be able to receive pull_request events, in that
     # case pull_request won't be present in the object, but commits will be
     if "pull_request" in issue or "commits" in issue:
-        checkout += "bots/make-checkout --verbose --bots-ref master --repo {repo} pull/{issue}/head && "
+        checkout += "bots/make-checkout --verbose {bots_ref} --repo {repo} pull/{issue}/head && "
     else:
-        checkout += "bots/make-checkout --verbose --bots-ref master --repo {repo} master && "
+        checkout += "bots/make-checkout --verbose {bots_ref} --repo {repo} master && "
 
     if verbose:
         return "issue-{issue} {name} {context}    {priority}".format(
@@ -206,6 +212,7 @@ def output_task(command, issue, repo, verbose):
             name=name,
             context=context,
             repo=repo,
+            bots_ref=bots_ref,
         )
 
 

--- a/make-checkout
+++ b/make-checkout
@@ -73,9 +73,6 @@ def main():
     # get bots/
     bots_clone_dir = os.path.join(TARGET_DIR, "bots")
     if opts.bots_ref:
-        # TODO: remove this when cockpit-project/cockpit#12872 has landed
-        if os.path.exists(bots_clone_dir):
-            shutil.rmtree(bots_clone_dir)
         execute("git", "clone", "--reference-if-able", "{}/{}".format(cache, "cockpit-project/bots"), "https://github.com/cockpit-project/bots", bots_clone_dir, cwd=TARGET_DIR)
         execute("git", "fetch", "--depth=1", "origin", opts.bots_ref or "master", cwd=bots_clone_dir)
         bots_ref = execute("git", "rev-parse", "FETCH_HEAD", cwd=bots_clone_dir).strip()


### PR DESCRIPTION
PR #36 broke issue-scan for bots project.

I tested this like this:

in bots it doesn't get a --bots-ref:
```
❱❱❱ ./issue-scan 
PRIORITY=0009 bots/make-checkout --verbose  --repo cockpit-project/bots pull/35/head && cd bots/make-checkout-workdir && bots/image-refresh --verbose --issue='35' centos-7 ; cd ../..
```
in podman it does:
```
❱❱❱ bots/issue-scan 
PRIORITY=0009 bots/make-checkout --verbose --bots-ref master --repo cockpit-project/cockpit-podman master && cd bots/make-checkout-workdir && bots/npm-update --verbose --issue='210'  ; cd ../..
```
I ran both generated commands and they work fine.