### PR TITLE
Rebase in make-checkout and not in tests-invoke

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -37,6 +37,7 @@ def main():
     parser = argparse.ArgumentParser(description="Fetch and checkout specific revision")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     parser.add_argument("--repo", nargs='?', help="Repository to check out")
+    parser.add_argument("--rebase", metavar="branch", help="Branch to rebase to")
     parser.add_argument("ref", help="The git ref to fetch")
     parser.add_argument("revision", nargs='?', help="Actual commit to check out, defaults to ref")
 
@@ -66,6 +67,14 @@ def main():
     execute("git", "clone", "--reference-if-able", "{}/{}".format(cache, api.repo), "https://github.com/{}".format(api.repo), TARGET_DIR)
     execute("git", "fetch", "origin", opts.ref, cwd=TARGET_DIR, error_on_fail=False)
     execute("git", "checkout", "--detach", opts.revision, cwd=TARGET_DIR, error_on_fail=False)
+
+    if opts.rebase:
+        remote_base = "origin/" + opts.rebase
+
+        execute("git", "fetch", "origin", opts.rebase, cwd=TARGET_DIR, error_on_fail=False)
+        sha = execute("git", "rev-parse", remote_base, cwd=TARGET_DIR, error_on_fail=False).strip()
+        sys.stderr.write("Rebasing onto {0} ({1}) ...\n".format(remote_base, sha))
+        execute("git", "rebase", remote_base, cwd=TARGET_DIR, error_on_fail=False)
 
 
 if __name__ == '__main__':

--- a/tests-invoke
+++ b/tests-invoke
@@ -22,7 +22,6 @@ import os
 import socket
 import subprocess
 import sys
-import traceback
 
 sys.dont_write_bytecode = True
 
@@ -37,9 +36,6 @@ DEVNULL = open("/dev/null", "r+")
 
 def main():
     parser = argparse.ArgumentParser(description='Run integration tests')
-    parser.add_argument('--rebase', help="Rebase onto the specific branch before testing")
-    parser.add_argument('-o', "--offline", action='store_true',
-                        help="Work offline, don''t fetch new data from origin for rebase")
     parser.add_argument('--publish', dest='publish', default=os.environ.get("TEST_PUBLISH", ""),
                         action='store', help='Publish results centrally to a sink')
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
@@ -59,7 +55,7 @@ def main():
         parser.error("TEST_REVISION is required for proper publishing")
 
     try:
-        task = PullTask(name, revision, opts.context, opts.rebase,
+        task = PullTask(name, revision, opts.context,
                         test_project=test_project, test_branch=test_branch)
         ret = task.run(opts)
     except RuntimeError as ex:
@@ -72,11 +68,10 @@ def main():
 
 
 class PullTask(object):
-    def __init__(self, name, revision, context, base, test_project, test_branch):
+    def __init__(self, name, revision, context, test_project, test_branch):
         self.name = name
         self.revision = revision
         self.context = context
-        self.base = base
         self.test_project = test_project
         self.test_branch = test_branch
 
@@ -184,23 +179,6 @@ class PullTask(object):
         os.environ["TEST_DESCRIPTION"] = description
         self.sink = sink.Sink(host, identifier, status)
 
-    def rebase(self):
-        remote_base = "origin" + "/" + self.base
-
-        # Rebase this branch onto the base, but only if it's not already an ancestor
-        try:
-            if subprocess.call(["git", "merge-base", "--is-ancestor", remote_base, "HEAD"]) != 0:
-                sha = subprocess.check_output(["git", "rev-parse", remote_base], universal_newlines=True).strip()
-                sys.stderr.write("Rebasing onto {0} ({1}) ...\n".format(remote_base, sha))
-                subprocess.check_call(["git", "reset", "HEAD"])
-                subprocess.check_call(["git", "rebase", remote_base])
-        except subprocess.CalledProcessError:
-            subprocess.call(["git", "rebase", "--abort"])
-            traceback.print_exc()
-            return "Rebase failed"
-
-        return None
-
     def stop_publishing(self, ret):
         sink = self.sink
 
@@ -245,10 +223,6 @@ class PullTask(object):
             self.start_publishing(opts.publish)
             os.environ["TEST_ATTACHMENTS"] = self.sink.attachments
 
-        # Retrieve information about our base branch and master (for bots/)
-        if self.base and not opts.offline:
-            subprocess.check_call(["git", "fetch", "origin", self.base, "master"])
-
         os.environ["TEST_NAME"] = self.name
 
         # Split OS and potential scenario
@@ -262,9 +236,6 @@ class PullTask(object):
         sys.stderr.write(msg)
 
         ret = None
-
-        if self.base:
-            ret = self.rebase()
 
         # Flush our own output before running command
         sys.stdout.flush()

--- a/tests-scan
+++ b/tests-scan
@@ -142,9 +142,8 @@ def tests_invoke(priority, name, number, revision, ref, context, base, original_
 
     checkout = "PRIORITY={priority:04d} ./make-checkout --verbose"
     cmd = "TEST_PROJECT={repo} TEST_NAME={name}-{current} TEST_REVISION={revision} ../tests-invoke --pull-number={pull_number} "
-    if base:
-        if base != ref:
-            cmd += " --rebase={base}"
+    if base != ref:
+        checkout += " --rebase={base}"
 
     checkout += " --repo={repo}"
 


### PR DESCRIPTION
It makes much more sense to do this in make-checkout. The only problem
is that if rebasing fails, it won't be in logs. But since the goal is to
make from logging wrapper around all commands, then also make-checkout
would log what is happening.

Also it could be written as shell script - but that may be a follow-up.