### PR TITLE
vm-run: add commandline flags to execute commands

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -21,11 +21,13 @@ from . import ssh_connection
 from . import timeout
 from .constants import DEFAULT_IDENTITY_FILE, ATOMIC_IMAGES, OSTREE_IMAGES, TEST_DIR
 
-LOGIN_MESSAGE = """
+LOCAL_MESSAGE = """
 TTY LOGIN
   User: {ssh_user}/admin  Password: foobar
   To quit use Ctrl+], Ctrl+5 (depending on locale)
 
+"""
+REMOTE_MESSAGE = """
 SSH ACCESS
   $ ssh -p {ssh_port} -i bots/machine/identity {ssh_user}@{ssh_address}
 
@@ -85,7 +87,7 @@ class Machine(ssh_connection.SSHConnection):
         # The Linux kernel boot_id
         self.boot_id = None
 
-    def diagnose(self):
+    def diagnose(self, tty=True):
         keys = {
             "ssh_user": self.ssh_user,
             "ssh_address": self.ssh_address,
@@ -93,7 +95,8 @@ class Machine(ssh_connection.SSHConnection):
             "web_address": self.web_address,
             "web_port": self.web_port,
         }
-        return LOGIN_MESSAGE.format(**keys)
+        message = (tty and LOCAL_MESSAGE or '') + REMOTE_MESSAGE
+        return message.format(**keys)
 
     def start(self):
         """Overridden by machine classes to start the machine"""

--- a/vm-run
+++ b/vm-run
@@ -144,6 +144,10 @@ try:
         ip = re.search("inet ([^/]+)", output).group(1)
         message = "\nBRIDGE IP FROM HOST\n  %s\n" % ip
 
+    # Wait here before the "Press ^C" message
+    if args.quiet:
+        machine.wait_boot()
+
     # Graphics console necessary
     if graphics:
         machine.graphics_console()
@@ -154,6 +158,8 @@ try:
 
     # else, just wait for a signal
     else:
+        print(machine.diagnose(tty=False))
+        print('[ ^C to terminate ]')
         machine.wait_for_exit()
 
 except testvm.Failure as ex:

--- a/vm-run
+++ b/vm-run
@@ -73,11 +73,19 @@ parser.add_argument('-G', '--graphics', action='store_true', help='Display a gra
 parser.add_argument('-q', '--quiet', action='store_true', help="Don't connect text console")
 parser.add_argument('-C', '--cpus', default=None, type=int, help='Number of cpus in the target machine')
 parser.add_argument('-S', '--storage', default=None, type=str, help='Add a second qcow2 disk at this path')
+parser.add_argument('-e', '--execute', metavar='COMMAND', action='append',
+                    help='Execute this (shell-interpreted) command (implies -q)')
+parser.add_argument('-s', '--systemd-start', metavar='UNIT', action='append', dest='execute',
+                    type=(lambda s: "systemctl enable --now {}".format(str(s))),
+                    help='Start this systemd unit (implies -q)')
 parser.add_argument('--network', action='store_true', help='Setup a bridged network for running machines')
 parser.add_argument('--no-network', action='store_true', help='Do not connect the machine to the Internet')
 
 parser.add_argument('image', help='The image to run')
 args = parser.parse_args()
+
+if args.execute:
+    args.quiet = True
 
 try:
     if args.network:
@@ -144,9 +152,16 @@ try:
         ip = re.search("inet ([^/]+)", output).group(1)
         message = "\nBRIDGE IP FROM HOST\n  %s\n" % ip
 
-    # Wait here before the "Press ^C" message
+    # we need this to execute any commands, but we also want to wait here
+    # before we display the "Press ^C" message
     if args.quiet:
         machine.wait_boot()
+
+    # execute any -e and -s commands
+    if args.execute:
+        for cmd in args.execute:
+            print('#', cmd)
+            machine.execute(cmd, stdout=1)
 
     # Graphics console necessary
     if graphics:


### PR DESCRIPTION
Add --execute and --systemd-start commandline arguments to execute
arbitrary commands or start systemd unit files.  This is pretty useful
for testing repeated incremental changes to an image.
    
These arguments imply --quiet.
