### PR TITLE
naughty: Close 256: RHEL 8.2 regression: setting time fails: avc: denied { sys_time } for comm="timedatex"

### DIFF
--- a/naughty/rhel-8/256-selinux-timedatex
+++ b/naughty/rhel-8/256-selinux-timedatex
@@ -1,1 +1,0 @@
-*Failed to set system clock: Operation not permitted


### PR DESCRIPTION
Known issue which has not occurred in 24 days

RHEL 8.2 regression: setting time fails: avc: denied { sys_time } for comm="timedatex"

Fixes #256