### PR TITLE
vm-run: Fix networking for windows-10

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -141,6 +141,13 @@ TEST_MCAST_XML = """
     <qemu:arg value='{netdriver},netdev=mcast0,mac={mac},bus=pci.0,addr=0x0f'/>
 """
 
+TEST_USERNET_XML = """
+    <qemu:arg value='-netdev'/>
+    <qemu:arg value='user,id=user0'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='{netdriver},netdev=user0,mac={mac},bus=pci.0,addr=0x0f'/>
+"""
+
 TEST_BRIDGE_XML = """
     <interface type="bridge">
       <source bridge="{bridge}"/>
@@ -227,8 +234,11 @@ class VirtNetwork:
         }
         return result
 
-    # Create resources for a host, returns address and XML
     def host(self, number=None, restrict=False, isolate=False, forward={}):
+        '''Create resources for a host, returns address and XML
+
+        isolate: True for no network at all, "user" for QEMU user network instead of bridging
+        '''
         result = self.interface(number)
         result["mcast"] = self.network
         result["restrict"] = restrict and "on" or "off"
@@ -245,7 +255,11 @@ class VirtNetwork:
             elif remote == "9090":
                 result["browser"] = result["forward"][remote]
 
-        if isolate:
+        if isolate == 'user':
+            result["bridge"] = ""
+            result["bridgedev"] = ""
+            result["ethernet"] = TEST_USERNET_XML.format(**result)
+        elif isolate:
             result["bridge"] = ""
             result["bridgedev"] = ""
             result["ethernet"] = ""

--- a/vm-run
+++ b/vm-run
@@ -97,11 +97,17 @@ try:
     if "windows" in args.image and memory is None:
         memory = 4096
 
+    # Windows does not get along with the mcast network, use QEMU user network for it instead
+    if "windows" in args.image and not bridge:
+        isolate = "user"
+    else:
+        isolate = False
+
     graphics = args.graphics or 'windows' in args.image
     network = testvm.VirtNetwork(0, bridge=bridge, image=args.image)
 
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,
-                                 networking=network.host(restrict=args.no_network),
+                                 networking=network.host(restrict=args.no_network, isolate=isolate),
                                  memory_mb=memory, cpus=args.cpus, graphics=graphics)
 
     # Hack to make things easier for users who don't know about kubeconfig


### PR DESCRIPTION
Without a bridge (which requires root privileges on the host),
`vm-run windows-10` ended up with broken networking, as Windows does not
get along with the mcast network.

Introduce a new mode to VirtNetwork that uses standard QEMU user
networking, enabled with `isolate="user"`. Use that mode in vm-run for
the windows image if there is no bridge.