### PR TITLE
naughty: Close 137: Podman cannot load stats from rootless containers

### DIFF
--- a/naughty/fedora-31/137-podman-stats-rootless
+++ b/naughty/fedora-31/137-podman-stats-rootless
@@ -1,4 +1,0 @@
-Failed to update container stats: {"error":"io.podman.ErrorOccurred","parameters":{"reason":"Link not found"}}
-*
-*b.wait(lambda: b.text("#containers-containers tbody tr:contains('busybox:latest') > td:nth-child(5)") != "")
-


### PR DESCRIPTION
Known issue which has not occurred in 23 days

Podman cannot load stats from rootless containers

Fixes #137