### PR TITLE
Whitelist candlepin project for tests

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -375,7 +375,10 @@ class GitHub(object):
                 count += 1
 
     def whitelist(self):
-        users = set()
+        # organizations which are allowed to use our CI (these use branches within the main repo for PRs)
+        users = {"candlepin"}
+
+        # individual persons from https://github.com/orgs/cockpit-project/teams/contributors/members
         teamId = self.teamIdFromName(TEAM_CONTRIBUTORS)
         page = 1
         count = 100

--- a/task/test-github
+++ b/task/test-github
@@ -175,7 +175,7 @@ class TestGitHub(unittest.TestCase):
     def testWhitelist(self):
         whitelist = self.api.whitelist()
         self.assertTrue(len(whitelist) > 0)
-        self.assertEqual(whitelist, set(["one", "two", "three"]))
+        self.assertEqual(whitelist, set(["one", "two", "three", "candlepin"]))
         self.assertNotIn("four", whitelist)
         self.assertNotIn("", whitelist)
 


### PR DESCRIPTION
The candlepin project uses branches inside the main candlepin repo,
instead of PRs from forks owned by individual people. Thus we can't
control these through our contributors team.

Explicitly list the allowed teams. Hardcoding this is a bit nasty, but
it's a lot simpler to change than figuring out how to get a team of
teams in GitHub (which doesn't seem to be possible at the moment).