### PR TITLE
image-refresh: Run default tests automatically

### DIFF
--- a/image-refresh
+++ b/image-refresh
@@ -156,7 +156,7 @@ def run(image, verbose=False, **kwargs):
 
     branch = task.branch(image, "images: Update {0} image".format(image), pathspec="images", **kwargs)
     if branch:
-        pull = task.pull(branch, labels=['bot', 'no-test'], run_tests=False, **kwargs)
+        pull = task.pull(branch, labels=['bot'], **kwargs)
 
         # Trigger this pull request
         api = github.GitHub()


### PR DESCRIPTION
This was useful when bots were part of cockpit as we didn't want to
trigger all contexts on image refreshes.

Now only default context is `host`. We don't really need to tests this
context on image refreshes either, but it is required context and it
blocks PRs from landing.

Noticed today as I had to manually trigger `host` on every image refresh in order to land them.
Also see my comment in https://github.com/cockpit-project/bots/pull/39