### PR TITLE
image-trigger: Drop non-existing ipa image

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -28,7 +28,6 @@ REFRESH = {
     "fedora-30": {},
     "fedora-31": {},
     "fedora-testing": {},
-    "ipa": {"refresh-days": 120},
     "ubuntu-1804": {},
     "ubuntu-stable": {},
     "openshift": {"refresh-days": 30},


### PR DESCRIPTION
It got removed in commit 58ce05dd54cd, superseded by the services image.