### PR TITLE
testmap: Remove manual composer test

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -102,7 +102,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'fedora-31/ci',
         ],
     },
     'weldr/cockpit-composer': {


### PR DESCRIPTION
We don't need this manual trigger anymore since we're dropping the test.