### PR TITLE
[no-test] testmap: add manual rhel-8-2/firefox trigger for cockpit-composer

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -149,6 +149,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
+            'rhel-8-2/firefox',
             'centos-8-stream',
         ],
     },


### PR DESCRIPTION
Add `rhel-8-2` in cockpit-composer test scenario for manual trigger.