### PR TITLE
testmap: Stop testing cockpit master on RHEL 8.1

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -27,7 +27,7 @@ REPO_BRANCH_CONTEXT = {
             'debian-stable', 'debian-testing',
             'ubuntu-1804', 'ubuntu-stable',
             'fedora-30', 'fedora-31',
-            'rhel-8-1-distropkg', 'rhel-8-1', 'rhel-8-2',
+            'rhel-8-1-distropkg', 'rhel-8-2',
         ],
         'rhel-7.8': ['rhel-7-8', 'rhel-atomic', 'continuous-atomic',
             'fedora-30/container-bastion', 'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome',


### PR DESCRIPTION
8.1 got released now, and we have maintained the rhel-8.1 for a while.
So stop testing the full master on rhel-8-1, just keep -8-2 and
-distropkg.