### PR TITLE
naughty: Close 78: Selinux prevents setting timezone via timedatectl, prevents write to /etc/localtime

### DIFF
--- a/naughty/fedora-31/78-selinux-timedatectl
+++ b/naughty/fedora-31/78-selinux-timedatectl
@@ -1,1 +1,0 @@
-*Failed to set time zone: Failed to update /etc/localtime*

--- a/naughty/fedora-31/78-selinux-timedatectl-2
+++ b/naughty/fedora-31/78-selinux-timedatectl-2
@@ -1,1 +1,0 @@
-*Failed to set time: Failed to set system clock: Operation not permitted*


### PR DESCRIPTION
Known issue which has not occurred in 24 days

Selinux prevents setting timezone via timedatectl, prevents write to /etc/localtime

Fixes #78