### PR TITLE
testmap: Test c-podman on rhel-8-2 as well

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -92,6 +92,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-30',
             'fedora-31',
             'rhel-8-1',
+            'rhel-8-2',
         ],
         '_manual': [
             'centos-8-stream',


### PR DESCRIPTION
Rhel-8-2 needs to be skipped on some tests, as it does not support CGroupsV2. I sent PR. Meanwhile this is blocked.