### PR TITLE
testmap: Define manual triggers for fedora-31

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -62,6 +62,11 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-testing',
+            'fedora-31/container-bastion',
+            'fedora-31/selenium-firefox',
+            'fedora-31/selenium-chrome',
+            'fedora-31/selenium-edge',
+            'fedora-31/firefox',
         ],
     },
     'cockpit-project/starter-kit': {
@@ -71,6 +76,7 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream',
         ],
         '_manual': [
+            'fedora-31',
         ],
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
We want to switch from Fedora-30 to Fedora-31 which means we need to
test these changes. In order to be able to do that, we need to define
manual contexts.