### PR TITLE
testmap: add manual rhel-7-7/tar target for composer

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -102,6 +102,10 @@ REPO_BRANCH_CONTEXT = {
             'rhel-7-7/openstack',
             'rhel-7-7/vmware',
         ],
+        # These can be triggered manually with bots/tests-trigger
+        '_manual': [
+            'rhel-7-7/tar',
+        ],
     },
     'weldr/cockpit-composer': {
         'master': [


### PR DESCRIPTION
The need for this arose from weldr/lorax [PR #823](https://github.com/weldr/lorax/pull/823).