### PR TITLE
naughty: Close 77: libvirtd sometimes crashes on rhel-8-1 when destroying guests

### DIFF
--- a/naughty/rhel-8/77-libvirtd-crash-domain-destroy-test-failed
+++ b/naughty/rhel-8/77-libvirtd-crash-domain-destroy-test-failed
@@ -1,5 +1,0 @@
-# testCreate (check_machines_dbus.TestMachinesDBus)
-*
-warning: ERROR    End of file while reading data: Input/output error
-Domain installation does not appear to have been successful.
-*

--- a/naughty/rhel-8/77-libvirtd-crash-domain-destroy-test-finished
+++ b/naughty/rhel-8/77-libvirtd-crash-domain-destroy-test-finished
@@ -1,5 +1,0 @@
-# testCreate (check_machines_dbus.TestMachinesDBus)
-*
-*Process * (libvirtd) of user 0 dumped core.
-Stack trace of thread *:
-* virDomainDefFree (libvirt.so.0)


### PR DESCRIPTION
Known issue which has not occurred in 24 days

libvirtd sometimes crashes on rhel-8-1 when destroying guests

Fixes #77