### PR TITLE
testmap: Move subscription-manager to rhel-8-2

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -132,10 +132,9 @@ REPO_BRANCH_CONTEXT = {
     },
     'candlepin/subscription-manager': {
         'master': [
-            'rhel-8-1',
+            'rhel-8-2',
         ],
         '_manual': [
-            'rhel-8-2',
         ]
     }
 }


### PR DESCRIPTION
Tests were fixed for that OS in
https://github.com/candlepin/subscription-manager/pull/2206