### PR TITLE
Add script for creating rel-eng based RHEL images

### DIFF
--- a/image-create
+++ b/image-create
@@ -90,6 +90,10 @@ class MachineBuilder:
             env = {
                 "TEST_OS": self.machine.image,
                 "DO_BUILD": "0" if args.no_build else "1",
+                "SERVER_REPO_URL": os.environ.get("SERVER_REPO_URL", ""),
+                "EXTRAS_REPO_URL": os.environ.get("EXTRAS_REPO_URL", ""),
+                "BASEOS_REPO_URL": os.environ.get("BASEOS_REPO_URL", ""),
+                "APPSTREAM_REPO_URL": os.environ.get("APPSTREAM_REPO_URL", ""),
             }
             self.machine.message("run setup script on guest")
 

--- a/image-create-rhel-compose
+++ b/image-create-rhel-compose
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eu
+
+COMPOSE=${COMPOSE:-""}
+EXTRAS_COMPOSE=${EXTRAS_COMPOSE:-""}
+
+if [ -z "$COMPOSE" ]; then
+    echo "Unspecified compose (use COMPOSE env variable)."
+    exit 1
+fi
+
+# RHEL-x.y(.z)-YYYYMMDD.b -> rhel-x-y
+final_image=${COMPOSE,,}
+final_image=${final_image//./-}
+image=${final_image:0:8}
+
+if [[ "$COMPOSE" =~ RHEL-7 ]]; then
+    if [[ -z "$EXTRAS_COMPOSE" ]]; then
+        EXTRAS_COMPOSE="latest-EXTRAS-7-RHEL-7"
+        echo "EXTRAS_COMPOSE not supplied, using '$EXTRAS_COMPOSE'."
+    fi
+    export SERVER_REPO_URL="http://download.devel.redhat.com/rel-eng/rhel-7/RHEL-7/$COMPOSE/compose/Server/x86_64/os"
+    export EXTRAS_REPO_URL="http://download.devel.redhat.com/rel-eng/rhel-7/EXTRAS-7/$EXTRAS_COMPOSE/compose/Server/x86_64/os"
+    install_url=$SERVER_REPO_URL
+else
+    export BASEOS_REPO_URL="http://download.devel.redhat.com/rel-eng/rhel-8/RHEL-8/$COMPOSE/compose/BaseOS/x86_64/os"
+    export APPSTREAM_REPO_URL="http://download.devel.redhat.com/rel-eng/rhel-8/RHEL-8/$COMPOSE/compose/AppStream/x86_64/os"
+    install_url=$BASEOS_REPO_URL
+fi
+
+bootstrap_script="$(dirname $0)/images/scripts/$image.bootstrap"
+mv $bootstrap_script ${bootstrap_script}.orig
+
+echo "#!/bin/bash
+set -eux
+
+BASE=\$(dirname \$0)
+\$BASE/virt-install-fedora \"\$1\" x86_64 \"$install_url\"
+" > $bootstrap_script
+chmod +x $bootstrap_script
+
+pushd $(dirname $0)
+./image-create $image $@
+mv ${bootstrap_script}.orig $bootstrap_script
+mv images/$image images/$final_image
+popd

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -35,7 +35,43 @@ set -x
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     # Configure repositories.
 
-    if [ "$IMAGE" = "rhel-7-7" ]; then
+    if [ -n "$SERVER_REPO_URL" -a -n "$EXTRAS_REPO_URL" ]; then
+    # disable all default repos
+    rm -f --verbose /etc/yum.repos.d/*.repo
+cat <<EOF > /etc/yum.repos.d/rel-eng.repo
+[RHEL-7]
+name=rhel7-server
+baseurl=$SERVER_REPO_URL
+enabled=1
+gpgcheck=0
+
+[EXTRAS-7]
+name=rhel7-extras
+baseurl=$EXTRAS_REPO_URL
+enabled=1
+gpgcheck=0
+EOF
+        $YUM_INSTALL yum-utils
+
+    elif [ -n "$BASEOS_REPO_URL" -a -n "$APPSTREAM_REPO_URL" ]; then
+    # disable all default repos
+    rm -f --verbose /etc/yum.repos.d/*.repo
+cat <<EOF > /etc/yum.repos.d/rel-eng.repo
+[RHEL-8-BaseOS]
+name=rhel8-baseos
+baseurl=$BASEOS_REPO_URL
+enabled=1
+gpgcheck=0
+
+[RHEL-8-AppStream]
+name=rhel8-appstream
+baseurl=$APPSTREAM_REPO_URL
+enabled=1
+gpgcheck=0
+EOF
+        $YUM_INSTALL yum-utils
+
+    elif [ "$IMAGE" = "rhel-7-7" ]; then
         # disable all default repos
         rm -f --verbose /etc/yum.repos.d/*.repo
 cat <<EOF > /etc/yum.repos.d/internal.repo


### PR DESCRIPTION
The existing bots scripts target at creating RHEL images from nightly composes, however, for composer testing we also need rel-eng-based images. The script just makes use of the already existing setup/bootstrap scripts and basically just performs a few URL/repo names replacements.

This is mostly a composer-related script (and it's a bit of a hack :), so if you think it should rather go directly to the lorax repo, I'm fine with it. Otherwise I think it best suits to be located next to the other image handling scripts, which is in the bots repo :).