### PR TITLE
 github.py: Query issues based on their modifications time

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -329,24 +329,14 @@ class GitHub(object):
         result = []
         page = 1
         count = 100
-        opened = True
         label = ",".join(labels)
-        while count == 100 and opened:
-            req = "issues?labels={0}&state=all&page={1}&per_page={2}".format(label, page, count)
+        while count == 100:
+            req = "issues?labels={0}&state={1}&page={2}&per_page={3}".format(label, state, page, count)
             issues = self.get(req)
             count = 0
             page += 1
-            opened = False
             for issue in issues:
                 count += 1
-
-                # On each loop of 100 issues we must encounter at least 1 open issue
-                if issue["state"] == "open":
-                    opened = True
-
-                # Make sure the state matches
-                if state != "all" and issue["state"] != state:
-                    continue
 
                 # Check that the issues are past the expected date
                 if since:

--- a/task/test-github
+++ b/task/test-github
@@ -73,6 +73,8 @@ def mockServer():
                 issues_ = issues
                 if "state=open" in self.path:
                     issues_ = [i for i in issues_ if i["state"] == "open"]
+                if "since=" in self.path:
+                    issues_ = [i for i in issues_ if "created_at" not in i.keys() and "closed_at" not in i.keys()]
                 self.replyJson(issues_)
             elif parsed.path == "/test/user":
                 if self.headers.get("If-None-Match") == "blah":

--- a/task/test-github
+++ b/task/test-github
@@ -70,7 +70,10 @@ def mockServer():
             if parsed.path == "/count":
                 self.replyJson(self.server.data["count"])
             elif parsed.path == "/issues":
-                self.replyJson(issues)
+                issues_ = issues
+                if "state=open" in self.path:
+                    issues_ = [i for i in issues_ if i["state"] == "open"]
+                self.replyJson(issues_)
             elif parsed.path == "/test/user":
                 if self.headers.get("If-None-Match") == "blah":
                     self.replyData("", status=304)


### PR DESCRIPTION
`github.py: Query issues based on their status`

This commit should be safe. Honestly I don't see why we would want to always query all issues and then filter them. Is there some good reason for this?

`github.py: Query issues since they were last modified`

Now it also would return issues that were only commented at in the given timeframe. Before it was querying only issues when they were opened/closed. Could this cause some problems? (I need to query issues based on their modification time and not when they were opened/closed)