### PR TITLE
machine: Robustify cockpit (re)starting

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -224,6 +224,7 @@ class Machine(ssh_connection.SSHConnection):
         elif tls:
             self.execute(script="""#!/bin/sh
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
+            systemctl reset-failed 'cockpit*' &&
             systemctl daemon-reload &&
             systemctl stop cockpit.service &&
             systemctl start cockpit.socket
@@ -237,6 +238,7 @@ class Machine(ssh_connection.SSHConnection):
             ExecStart=
             %s --no-tls" `systemctl cat cockpit.service | grep ExecStart=` \
                     > /etc/systemd/system/cockpit.service.d/notls.conf &&
+            systemctl reset-failed 'cockpit*' &&
             systemctl daemon-reload &&
             systemctl stop cockpit.service &&
             systemctl start cockpit.socket
@@ -253,7 +255,7 @@ class Machine(ssh_connection.SSHConnection):
             self.execute("podman restart `podman ps --quiet --filter ancestor=cockpit/ws`")
             self.wait_for_cockpit_running()
         else:
-            self.execute("systemctl restart cockpit")
+            self.execute("systemctl reset-failed 'cockpit*'; systemctl restart cockpit")
 
     def stop_cockpit(self):
         """Stop Cockpit.


### PR DESCRIPTION
Some tests start or restart cockpit very often, which sometimes triggers
systemd's restart limit. Reset the units to avoid that.