### PR TITLE
task: Drop explicit python interpreter from sink invocation

### DIFF
--- a/task/sink.py
+++ b/task/sink.py
@@ -37,10 +37,8 @@ class Sink(object):
         self.status = status
 
         # Start a gzip and cat processes
-        self.ssh = subprocess.Popen([
-            "ssh", "-o", "ServerAliveInterval=30", host, "--",
-            "python", "sink", identifier
-        ], stdin=subprocess.PIPE)
+        self.ssh = subprocess.Popen(["ssh", "-o", "ServerAliveInterval=30", host, "--", "./sink", identifier],
+                                    stdin=subprocess.PIPE)
 
         # Send the status line
         self.ssh.stdin.write(json.dumps(status).encode('utf-8') + b"\n")


### PR DESCRIPTION
Leave the choice of the interpreter to the remote sink's shebang,
instead of harcoding "python". Fedora 31 changed the meaning of "python"
to mean "Python 3" now, which completely breaks the sink.

https://github.com/cockpit-project/cockpituous/pull/304 pins down the
hashbang, and eventually the sink will be ported to Python 3 properly.