### PR TITLE
testmap: Enable fedora-coreos on cockpit-ostree

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -77,9 +77,9 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'continuous-atomic',
             'rhel-atomic',
+            'fedora-coreos',
         ],
         '_manual': [
-            'fedora-coreos',
         ],
     },
     'cockpit-project/cockpit-podman': {


### PR DESCRIPTION
This was enabled in https://github.com/cockpit-project/cockpit-ostree/pull/40