### PR TITLE
image-customize: Auto-detect package manager for --install

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -32,9 +32,8 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose progress details')
 parser.add_argument('-i', '--install', action='append', dest="packagelist", default=[], help='Install packages')
-parser.add_argument('-I', '--install-command', action='store', dest="installcommand",
-                    default="yum --setopt=skip_missing_names_on_install=False -y install",
-                    help="Command used to install packages in machine")
+parser.add_argument('-I', '--install-command',
+                    help="Command used to install packages in machine (default: auto-detect dnf/yum/apt)")
 parser.add_argument('-r', '--run-command', action='append', dest="commandlist",
                     default=[], help='Run command inside virtual machine')
 parser.add_argument('-s', '--script', action='append', dest="scriptlist",
@@ -117,6 +116,17 @@ def install_packages(machine_instance, packagelist, install_command):
     """Install packages into a test image
     It could be done via local rpms or normal package installation
     """
+
+    if not install_command:
+        # this will fail if neither is available -- exception is clear enough, this is a developer tool
+        out = machine_instance.execute("which dnf || which yum || which apt-get")
+        if 'dnf' in out:
+            install_command = "dnf install -y"
+        elif 'yum' in out:
+            install_command = "yum --setopt=skip_missing_names_on_install=False -y install"
+        else:
+            install_command = "apt-get install -y"
+
     allpackages = []
     for foo in packagelist:
         if os.path.isfile(foo):
@@ -144,7 +154,7 @@ if args.commandlist or args.packagelist or args.scriptlist or args.uploadlist or
         if args.commandlist:
             run_command(machine, args.commandlist)
         if args.packagelist:
-            install_packages(machine, args.packagelist, args.installcommand)
+            install_packages(machine, args.packagelist, args.install_command)
         if args.scriptlist:
             run_script(machine, args.scriptlist)
     finally:


### PR DESCRIPTION
This fixes image-customize for Fedora 31, which does not have the "yum"
shim installed by default any more. This now also works for
Debian/Ubuntu images.

This should avoid the need for --install-command in most cases.