### PR TITLE
Revert "testmap: Revert switch to Fedora-31 for weldr/lorax"

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -72,14 +72,14 @@ REPO_BRANCH_CONTEXT = {
     },
     'weldr/lorax': {
         'master': [
-            'fedora-30',
-            'fedora-30/tar',
-            'fedora-30/live-iso',
-            'fedora-30/qcow2',
-            'fedora-30/aws',
-            'fedora-30/azure',
-            'fedora-30/openstack',
-            'fedora-30/vmware',
+            'fedora-31',
+            'fedora-31/tar',
+            'fedora-31/live-iso',
+            'fedora-31/qcow2',
+            'fedora-31/aws',
+            'fedora-31/azure',
+            'fedora-31/openstack',
+            'fedora-31/vmware',
         ],
         'rhel8-branch': [
             'rhel-8-1',
@@ -103,15 +103,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'fedora-31',
             'fedora-31/ci',
-            'fedora-31/tar',
-            'fedora-31/live-iso',
-            'fedora-31/qcow2',
-            'fedora-31/aws',
-            'fedora-31/azure',
-            'fedora-31/openstack',
-            'fedora-31/vmware',
         ],
     },
     'weldr/cockpit-composer': {


### PR DESCRIPTION
This reverts commit 1417905f839dfba8a221b0e9bb630b8d07717f8e.

Nested virt issues have been sorted out so lorax-composer test suite shouldn't have any problems with qcow2, live-iso or kickstart tar tests going forward.