### PR TITLE
testmap: Drop leftover rhel-8-1 composer image refresh test

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -171,7 +171,6 @@ IMAGE_REFRESH_TRIGGERS = {
         "rhel-8-2@cockpit-project/cockpit",
         "rhel-7-8@cockpit-project/cockpit/rhel-7.8",
         "fedora-31/firefox@weldr/cockpit-composer",
-        "rhel-8-1/chrome@weldr/cockpit-composer",
     ]
 }
 


### PR DESCRIPTION
The RHEL composer tests were dropped in commit 91a0a8744, but not for
the services image.