### PR TITLE
Cleanup in tests-invoke no.2

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -177,13 +177,6 @@ class PullTask(object):
         status["link"] = "log.html"
         status["extras"] = ["https://raw.githubusercontent.com/cockpit-project/bots/master/task/log.html"]
 
-        # Include information about which base we're testing against
-        if self.base:
-            subprocess.check_call(["git", "fetch", "origin", self.base])
-            commit = subprocess.check_output(["git", "rev-parse", "origin/" + self.base],
-                                             universal_newlines=True).strip()
-            status["base"] = commit
-
         # For other scripts to use
         os.environ["TEST_DESCRIPTION"] = description
         self.sink = sink.Sink(host, identifier, status)

--- a/tests-invoke
+++ b/tests-invoke
@@ -55,6 +55,9 @@ def main():
     # TEST_BRANCH would be `rhel-8.0`
     test_branch = os.environ.get("TEST_BRANCH")
 
+    if opts.publish and not revision:
+        parser.error("TEST_REVISION is required for proper publishing")
+
     try:
         task = PullTask(name, revision, opts.context, opts.rebase,
                         test_project=test_project, test_branch=test_branch)
@@ -242,16 +245,11 @@ class PullTask(object):
             self.start_publishing(opts.publish)
             os.environ["TEST_ATTACHMENTS"] = self.sink.attachments
 
-        head = subprocess.check_output(["git", "rev-parse", "HEAD"], universal_newlines=True).strip()
-        if not self.revision:
-            self.revision = head
-
         # Retrieve information about our base branch and master (for bots/)
         if self.base and not opts.offline:
             subprocess.check_call(["git", "fetch", "origin", self.base, "master"])
 
         os.environ["TEST_NAME"] = self.name
-        os.environ["TEST_REVISION"] = self.revision
 
         # Split OS and potential scenario
         (image, _, scenario) = self.context.partition("/")


### PR DESCRIPTION
I am looking into how we can move the rebasing out of invoke and how we can make it simpler (and then split into logging and really tests invoking (which may not need to be even script only executing command on cmdline)).

- For commit `Do not parse HEAD `: I've checked `tests-scan` and it seem to be always set (from what github sends)

- For commit `Do not set 'base'`: I haven't found where this is used. @Gundersanne @martinpitt can you find such case?