### PR TITLE
testmap: Fix tests_for_image() to consider -distropkg contexts

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -228,7 +228,7 @@ def tests_for_image(image):
             if branch.startswith('_'):
                 continue
             for context in contexts:
-                if context.split('/')[0] == image:
+                if context.split('/')[0].replace('-distropkg', '') == image:
                     c = context + '@' + repo
                     if branch != "master":
                         c += "/" + branch


### PR DESCRIPTION
This happened recently in https://github.com/cockpit-project/bots/pull/299 -- I noticed that the rhel-8-1-distropkg@ context for cockpit master was missing.

With an additional print() in tests-trigger, this now shows the correct result:
```
❱❱❱ ./tests-trigger 299 image:rhel-8-1
rhel-8-1@cockpit-project/cockpit/rhel-8.1
rhel-8-1@candlepin/subscription-manager
rhel-8-1@cockpit-project/cockpit-podman
rhel-8-1/tar@weldr/lorax/rhel8-branch
rhel-8-1/aws@weldr/lorax/rhel8-branch
rhel-8-1/qcow2@weldr/lorax/rhel8-branch
rhel-8-1@weldr/lorax/rhel8-branch
host
rhel-8-1@cockpit-project/cockpit/rhel-8-appstream
rhel-8-1/vmware@weldr/lorax/rhel8-branch
rhel-8-1-distropkg@cockpit-project/cockpit
rhel-8-1-distropkg@cockpit-project/cockpit/rhel-8-appstream
rhel-8-1/live-iso@weldr/lorax/rhel8-branch
rhel-8-1/azure@weldr/lorax/rhel8-branch
rhel-8-1/chrome@weldr/cockpit-composer
rhel-8-1/openstack@weldr/lorax/rhel8-branch
```