### PR TITLE
testmap: Add experimental context for testing Firefox through CDP

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -51,6 +51,7 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'fedora-i386',
             'fedora-testing',
+            'fedora-30/firefox', # Experimental context for Firefox CDP testing
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
I am getting some nice results with firefox CDP testing, like all tests in `test/verify/check-services` pass. I am still aware of few issues, but in meantime I want to prepare CI.