### PR TITLE
npm-update fixes

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -116,24 +116,28 @@ def run(specified_package, verbose=False, **kwargs):
 
             # Write out the original package.json with the updated version
             package_json(orig_package_json, package, new_version)
+            if not kwargs["dry"]:
+                # Create a pull request from these changes
+                title = "package.json: Update {0} package dependency".format(package)
+                branch = task.branch(package, title, pathspec="package.json", **kwargs)
 
-            # Create a pull request from these changes
-            title = "package.json: Update {0} package dependency".format(package)
-            branch = task.branch(package, title, pathspec="package.json", **kwargs)
+                # List of files that probably touch this package
+                lines = output("git", "grep", "-w", package)
+                comment = "Please manually check features related to these files:\n\n```\n{0}```".format(lines)
 
-            # List of files that probably touch this package
-            lines = output("git", "grep", "-w", package)
-            comment = "Please manually check features related to these files:\n\n```\n{0}```".format(lines)
+                if branch:
+                    kwargs["title"] = title
+                    pull = task.pull(branch, **kwargs)
 
-            if branch:
-                kwargs["title"] = title
-                pull = task.pull(branch, **kwargs)
-
-                task.comment(pull, comment)
+                    task.comment(pull, comment)
+                    break
+            else:
+                # in dry mode, still only update one dep, so that updates can be tested one by one
                 break
 
     # Undo our changes
-    package_json(orig_package_json)
+    if not kwargs["dry"]:
+        package_json(orig_package_json)
 
 
 if __name__ == '__main__':

--- a/npm-update
+++ b/npm-update
@@ -30,6 +30,8 @@ FRAGILE = [
     "paternfly-bootstrap-combobox",
     # version 0.32.2 switches to babel 7, which causes build failures with our babel 6 build system
     "react-bootstrap",
+    "angular",
+    "angular-route",
 ]
 
 import collections


### PR DESCRIPTION
This now avoids broken angular updates like https://github.com/cockpit-project/cockpit-ostree/pull/37/ . npm-update now can also be used reasonably with `--dry`. In the first step it tries to update angular-route (before the second patch):
```diff
--- package.json
+++ package.json
@@ -43,7 +43,7 @@
     "angular": "1.7.9",
     "angular-bootstrap-npm": "0.13.4",
     "angular-gettext": "2.3.11",
-    "angular-route": "1.3.20",
+    "angular-route": "1.7.9",
     "bootstrap": "3.4.1",
     "moment": "2.24.0",
     "patternfly": "3.59.4"

```
and when running it again, it goes on to the next package, with the correct format:
```diff
--- package.json
+++ package.json
@@ -42,8 +42,8 @@
     "@babel/polyfill": "7.8.3",
     "angular": "1.7.9",
     "angular-bootstrap-npm": "0.13.4",
-    "angular-gettext": "2.3.11",
-    "angular-route": "1.3.20",
+    "angular-gettext": "2.4.1",
+    "angular-route": "1.7.9",
     "bootstrap": "3.4.1",
     "moment": "2.24.0",
     "patternfly": "3.59.4"
```

I also ran it without `--dry`, and it produces https://github.com/cockpit-project/cockpit-ostree/pull/39 . This has the correct format and shape, so I didn't break the no-dry case.

I'll check whether the angular-gettext update actually works. If so, it's fine, if not, I'll add it to FRAGILE. But that won't affect the first two commits here.

**Update**: bumping angular-gettext worked fine.