### PR TITLE
Migrate weldr/lorax rhel8-branch tests to rhel-8-2

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -132,6 +132,14 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'centos-8-stream',
+            'rhel-8-2',
+            'rhel-8-2/live-iso',
+            'rhel-8-2/qcow2',
+            'rhel-8-2/aws',
+            'rhel-8-2/azure',
+            'rhel-8-2/openstack',
+            'rhel-8-2/vmware',
+            'rhel-8-2/tar',
         ],
     },
     'weldr/cockpit-composer': {


### PR DESCRIPTION
I would like to migrate our rhel8-branch tests to rhel-8-2.
Thanks.