### PR TITLE
[no-test] testmap: Migrate weldr/lorax rhel8-branch automatic tests to rhel-8-2

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -110,14 +110,14 @@ REPO_BRANCH_CONTEXT = {
             'fedora-31/vmware',
         ],
         'rhel8-branch': [
-            'rhel-8-1',
-            'rhel-8-1/live-iso',
-            'rhel-8-1/qcow2',
-            'rhel-8-1/aws',
-            'rhel-8-1/azure',
-            'rhel-8-1/openstack',
-            'rhel-8-1/vmware',
-            'rhel-8-1/tar',
+            'rhel-8-2',
+            'rhel-8-2/live-iso',
+            'rhel-8-2/qcow2',
+            'rhel-8-2/aws',
+            'rhel-8-2/azure',
+            'rhel-8-2/openstack',
+            'rhel-8-2/vmware',
+            'rhel-8-2/tar',
         ],
         'rhel7-extras': [
             'rhel-7-8',
@@ -132,14 +132,6 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'centos-8-stream',
-            'rhel-8-2',
-            'rhel-8-2/live-iso',
-            'rhel-8-2/qcow2',
-            'rhel-8-2/aws',
-            'rhel-8-2/azure',
-            'rhel-8-2/openstack',
-            'rhel-8-2/vmware',
-            'rhel-8-2/tar',
         ],
     },
     'weldr/cockpit-composer': {


### PR DESCRIPTION
Manual testing showed no problems. We can switch to rhel-8-2.
Tested on this PR: https://github.com/weldr/lorax/pull/938