### PR TITLE
naughty: Close 268: ABRT tests/reportd fails with: reportd task for workflow workflow_FedoraCCpp did not finish: Event collect_GConf has no handlers defined

### DIFF
--- a/naughty/fedora-30/268-reportd-event-collect
+++ b/naughty/fedora-30/268-reportd-event-collect
@@ -1,1 +1,0 @@
-*reportd task for workflow workflow_FedoraCCpp did not finish: Event collect_* has no handlers defined*

--- a/naughty/fedora-31/268-reportd-event-collect
+++ b/naughty/fedora-31/268-reportd-event-collect
@@ -1,1 +1,0 @@
-*reportd task for workflow workflow_FedoraCCpp did not finish: Event collect_* has no handlers defined*


### PR DESCRIPTION
Known issue which has not occurred in 25 days

ABRT tests/reportd fails with: reportd task for workflow workflow_FedoraCCpp did not finish: Event collect_GConf has no handlers defined

Fixes #268