### PR TITLE
testmap: run rhel-7-7/tar automatically for weldr/lorax

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -101,10 +101,10 @@ REPO_BRANCH_CONTEXT = {
             'rhel-7-7/azure',
             'rhel-7-7/openstack',
             'rhel-7-7/vmware',
+            'rhel-7-7/tar',
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'rhel-7-7/tar',
         ],
     },
     'weldr/cockpit-composer': {


### PR DESCRIPTION
Now that the `rhel-7-7/tar` test passed in CI (weldr/lorax#823), it should be executed automatically. One thing I'm not sure about is whether I can leave the `_manual` list empty just for reference, or should I rather remove it completely?