### PR TITLE
images: Update cockpit/ws container on fedora-coreos with local packages/files

### DIFF
--- a/images/scripts/fedora-coreos.install
+++ b/images/scripts/fedora-coreos.install
@@ -10,6 +10,21 @@ cd /var/tmp/build-results/
 rpm-ostree install cockpit-bridge-*.rpm cockpit-dashboard-*.rpm \
     cockpit-networkmanager-*.rpm cockpit-system-*.rpm cockpit-tests-*.rpm
 
+# update cockpit-ws and install scripts in the container
+podman run --name build-cockpit -i \
+    -v /var/tmp/build-results:/run/build-results:Z \
+    -v /var/tmp/containers:/run/containers:Z \
+    cockpit/ws sh -exc '
+rpm --freshen --verbose /run/build-results/cockpit-ws-*.rpm /run/build-results/cockpit-bridge-*.rpm /run/build-results/cockpit-dashboard-*.rpm
+cp /run/containers/ws/atomic-* /container/
+'
+podman commit build-cockpit cockpit/ws
+podman rm -f build-cockpit
+
+# move original docker image away, to make sure that our tests use the updated one
+podman tag docker.io/cockpit/ws:latest docker.io/cockpit/ws:released
+podman rmi docker.io/cockpit/ws
+
 # run cockpit/ws once to generate certificate; avoids slow down on every start
 podman container runlabel INSTALL cockpit/ws
 


### PR DESCRIPTION
So that our tests actually run changes from the PR and master, instead
of the latest released cockpit/ws on Docker hub.

This effectively does what images/scripts/lib/atomic.install does, but
with podman and slightly simpler and more robust.

Note that this skips all the libssh update hackery from
atomic.{install,setup}. Let's restrict ourselves to the libssh version
that was available in the latest cockpit/ws release. This happens every
two weeks, which should be sufficient.

Rename the original image downloaded from docker.io, to make sure our
tests use the localhost/cockpit/ws image.