### PR TITLE
*-scan: Drop /dev/kvm check

### DIFF
--- a/issue-scan
+++ b/issue-scan
@@ -28,10 +28,6 @@ NAMES = [
     "flakes-refresh",
 ]
 
-KVM_TASKS = [
-    "image-refresh"
-]
-
 # RHEL tasks have to be done inside Red Hat network
 REDHAT_TASKS = [
     "rhel",
@@ -52,7 +48,6 @@ REDHAT_CREDS = "~/.rhel/login"
 
 import argparse
 import pipes
-import os
 import sys
 import json
 
@@ -80,10 +75,6 @@ def main():
     if opts.amqp and no_amqp:
         parser.error("AMQP host:port specified but python-amqp not available")
 
-    kvm = os.access("/dev/kvm", os.R_OK | os.W_OK)
-    if not kvm:
-        sys.stderr.write("issue-scan: No /dev/kvm access, not creating images here\n")
-
     # Figure if we're in a Kubernetes namespace. This file will always exist
     try:
         with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
@@ -97,9 +88,6 @@ def main():
                 queue_task(q.channel, result)
             continue
 
-        if not kvm and contains_any(result, KVM_TASKS):
-            sys.stderr.write("issue-scan: skipping (no kvm): {0}\n".format(result))
-            continue
         elif not redhat_network() and contains_any(result, REDHAT_TASKS):
             sys.stderr.write("issue-scan: skipping (outside redhat): {0}\n".format(result))
             continue

--- a/tests-scan
+++ b/tests-scan
@@ -23,7 +23,6 @@ REPO_EXTRA_INVOKE_OPTIONS = {
 }
 
 import argparse
-import os
 import json
 import pipes
 import sys
@@ -415,11 +414,6 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
 
 
 def scan_for_pull_tasks(api, policy, opts, repo):
-    kvm = os.access("/dev/kvm", os.R_OK | os.W_OK)
-    if not kvm:
-        logging.error("tests-scan: No /dev/kvm access, not running tests here")
-        return []
-
     results = cockpit_tasks(api, not opts.dry, policy, repo, opts.pull_data, opts.pull_number, opts.sha, opts.amqp)
 
     if opts.human_readable:


### PR DESCRIPTION
These scripts now merely produce AMQP queue entries, for which it does
not matter where they run.

This was important while issues and tasks ran from projects' .tasks
files, but these days are gone.