### PR TITLE
naughty: Apply issue #80 to RHEL 8

### DIFF
--- a/naughty/rhel-8/80-sssd-ssh-ticket-expired
+++ b/naughty/rhel-8/80-sssd-ssh-ticket-expired
@@ -1,0 +1,4 @@
+  File "test/verify/check-realms", line *, in testNegotiate
+    b.wait_popdown('troubleshoot-dialog')
+*
+testlib.Error: timeout


### PR DESCRIPTION
RHEL 8.2 inherited the sssd regression from F31:
https://bugzilla.redhat.com/show_bug.cgi?id=1757224