### PR TITLE
naughty: Consistent pattern for unexpected audit messages

### DIFF
--- a/naughty/continuous-atomic/62-selinux-rhsmd-dbus
+++ b/naughty/continuous-atomic/62-selinux-rhsmd-dbus
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="dbus"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="dbus"

--- a/naughty/continuous-atomic/62-selinux-rhsmd-encodings
+++ b/naughty/continuous-atomic/62-selinux-rhsmd-encodings
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="encodings"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="encodings"

--- a/naughty/continuous-atomic/62-selinux-rhsmd-python2.7
+++ b/naughty/continuous-atomic/62-selinux-rhsmd-python2.7
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="python2.7"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="python2.7"

--- a/naughty/continuous-atomic/62-selinux-rhsmd-subscription_manager
+++ b/naughty/continuous-atomic/62-selinux-rhsmd-subscription_manager
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="subscription_manager"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="subscription_manager"

--- a/naughty/fedora-30/118-selinux-rpcbind-name_bind
+++ b/naughty/fedora-30/118-selinux-rpcbind-name_bind
@@ -1,1 +1,1 @@
-testlib.Error: audit: type=1400 audit(*): avc:  denied  { name_bind } * comm="rpcbind"
+* type=1400 audit(*): avc:  denied  { name_bind } * comm="rpcbind"

--- a/naughty/fedora-30/74-selinux-dac-override-firewalld
+++ b/naughty/fedora-30/74-selinux-dac-override-firewalld
@@ -1,1 +1,1 @@
-audit: type=1400 * avc:  denied  { dac_override } * comm="firewalld"
+* type=1400 * avc:  denied  { dac_override } * comm="firewalld"

--- a/naughty/fedora-31/118-selinux-rpcbind-name_bind
+++ b/naughty/fedora-31/118-selinux-rpcbind-name_bind
@@ -1,1 +1,1 @@
-testlib.Error: audit: type=1400 audit(*): avc:  denied  { name_bind } * comm="rpcbind"
+* type=1400 audit(*): avc:  denied  { name_bind } * comm="rpcbind"

--- a/naughty/fedora-31/79-selinux-nm-system-cat
+++ b/naughty/fedora-31/79-selinux-nm-system-cat
@@ -1,1 +1,1 @@
-testlib.Error: audit: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="NetworkManager" path="/var/tmp/dracut.*/systemd-cat" dev="dm-0" ino=* scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0 tclass=fifo_file permissive=0
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="NetworkManager" path="/var/tmp/dracut.*/systemd-cat" dev="dm-0" ino=* scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0 tclass=fifo_file permissive=0

--- a/naughty/rhel-7/61-selinux-systemd-machine-search
+++ b/naughty/rhel-7/61-selinux-systemd-machine-search
@@ -1,1 +1,1 @@
-Error: type=1400 audit*: avc:  denied  { search } for  pid=* comm="systemd-machine" name="*" dev="proc" ino=* scontext=system_u:system_r:systemd_machined_t:* tcontext=system_u:system_r:svirt_tcg_t:*
+* type=1400 audit*: avc:  denied  { search } for  pid=* comm="systemd-machine" name="*" dev="proc" ino=* scontext=system_u:system_r:systemd_machined_t:* tcontext=system_u:system_r:svirt_tcg_t:*

--- a/naughty/rhel-7/67-selinux-dnsmasq-nm
+++ b/naughty/rhel-7/67-selinux-dnsmasq-nm
@@ -1,1 +1,1 @@
-*type=1400 audit(*): avc:  denied * comm="dnsmasq" name="NetworkManager"
+* type=1400 audit(*): avc:  denied * comm="dnsmasq" name="NetworkManager"

--- a/naughty/rhel-7/73-selinux-getattr-iscsid
+++ b/naughty/rhel-7/73-selinux-getattr-iscsid
@@ -1,1 +1,1 @@
-Error: type=1400 * avc:  denied  { getattr } * comm="iscsid"
+* type=1400 * avc:  denied  { getattr } * comm="iscsid"

--- a/naughty/rhel-8/12355-selinux-search-krb5
+++ b/naughty/rhel-8/12355-selinux-search-krb5
@@ -1,1 +1,1 @@
-*type=1400 audit(*): avc:  denied  { search } for * comm="sssd_be" name="krb5"
+* type=1400 audit(*): avc:  denied  { search } for * comm="sssd_be" name="krb5"

--- a/naughty/rhel-8/67-selinux-dnsmasq-nm
+++ b/naughty/rhel-8/67-selinux-dnsmasq-nm
@@ -1,1 +1,1 @@
-*type=1400 audit(*): avc:  denied * comm="dnsmasq" name="NetworkManager"
+* type=1400 audit(*): avc:  denied * comm="dnsmasq" name="NetworkManager"

--- a/naughty/rhel-8/74-selinux-dac-override-firewalld
+++ b/naughty/rhel-8/74-selinux-dac-override-firewalld
@@ -1,1 +1,1 @@
-audit: type=1400 * avc:  denied  { dac_override } * comm="firewalld"
+* type=1400 * avc:  denied  { dac_override } * comm="firewalld"

--- a/naughty/rhel-atomic/62-selinux-rhsmd
+++ b/naughty/rhel-atomic/62-selinux-rhsmd
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd"

--- a/naughty/rhel-atomic/62-selinux-rhsmd-dbus
+++ b/naughty/rhel-atomic/62-selinux-rhsmd-dbus
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="dbus"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="dbus"

--- a/naughty/rhel-atomic/62-selinux-rhsmd-encodings
+++ b/naughty/rhel-atomic/62-selinux-rhsmd-encodings
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="encodings"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="encodings"

--- a/naughty/rhel-atomic/62-selinux-rhsmd-subscription_manager
+++ b/naughty/rhel-atomic/62-selinux-rhsmd-subscription_manager
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="subscription_manager"
+* type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="subscription_manager"

--- a/naughty/rhel-atomic/67-selinux-dnsmasq-nm
+++ b/naughty/rhel-atomic/67-selinux-dnsmasq-nm
@@ -1,1 +1,1 @@
-*type=1400 audit(*): avc:  denied * comm="dnsmasq" name="NetworkManager"
+* type=1400 audit(*): avc:  denied * comm="dnsmasq" name="NetworkManager"

--- a/naughty/rhel-atomic/71-selinux-chronyd-sendto
+++ b/naughty/rhel-atomic/71-selinux-chronyd-sendto
@@ -1,1 +1,1 @@
-Error: type=1400 audit(*): avc:  denied  { sendto } for  pid=* comm="chronyd" * tclass=unix_dgram_socket
+* type=1400 audit(*): avc:  denied  { sendto } for  pid=* comm="chronyd" * tclass=unix_dgram_socket


### PR DESCRIPTION
The precise output format of unexpected messages has changed over time.
A long time ago with Pythoh 2 they were prefixed with `Error:`, then
with Python 3 it changed to `testlib.Error:`, and with [1] that prefix
moved to a separate line.

Change the naughties to accept any prefix, so that this works across all
branches.

[1] https://github.com/cockpit-project/cockpit/pull/13022