### PR TITLE
testmap: only test cockpit-composer on fedora-31

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -136,16 +136,12 @@ REPO_BRANCH_CONTEXT = {
     },
     'weldr/cockpit-composer': {
         'master': [
-            'fedora-30/chrome',
-            'rhel-8-2/firefox',
+            'fedora-31/chrome',
             'fedora-31/edge',
             'fedora-31/firefox',
-            'rhel-7-8/firefox',
-            'rhel-8-1/chrome',
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'centos-8-stream',
         ],
     },
     'candlepin/subscription-manager': {


### PR DESCRIPTION
Cockpit-composer will begin using osbuild-composer instead of lorax. This change will cause the tests to fail on distros that aren't fedora-31 so these test environments are now only triggered manually. This PR is required for https://github.com/weldr/cockpit-composer/pull/868