### PR TITLE
[no-test] testmap: add manual fedora-31/firefox target for cockpit-composer

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -121,6 +121,10 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-0/firefox',
             'rhel-8-0/edge',
         ],
+        # These can be triggered manually with bots/tests-trigger
+        '_manual': [
+            'fedora-31/firefox'
+        ],
     },
     'candlepin/subscription-manager': {
         'master': [


### PR DESCRIPTION
Adds a manual trigger to run cockpit-composer's tests on firefox on fedora-31. 