### PR TITLE
Revert switch to Fedora-31 for weldr/lorax

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -73,14 +73,14 @@ REPO_BRANCH_CONTEXT = {
     },
     'weldr/lorax': {
         'master': [
-            'fedora-31',
-            'fedora-31/tar',
-            'fedora-31/live-iso',
-            'fedora-31/qcow2',
-            'fedora-31/aws',
-            'fedora-31/azure',
-            'fedora-31/openstack',
-            'fedora-31/vmware',
+            'fedora-30',
+            'fedora-30/tar',
+            'fedora-30/live-iso',
+            'fedora-30/qcow2',
+            'fedora-30/aws',
+            'fedora-30/azure',
+            'fedora-30/openstack',
+            'fedora-30/vmware',
         ],
         'rhel8-branch': [
             'rhel-8-1',
@@ -104,7 +104,15 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
+            'fedora-31',
             'fedora-31/ci',
+            'fedora-31/tar',
+            'fedora-31/live-iso',
+            'fedora-31/qcow2',
+            'fedora-31/aws',
+            'fedora-31/azure',
+            'fedora-31/openstack',
+            'fedora-31/vmware',
         ],
     },
     'weldr/cockpit-composer': {


### PR DESCRIPTION
we've got problems booting Composer images with QEMU so revert
until this has been sorted out. Keep the new test targets for
manual scheduling.

@martinpitt, @larskarlitski - for more info about the issues I'm seeing:
https://github.com/weldr/lorax/pull/887#issuecomment-546387920

Should have tested this before landing it directly. :-(