### PR TITLE
Fix image-upload for multiple RHEL stores and broken cockpit-11

### DIFF
--- a/image-download
+++ b/image-download
@@ -46,15 +46,10 @@ import urllib.parse
 from machine.machine_core.constants import IMAGES_DIR
 from machine.machine_core.directories import get_images_data_dir
 
-from task import REDHAT_STORES
+from task import PUBLIC_STORES, REDHAT_STORES
 from task.testmap import get_test_image
 
 CONFIG = "~/.config/image-stores"
-DEFAULT = [
-    "http://cockpit-images.verify.svc.cluster.local",
-    "https://images-cockpit.apps.ci.centos.org/",
-    "https://209.132.184.41:8493/",
-] + REDHAT_STORES
 
 DEVNULL = open("/dev/null", "r+")
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
@@ -137,7 +132,8 @@ def download(dest, force, state, quiet, stores):
                 stores = fp.read().strip().split("\n")
         else:
             stores = []
-        stores += DEFAULT
+        stores += PUBLIC_STORES
+        stores += REDHAT_STORES
 
     # The time condition for If-Modified-Since
     exists = not force and os.path.exists(dest)

--- a/image-refresh
+++ b/image-refresh
@@ -22,7 +22,7 @@ import subprocess
 import sys
 
 import task
-from task import github, testmap, REDHAT_STORES
+from task import github, testmap
 
 from machine.machine_core.directories import BOTS_DIR
 
@@ -39,12 +39,7 @@ def run(image, verbose=False, **kwargs):
     # Cleanup any extraneous disk usage elsewhere
     subprocess.check_call([os.path.join(BOTS_DIR, "vm-reset")])
 
-    cmd = [os.path.join(BOTS_DIR, "image-create"), "--verbose", "--upload"]
-    # these images are not freely redistributable, keep them Red Hat internal
-    if image.startswith("rhel") or image.startswith("windows"):
-        # FIXME: Move this to image-upload and try all stores
-        cmd += ["--store", REDHAT_STORES[0]]
-    cmd += [image]
+    cmd = [os.path.join(BOTS_DIR, "image-create"), "--verbose", "--upload", image]
 
     os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"
     ret = subprocess.call(cmd)

--- a/image-upload
+++ b/image-upload
@@ -17,15 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-
-# The default settings here should match one of the default download stores
-DEFAULT_UPLOAD = [
-    "https://images-cockpit.apps.ci.centos.org/",
-    "https://209.132.184.41:8493/",
-]
-
-TOKEN = "~/.config/github-token"
-
 import argparse
 import getpass
 import errno
@@ -37,6 +28,10 @@ import urllib.parse
 
 from machine.machine_core.constants import IMAGES_DIR
 from machine.machine_core.directories import BOTS_DIR, get_images_data_dir
+
+from task import PUBLIC_STORES
+
+TOKEN = "~/.config/github-token"
 
 
 def upload(store, source):
@@ -108,7 +103,7 @@ def main():
         sources.append(source)
 
     for source in sources:
-        for store in (args.store or DEFAULT_UPLOAD):
+        for store in (args.store or PUBLIC_STORES):
             ret = upload(store, source)
             if ret == 0:
                 return ret

--- a/image-upload
+++ b/image-upload
@@ -29,7 +29,7 @@ import urllib.parse
 from machine.machine_core.constants import IMAGES_DIR
 from machine.machine_core.directories import BOTS_DIR, get_images_data_dir
 
-from task import PUBLIC_STORES
+from task import PUBLIC_STORES, REDHAT_STORES
 
 TOKEN = "~/.config/github-token"
 
@@ -103,7 +103,17 @@ def main():
         sources.append(source)
 
     for source in sources:
-        for store in (args.store or PUBLIC_STORES):
+        # determine possible stores, unless explicitly given
+        stores = args.store
+        if not stores:
+            # these images are not freely redistributable, keep them Red Hat internal
+            b = os.path.basename(source)
+            if b.startswith("rhel") or image.startswith("windows"):
+                stores = REDHAT_STORES
+            else:
+                stores = PUBLIC_STORES
+
+        for store in stores:
             ret = upload(store, source)
             if ret == 0:
                 return ret

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -47,10 +47,18 @@ __all__ = (
     "verbose",
     "stale",
     "redhat_network",
+    "PUBLIC_STORES",
     "REDHAT_STORES",
 )
 
 sys.dont_write_bytecode = True
+
+# Servers which have public images
+PUBLIC_STORES = [
+    "https://images-cockpit.apps.ci.centos.org/",
+    # instance in fedorainfracloud.org
+    "https://209.132.184.41:8493/",
+]
 
 # Servers which have the private RHEL/Windows images
 REDHAT_STORES = [


### PR DESCRIPTION
I'm also doing a test image refresh here. It doesn't need to land, but it must be able to get uploaded to the AWS image store. That's the bit that doesn't currently work.

 * [x] image-refresh rhel-8-1