### PR TITLE
make-checkout, tests-scan: Drop obsolete --base option

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -36,7 +36,6 @@ TARGET_DIR = os.path.realpath(os.path.join(BOTS_DIR, "make-checkout-workdir"))
 def main():
     parser = argparse.ArgumentParser(description="Fetch and checkout specific revision")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
-    parser.add_argument("--base", nargs='?', help="Base branch that revision is for")
     parser.add_argument("--repo", nargs='?', help="Repository to check out")
     parser.add_argument("--bots-ref", help="bots/ ref to check out from cockpit, for non-default --repo")
     parser.add_argument("ref", help="The git ref to fetch")

--- a/tests-scan
+++ b/tests-scan
@@ -151,7 +151,6 @@ def tests_invoke(priority, name, number, revision, ref, context, base, original_
     if base:
         if base != ref:
             cmd += " --rebase={base}"
-        checkout += " --base={base}"
 
     checkout += " --repo={repo}"
 


### PR DESCRIPTION
make-checkout does not do anything with this argument.