### PR TITLE
Stop preparing bots in make-checkout

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -37,7 +37,6 @@ def main():
     parser = argparse.ArgumentParser(description="Fetch and checkout specific revision")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     parser.add_argument("--repo", nargs='?', help="Repository to check out")
-    parser.add_argument("--bots-ref", help="bots/ ref to check out from cockpit, for non-default --repo")
     parser.add_argument("ref", help="The git ref to fetch")
     parser.add_argument("revision", nargs='?', help="Actual commit to check out, defaults to ref")
 
@@ -67,14 +66,6 @@ def main():
     execute("git", "clone", "--reference-if-able", "{}/{}".format(cache, api.repo), "https://github.com/{}".format(api.repo), TARGET_DIR)
     execute("git", "fetch", "origin", opts.ref, cwd=TARGET_DIR, error_on_fail=False)
     execute("git", "checkout", "--detach", opts.revision, cwd=TARGET_DIR, error_on_fail=False)
-
-    # get bots/
-    bots_clone_dir = os.path.join(TARGET_DIR, "bots")
-    if opts.bots_ref:
-        execute("git", "clone", "--reference-if-able", "{}/{}".format(cache, "cockpit-project/bots"), "https://github.com/cockpit-project/bots", bots_clone_dir)
-        execute("git", "fetch", "--depth=1", "origin", opts.bots_ref or "master", cwd=bots_clone_dir)
-        bots_ref = execute("git", "rev-parse", "FETCH_HEAD", cwd=bots_clone_dir).strip()
-        execute("git", "checkout", "--force", bots_ref or "bots_origin/master", cwd=bots_clone_dir, error_on_fail=False)
 
 
 if __name__ == '__main__':

--- a/tests-scan
+++ b/tests-scan
@@ -147,15 +147,12 @@ def tests_invoke(priority, name, number, revision, ref, context, base, original_
     current = time.strftime('%Y%m%d-%H%M%M')
 
     checkout = "PRIORITY={priority:04d} ./make-checkout --verbose"
-    cmd = "TEST_PROJECT={repo} TEST_NAME={name}-{current} TEST_REVISION={revision} bots/tests-invoke --pull-number={pull_number} "
+    cmd = "TEST_PROJECT={repo} TEST_NAME={name}-{current} TEST_REVISION={revision} ../tests-invoke --pull-number={pull_number} "
     if base:
         if base != ref:
             cmd += " --rebase={base}"
 
     checkout += " --repo={repo}"
-
-    if bots_ref:
-        checkout += " --bots-ref={bots_ref}"
 
     # The repo of this test differs from the PR's repo
     if options.repo != repo:
@@ -172,6 +169,7 @@ def tests_invoke(priority, name, number, revision, ref, context, base, original_
     if bots_ref:
         # we are checking the external repo on a cockpit PR, so stay on the project's master
         checkout += " {ref} && "
+        cmd = "COCKPIT_BOTS_REF={bots_ref} " + cmd
     else:
         # we are testing the repo itself, checkout revision from the PR
         checkout += " {ref} {revision} && "


### PR DESCRIPTION
Instead define `COCKPIT_BOTS_REF` environment variable and let projects
resolve it on their own.

PR in cockpit:
```
PRIORITY=0005 ./make-checkout --verbose --repo=cockpit-project/cockpit pull/12927/head && cd make-checkout-workdir && COCKPIT_BOTS_REF=master TEST_PROJECT=cockpit-project/cockpit TEST_NAME=pull-12927-20191007-144646 TEST_REVISION=d0c3cb2642d8dcfffe473f376364b3752c273bc1 ../tests-invoke --pull-number=12927  --rebase=master fedora-30 ; cd ..
```

Also tried to replace `COCKPIT_BOTS_REF=master` with `COCKPIT_BOTS_REF=pull/102/head` and it prepared bots without `bots` symlink as changed in #102.

PR in bots:
```
PRIORITY=0004 ./make-checkout --verbose --repo=cockpit-project/bots pull/102/head 4868ab7fe025fbbc3c2d99444a16768d07a4d72f && cd make-checkout-workdir && TEST_PROJECT=cockpit-project/bots TEST_NAME=pull-102-20191007-145252 TEST_REVISION=4868ab7fe025fbbc3c2d99444a16768d07a4d72f ../tests-invoke --pull-number=102  --rebase=master host ; cd ..
```

