### PR TITLE
image-refresh: Move some test triggers to rhel-7.8

### DIFF
--- a/image-refresh
+++ b/image-refresh
@@ -32,7 +32,7 @@ TRIGGERS = {
     ],
     "continuous-atomic": [
         "continuous-atomic@cockpit-project/cockpit-ostree",
-        "continuous-atomic@cockpit-project/cockpit/rhel-7.7",
+        "continuous-atomic@cockpit-project/cockpit/rhel-7.8",
     ],
     "debian-testing": [
         "debian-testing@cockpit-project/cockpit"
@@ -80,7 +80,6 @@ TRIGGERS = {
         "ubuntu-stable@cockpit-project/cockpit"
     ],
     "openshift": [
-        "rhel-7-7@cockpit-project/cockpit/rhel-7.7",
         "rhel-7-8@cockpit-project/cockpit/rhel-7.8",
     ],
     "ipa": [
@@ -118,7 +117,7 @@ TRIGGERS = {
     ],
     "rhel-atomic": [
         "rhel-atomic@cockpit-project/cockpit-ostree",
-        "rhel-atomic@cockpit-project/cockpit/rhel-7.7",
+        "rhel-atomic@cockpit-project/cockpit/rhel-7.8",
     ]
 }
 

--- a/task/testmap.py
+++ b/task/testmap.py
@@ -43,7 +43,7 @@ REPO_BRANCH_CONTEXT = {
         'rhel-8.1': ['fedora-30/container-bastion',
             'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome', 'rhel-8-1',
         ],
-        'rhel-7.8': ['rhel-7-8',
+        'rhel-7.8': ['rhel-7-8', 'rhel-atomic',
             'fedora-30/container-bastion', 'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome',
         ],
         # These can be triggered manually with bots/tests-trigger


### PR DESCRIPTION
rhel-7.7 is not an actively maintained branch any more.

 - [x] fix rhel-atomic test on rhel-7.8 branch: https://github.com/cockpit-project/cockpit/pull/12959