### PR TITLE
naughty: Close 60: Debian: parted clobbers in-memory state of extended partitions

### DIFF
--- a/naughty/debian-stable/60-parted-clobbers-extended-partitions
+++ b/naughty/debian-stable/60-parted-clobbers-extended-partitions
@@ -1,1 +1,0 @@
-self.content_row_wait_in_col(3, 1, "xfs File System")

--- a/naughty/debian-testing/60-parted-clobbers-extended-partitions
+++ b/naughty/debian-testing/60-parted-clobbers-extended-partitions
@@ -1,1 +1,0 @@
-self.content_row_wait_in_col(3, 1, "xfs File System")

--- a/naughty/ubuntu-1804/60-parted-clobbers-extended-partitions
+++ b/naughty/ubuntu-1804/60-parted-clobbers-extended-partitions
@@ -1,1 +1,0 @@
-self.content_row_wait_in_col(3, 1, "xfs File System")

--- a/naughty/ubuntu-stable/60-parted-clobbers-extended-partitions
+++ b/naughty/ubuntu-stable/60-parted-clobbers-extended-partitions
@@ -1,1 +1,0 @@
-self.content_row_wait_in_col(3, 1, "xfs File System")


### PR DESCRIPTION
Known issue which has not occurred in 24 days

Debian: parted clobbers in-memory state of extended partitions

Fixes #60