### PR TITLE
Always use log.html

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -44,7 +44,6 @@ def main():
                         action='store', help='Publish results centrally to a sink')
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
     parser.add_argument('--pull-number', help="The number of the pull request to test")
-    parser.add_argument('--html-logs', action='store_true', help="Use log.html to prettify the raw logs")
     parser.add_argument('context', help="The context or type of integration tests to run")
     opts = parser.parse_args()
 
@@ -58,8 +57,7 @@ def main():
 
     try:
         task = PullTask(name, revision, opts.context, opts.rebase,
-                        test_project=test_project, test_branch=test_branch,
-                        html_logs=opts.html_logs)
+                        test_project=test_project, test_branch=test_branch)
         ret = task.run(opts)
     except RuntimeError as ex:
         ret = str(ex)
@@ -71,14 +69,13 @@ def main():
 
 
 class PullTask(object):
-    def __init__(self, name, revision, context, base, test_project, test_branch, html_logs):
+    def __init__(self, name, revision, context, base, test_project, test_branch):
         self.name = name
         self.revision = revision
         self.context = context
         self.base = base
         self.test_project = test_project
         self.test_branch = test_branch
-        self.html_logs = html_logs
 
         self.sink = None
         self.github_status_data = None
@@ -177,20 +174,8 @@ class PullTask(object):
             }
         }
 
-        if self.html_logs:
-            # explicit request for html logs
-            status["link"] = "log.html"
-            status["extras"] = ["https://raw.githubusercontent.com/cockpit-project/bots/master/task/log.html"]
-        elif self.test_project != "cockpit-project/cockpit":
-            # third-party project, link directly to text log
-            status["link"] = "log"
-        else:
-            # Testing cockpit itself, use HTML log from current
-            # revision.  Use log.html from code under test, but only
-            # if we are on master.  Other branches don't have a bots/
-            # in their repo.
-            status["link"] = "log.html"
-            status["extras"] = ["https://raw.githubusercontent.com/cockpit-project/bots/{0}/task/log.html".format(self.revision if not self.base else "master")]
+        status["link"] = "log.html"
+        status["extras"] = ["https://raw.githubusercontent.com/cockpit-project/bots/master/task/log.html"]
 
         # Include information about which base we're testing against
         if self.base:

--- a/tests-scan
+++ b/tests-scan
@@ -17,11 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-# Random extra options for tests-invoke
-REPO_EXTRA_INVOKE_OPTIONS = {
-    'candlepin/subscription-manager': ["--html-logs"]
-}
-
 import argparse
 import json
 import pipes
@@ -156,9 +151,6 @@ def tests_invoke(priority, name, number, revision, ref, context, base, original_
     # The repo of this test differs from the PR's repo
     if options.repo != repo:
         cmd = "GITHUB_BASE={github_base} " + cmd
-
-    if repo in REPO_EXTRA_INVOKE_OPTIONS:
-        cmd += " " + " ".join(REPO_EXTRA_INVOKE_OPTIONS[repo])
 
     # Let tests-invoke know that we are triggering different branch - it needs to post correct status
     if base != original_base:


### PR DESCRIPTION
If project does not support proper html logs, then it just shows one box
with textual output.

Now also podman will have html logs (which is awesome!)

How to test:
1. Get some log (for example [podman](https://209.132.184.41:8493/logs/pull-173-20191002-115353-aeb97d42-cockpit-project-cockpit-podman--fedora-29/log), [composer](https://209.132.184.41:8493/logs/pull-802-20191008-220000-53663f9a-weldr-cockpit-composer--fedora-30-chrome/log)) as save them as `log`
2. `curl -k -o log.html https://raw.githubusercontent.com/cockpit-project/bots/master/task/log.html`
3. `python3 -m http.server`
4. visit http://localhost:8000/log.html