### PR TITLE
image-refresh: Do not specify no-test label

### DIFF
--- a/image-refresh
+++ b/image-refresh
@@ -48,7 +48,7 @@ def run(image, verbose=False, **kwargs):
 
     branch = task.branch(image, "images: Update {0} image".format(image), pathspec="images", **kwargs)
     if branch:
-        pull = task.pull(branch, labels=['bot', 'no-test'], run_tests=False, **kwargs)
+        pull = task.pull(branch, labels=['bot'], run_tests=False, **kwargs)
 
         # Trigger this pull request
         api = github.GitHub()


### PR DESCRIPTION
Not needed, as we trigger by default only `host` context for PRs in bots
repository.

I thought there was much to clean up, but seems only this is what is not needed anymore.