### PR TITLE
naughty: Close 75: podman crashes on fedora-30 when doing bulk deletion of images and calling ListImages in parallel

### DIFF
--- a/naughty/fedora-30/75-podman-image-deletion-listing-crash
+++ b/naughty/fedora-30/75-podman-image-deletion-listing-crash
@@ -1,3 +1,0 @@
-# testRunImage (__main__.TestApplication)*
-*
-*Process * (podman) of user 0 dumped core.

--- a/naughty/fedora-30/75-podman-image-deletion-listing-crash-2
+++ b/naughty/fedora-30/75-podman-image-deletion-listing-crash-2
@@ -1,3 +1,0 @@
-# testRunImage (__main__.TestApplication)
-*
-* warning: Failed to do *: {"name":"ConnectionClosed","parameters":{}}*


### PR DESCRIPTION
Known issue which has not occurred in 21 days

podman crashes on fedora-30 when doing bulk deletion of images and calling ListImages in parallel

Fixes #75