### PR TITLE
images: Drop freeipa-client from debian-testing

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-ba2d089cb5707a94591d5825334e6e8d189d1b7a17b9f657d50f9222ba2e7954.qcow2
+debian-testing-e6e70d6fb0be24b34c0465cd182c2ddcd2f2a755dcdc7fdff90cb6f699882720.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -120,13 +120,6 @@ apt-get install -y eatmydata
 # remove packages that we don't need
 for p in lxd snapd landscape-common accountsservice open-vm-tools ufw cloud-init; do eatmydata apt-get purge -y --auto-remove $p || true; done
 
-# HACK: work around fuse 2.9.9-1 install failure (https://bugs.debian.org/935496)
-if [ "$1" = "debian-testing" ]; then
-    rm /dev/fuse
-    # this needs to happen right away, as upgrading other packages triggers udev events which recreate /dev/fuse
-    eatmydata apt-get install -y fuse
-fi
-
 # HACK: debian-stable image got /usr/bin/qemu-img removed, even though qemu-utils package is installed
 if [ "$1" = "debian-stable" ]; then
     eatmydata apt-get install --reinstall -y qemu-utils

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -112,6 +112,11 @@ if [ "$1" = "debian-testing" ]; then
     echo 'deb http://deb.debian.org/debian testing main' > /etc/apt/sources.list
 fi
 
+# freeipa got dropped from testing: https://tracker.debian.org/pkg/freeipa
+if [ "$1" = "debian-testing" ]; then
+    IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
+fi
+
 export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
 # apt go-faster


### PR DESCRIPTION
https://tracker.debian.org/pkg/freeipa has fallen out of testing a month
ago, until https://tracker.debian.org/pkg/dogtag-pki will be ported to
Java 11 and get back into testing. This apparently takes a while, so
unblock image updates by removing it for now.

Fixes #130

 * [x] image-refresh debian-testing
 * [x] Disable IPA related tests: https://github.com/cockpit-project/cockpit/pull/13044