### PR TITLE
test: Use 'git grep' for finding python files

### DIFF
--- a/test/run
+++ b/test/run
@@ -3,7 +3,7 @@
 set -eu
 
 # run static code checks like pyflakes and pep8
-PYFILES=$(grep -lI '^#!.*python' `find -path ./make-checkout-workdir -prune -o -type f ! -name '.*'` 2>/dev/null)
+PYFILES=$(git grep -lI '^#!.*python')
 python3 -m pyflakes $PYFILES
 
 # FIXME: Fix code for the warnings and re-enable them


### PR DESCRIPTION
We were using `find` which had a few problems:
1. It was listing all files in `.git/`
2. It listed `./make-checkout-workdir` (and thus failed when this directory existed)
3. It was not easy to read

`git grep` concerns only git files, which is what we want anyway - and
`git` command is present everywhere where we run these tests.