### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/images/fedora-testing
+++ b/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-3a1c6dacb5817398545eb10c716fba6cf106ec921506faddde705274f4ba401a.qcow2
+fedora-testing-1e1f1e7db2f4d33f4849a3af1adbf5b0e8b687555ce965f7c6f6645fbbb2d41b.qcow2


### PR DESCRIPTION
Image refresh for fedora-testing
 * [x] image-refresh fedora-testing
 * [x] Adjust obsolete abrt-ccpp.service: https://github.com/cockpit-project/cockpit/pull/13117