### PR TITLE
Fixes for absent e2e cluster

### DIFF
--- a/image-download
+++ b/image-download
@@ -83,7 +83,8 @@ def find(name, stores, latest, quiet):
 
             def curl(*args):
                 try:
-                    cmd = ["curl"] + list(args) + ["--head", "--silent", "--fail", "--cacert", ca, source]
+                    cmd = ["curl"] + list(args) + ["--head", "--connect-timeout", "10", "--silent",
+                                                   "--fail", "--cacert", ca, source]
                     start = time.time()
                     output = subprocess.check_output(cmd, universal_newlines=True)
                     found.append((cmd, output, message, time.time() - start))

--- a/image-download
+++ b/image-download
@@ -46,7 +46,7 @@ import urllib.parse
 from machine.machine_core.constants import IMAGES_DIR
 from machine.machine_core.directories import get_images_data_dir
 
-from task import REDHAT_STORE
+from task import REDHAT_STORES
 from task.testmap import get_test_image
 
 CONFIG = "~/.config/image-stores"
@@ -54,10 +54,7 @@ DEFAULT = [
     "http://cockpit-images.verify.svc.cluster.local",
     "https://images-cockpit.apps.ci.centos.org/",
     "https://209.132.184.41:8493/",
-    REDHAT_STORE,
-    # fallback RedHat-internal image server in AWS (internal VPN only)
-    "https://10.29.163.169:8493/",
-]
+] + REDHAT_STORES
 
 DEVNULL = open("/dev/null", "r+")
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"

--- a/image-refresh
+++ b/image-refresh
@@ -22,7 +22,7 @@ import subprocess
 import sys
 
 import task
-from task import github, testmap, REDHAT_STORE
+from task import github, testmap, REDHAT_STORES
 
 from machine.machine_core.directories import BOTS_DIR
 
@@ -42,7 +42,8 @@ def run(image, verbose=False, **kwargs):
     cmd = [os.path.join(BOTS_DIR, "image-create"), "--verbose", "--upload"]
     # these images are not freely redistributable, keep them Red Hat internal
     if image.startswith("rhel") or image.startswith("windows"):
-        cmd += ["--store", REDHAT_STORE]
+        # FIXME: Move this to image-upload and try all stores
+        cmd += ["--store", REDHAT_STORES[0]]
     cmd += [image]
 
     os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -520,6 +520,7 @@ def redhat_network():
     '''
     if redhat_network.result is None:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(10)
         store = urllib.parse.urlparse(REDHAT_STORE)
         try:
             s.connect((store.hostname, store.port))


### PR DESCRIPTION
Our primary internal image server (https://cockpit-11.e2e.bos.redhat.com:8493/) is down right now, and trying to connect to it hangs eternally. This also causes the "am I in the RH network?" detection to fail, thus currently our AWS and PSI bots don't run any rhel* and windows tests.