### PR TITLE
bots: Add naughty for libvirtd crash causing flakiness to testConfigureBeforeInstall

### DIFF
--- a/naughty/rhel-8/81-libvirtd-crash-domain-destroy-testConfigureBeforeInstall
+++ b/naughty/rhel-8/81-libvirtd-crash-domain-destroy-testConfigureBeforeInstall
@@ -1,0 +1,7 @@
+Domain installation does not appear to have been successful.
+If it was, you can restart your domain by running:
+  virsh --connect qemu:///system start VmNotInstalled
+*
+Traceback (most recent call last):
+  File "test/verify/check-machines-dbus", line *, in testConfigureBeforeInstall
+    b.wait_in_text("#vm-VmNotInstalled-state", "shut off")


### PR DESCRIPTION
Downstream bug: https://bugzilla.redhat.com/show_bug.cgi?id=1739564
Fixes #81