### PR TITLE
Port image-{download,upload,prune} away from testvm

### DIFF
--- a/image-download
+++ b/image-download
@@ -43,8 +43,11 @@ import time
 import fcntl
 import urllib.parse
 
-from machine import testvm
+from machine.machine_core.constants import IMAGES_DIR
+from machine.machine_core.directories import get_images_data_dir
+
 from task import REDHAT_STORE
+from task.testmap import get_test_image
 
 CONFIG = "~/.config/image-stores"
 DEFAULT = [
@@ -62,7 +65,7 @@ EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
 
 def find(name, stores, latest, quiet):
     found = []
-    ca = os.path.join(testvm.IMAGES_DIR, "files", "ca.pem")
+    ca = os.path.join(IMAGES_DIR, "files", "ca.pem")
 
     for store in stores:
         url = urllib.parse.urlparse(store)
@@ -196,14 +199,14 @@ def download(dest, force, state, quiet, stores):
 
 # Calculate a place to put images where links are not committed in git
 def state_target(path):
-    data_dir = testvm.get_images_data_dir()
+    data_dir = get_images_data_dir()
     os.makedirs(data_dir, mode=0o775, exist_ok=True)
     return os.path.join(data_dir, path)
 
 
 # Calculate a place to put images where links are committed in git
 def committed_target(image):
-    link = os.path.join(testvm.IMAGES_DIR, image)
+    link = os.path.join(IMAGES_DIR, image)
     if not os.path.islink(link):
         raise RuntimeError("image link does not exist: " + image)
 
@@ -216,17 +219,17 @@ def committed_target(image):
         relative_dir = os.path.dirname(os.path.abspath(link))
         full_dest = os.path.join(relative_dir, dest)
 
-    dest = os.path.join(testvm.get_images_data_dir(), dest)
+    dest = os.path.join(get_images_data_dir(), dest)
 
     # We have the file but there is not valid link
     if os.path.exists(dest):
         try:
-            os.symlink(dest, os.path.join(testvm.IMAGES_DIR, os.readlink(link)))
+            os.symlink(dest, os.path.join(IMAGES_DIR, os.readlink(link)))
         except FileExistsError:
             pass
 
     # The image file in the images directory, may be same as dest
-    image_file = os.path.join(testvm.IMAGES_DIR, os.readlink(link))
+    image_file = os.path.join(IMAGES_DIR, os.readlink(link))
 
     # Double check that symlink in place but never make a cycle.
     if os.path.abspath(dest) != os.path.abspath(image_file):
@@ -257,7 +260,7 @@ def wait_lock(target):
 
 
 def download_images(image_list, force, quiet, state, store):
-    data_dir = testvm.get_images_data_dir()
+    data_dir = get_images_data_dir()
     os.makedirs(data_dir, exist_ok=True)
 
     # A default set of images are all links in git.  These links have
@@ -267,15 +270,15 @@ def download_images(image_list, force, quiet, state, store):
     if not image_list:
         image_list = []
         if not state:
-            for filename in os.listdir(testvm.IMAGES_DIR):
-                link = os.path.join(testvm.IMAGES_DIR, filename)
+            for filename in os.listdir(IMAGES_DIR):
+                link = os.path.join(IMAGES_DIR, filename)
                 if os.path.islink(link) and os.path.dirname(os.readlink(link)) == "":
                     image_list.append(filename)
 
     success = True
 
     for image in image_list:
-        image = testvm.get_test_image(image)
+        image = get_test_image(image)
         try:
             if state:
                 target = state_target(image)

--- a/image-prune
+++ b/image-prune
@@ -28,7 +28,8 @@ import time
 
 from task import github
 
-from machine import testvm
+from machine.machine_core.constants import IMAGES_DIR
+from machine.machine_core.directories import get_images_data_dir
 
 # threshold in G below which unreferenced qcow2 images will be pruned, even if they aren't old
 PRUNE_THRESHOLD_G = float(os.environ.get("PRUNE_THRESHOLD_G", 15))
@@ -37,7 +38,7 @@ PRUNE_THRESHOLD_G = float(os.environ.get("PRUNE_THRESHOLD_G", 15))
 def enough_disk_space():
     """Check if available disk space in our data store is sufficient
     """
-    st = os.statvfs(testvm.get_images_data_dir())
+    st = os.statvfs(get_images_data_dir())
     free = st.f_bavail * st.f_frsize / (1024 * 1024 * 1024)
     return free >= PRUNE_THRESHOLD_G
 
@@ -143,8 +144,8 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
         targets = get_image_names(quiet, open_pull_requests, offline)
 
     # what we have in the current checkout might already have been added by its branch, but check anyway
-    for filename in os.listdir(testvm.IMAGES_DIR):
-        path = os.path.join(testvm.IMAGES_DIR, filename)
+    for filename in os.listdir(IMAGES_DIR):
+        path = os.path.join(IMAGES_DIR, filename)
 
         # only consider original image entries as trustworthy sources and ignore non-links
         if path.endswith(".qcow2") or path.endswith(".partial") or not os.path.islink(path):
@@ -154,8 +155,8 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
         targets.add(target)
 
     expiry_threshold = now - IMAGE_EXPIRE * 86400
-    for filename in os.listdir(testvm.get_images_data_dir()):
-        path = os.path.join(testvm.get_images_data_dir(), filename)
+    for filename in os.listdir(get_images_data_dir()):
+        path = os.path.join(get_images_data_dir(), filename)
         if not force and (enough_disk_space() and os.lstat(path).st_mtime > expiry_threshold):
             continue
         if os.path.isfile(path) and (path.endswith(".xz") or path.endswith(".qcow2") or path.endswith(".partial")) and filename not in targets:
@@ -165,8 +166,8 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
                 os.unlink(path)
 
     # now prune broken links
-    for filename in os.listdir(testvm.IMAGES_DIR):
-        path = os.path.join(testvm.IMAGES_DIR, filename)
+    for filename in os.listdir(IMAGES_DIR):
+        path = os.path.join(IMAGES_DIR, filename)
 
         # don't prune original image entries and ignore non-links
         if not path.endswith(".qcow2") or not os.path.islink(path):
@@ -182,8 +183,8 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
 
 def every_image():
     result = []
-    for filename in os.listdir(testvm.IMAGES_DIR):
-        link = os.path.join(testvm.IMAGES_DIR, filename)
+    for filename in os.listdir(IMAGES_DIR):
+        link = os.path.join(IMAGES_DIR, filename)
         if os.path.islink(link):
             result.append(filename)
     return result

--- a/image-upload
+++ b/image-upload
@@ -35,8 +35,8 @@ import subprocess
 import sys
 import urllib.parse
 
-from machine import testvm
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import IMAGES_DIR
+from machine.machine_core.directories import BOTS_DIR, get_images_data_dir
 
 
 def upload(store, source):
@@ -93,13 +93,13 @@ def main():
     parser.add_argument('image', nargs='*')
     args = parser.parse_args()
 
-    data_dir = testvm.get_images_data_dir()
+    data_dir = get_images_data_dir()
     sources = []
     for image in args.image:
         if args.state:
             source = os.path.join(data_dir, image)
         else:
-            link = os.path.join(testvm.IMAGES_DIR, image)
+            link = os.path.join(IMAGES_DIR, image)
             if not os.path.islink(link):
                 parser.error("image link does not exist: " + image)
             source = os.path.join(data_dir, os.readlink(link))

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -34,23 +34,8 @@ from .constants import TEST_DIR, BOTS_DIR
 from .directories import get_temp_dir
 
 sys.path.insert(1, BOTS_DIR)
-from task import testmap
 
 MEMORY_MB = 1024
-
-
-# The OSTree variants can't build their own packages, so we build in
-# their classic siblings.  For example, rhel-atomic is built
-# in rhel-7-X
-def get_build_image(image):
-    (test_os, unused) = os.path.splitext(os.path.basename(image))
-    return testmap.OSTREE_BUILD_IMAGE.get(image, image)
-
-
-# some tests have suffixes that run the same image in different modes; map a
-# test context image to an actual physical image name
-def get_test_image(image):
-    return image.replace("-distropkg", "")
 
 
 # based on http://stackoverflow.com/a/17753573

--- a/machine/machine_core/testvm.py
+++ b/machine/machine_core/testvm.py
@@ -18,7 +18,7 @@
 from .timeout import Timeout
 from .machine import Machine
 from .exceptions import Failure, RepeatableFailure
-from .machine_virtual import VirtMachine, VirtNetwork, get_build_image, get_test_image
+from .machine_virtual import VirtMachine, VirtNetwork
 from .constants import BOTS_DIR, TEST_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
 
-__all__ = [Timeout, Machine, Failure, RepeatableFailure, VirtMachine, VirtNetwork, get_build_image, get_test_image, BOTS_DIR, TEST_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT]
+__all__ = [Timeout, Machine, Failure, RepeatableFailure, VirtMachine, VirtNetwork, BOTS_DIR, TEST_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT]

--- a/machine/testvm.py
+++ b/machine/testvm.py
@@ -28,10 +28,11 @@ if machine_dir not in sys.path:
 from machine_core.timeout import Timeout
 from machine_core.machine import Machine
 from machine_core.exceptions import Failure, RepeatableFailure
-from machine_core.machine_virtual import VirtMachine, VirtNetwork, get_build_image, get_test_image
+from machine_core.machine_virtual import VirtMachine, VirtNetwork
 from machine_core.constants import BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
 from machine_core.cli import cmd_cli
 from machine_core.directories import get_images_data_dir, get_temp_dir
+from task.testmap import get_build_image, get_test_image
 
 __all__ = [Timeout, Machine, Failure, RepeatableFailure, VirtMachine, VirtNetwork, get_build_image, get_test_image, get_images_data_dir, get_temp_dir, BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT]
 

--- a/task/testmap.py
+++ b/task/testmap.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os.path
+
+
 REPO_BRANCH_CONTEXT = {
     'cockpit-project/bots': {
         'master': [
@@ -159,6 +162,19 @@ IMAGE_REFRESH_TRIGGERS = {
         "rhel-7-8@cockpit-project/cockpit/rhel-7.8",
     ]
 }
+
+# The OSTree variants can't build their own packages, so we build in
+# their classic siblings.  For example, rhel-atomic is built
+# in rhel-7-X
+def get_build_image(image):
+    (test_os, unused) = os.path.splitext(os.path.basename(image))
+    return OSTREE_BUILD_IMAGE.get(image, image)
+
+
+# some tests have suffixes that run the same image in different modes; map a
+# test context image to an actual physical image name
+def get_test_image(image):
+    return image.replace("-distropkg", "")
 
 
 def projects():

--- a/tests-policy
+++ b/tests-policy
@@ -36,14 +36,7 @@ FLAKE_THRESHOLD = 0.4
 
 from task import github
 from machine.machine_core.directories import BOTS_DIR
-
-
-try:
-    from machine.testvm import get_test_image
-except ImportError:
-    # fallback for unit tests where libvirt is not available
-    def get_test_image(i):
-        return i
+from task.testmap import get_test_image
 
 
 def main():


### PR DESCRIPTION
These scripts don't need libvirt, so stop using the testvm.py backwards
compat shim, and import the necessary machine_core API bits directly.

This allows us to run these scripts in very restricted environments such
as a cockpit/images container.