### PR TITLE
testmap: Drop cockpit rhel-8-appstream branch

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -51,18 +51,12 @@ REPO_BRANCH_CONTEXT = {
             'fedora-30/selenium-chrome',
             'centos-7',
             ],
-        'rhel-8-appstream': [
-            'fedora-30/container-bastion',
-            'fedora-30/selenium-firefox',
-            'fedora-30/selenium-chrome',
-            'rhel-8-1-distropkg',
-            'rhel-8-1',
-            ],
         'rhel-8.1': [
             'fedora-30/container-bastion',
             'fedora-30/selenium-firefox',
             'fedora-30/selenium-chrome',
             'rhel-8-1',
+            'rhel-8-1-distropkg',
             ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [


### PR DESCRIPTION
This initially seemed like a good idea, but it's too much overhead to
maintain two branches per RHEL minor release, and does not actually buy
us anything. It's enough to maintain one branch, and cut releases from
it as we need them, as the resulting RPMs are not overlapping anyway.