### PR TITLE
bots: Avoid long fedora-31 shutdown hang due to packagekit.service

### DIFF
--- a/images/scripts/fedora-31.install
+++ b/images/scripts/fedora-31.install
@@ -2,3 +2,7 @@
 
 set -e
 /var/lib/testvm/fedora.install "$@"
+
+# HACK: packagekit.service hangs on stop; https://bugzilla.redhat.com/show_bug.cgi?id=1717185
+mkdir -p /etc/systemd/system/packagekit.service.d
+printf '[Service]\nTimeoutStopSec=5\n' > /etc/systemd/system/packagekit.service.d/timeout.conf


### PR DESCRIPTION
We don't have any persistent PackageKit state on our test images anyway,
so it's fine to just get it killed fast on shutdown.

See https://bugzilla.redhat.com/show_bug.cgi?id=1717185

---

This fixes test/image-prepare and tests that reboot, and shaves off 1½ minutes from each of these.