### PR TITLE
naughty: Close 80: krb5 regression: SSH GSS authentication fails with "Ticket expired"

### DIFF
--- a/naughty/fedora-31/80-sssd-ssh-ticket-expired
+++ b/naughty/fedora-31/80-sssd-ssh-ticket-expired
@@ -1,4 +1,0 @@
-  File "test/verify/check-realms", line *, in testNegotiate
-    b.wait_popdown('troubleshoot-dialog')
-*
-testlib.Error: timeout

--- a/naughty/rhel-8/80-sssd-ssh-ticket-expired
+++ b/naughty/rhel-8/80-sssd-ssh-ticket-expired
@@ -1,4 +1,0 @@
-  File "test/verify/check-realms", line *, in testNegotiate
-    b.wait_popdown('troubleshoot-dialog')
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 27 days

krb5 regression: SSH GSS authentication fails with "Ticket expired"

Fixes #80