### PR TITLE
naughty: Close 342: RHEL 8.2 regression: setroubleshoot does not use restorecon plugin

### DIFF
--- a/naughty/rhel-8/342-setroubleshoot-restorecon
+++ b/naughty/rhel-8/342-setroubleshoot-restorecon
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-setroubleshoot", line *, in testTroubleshootAlerts
-    b.wait_in_text(panel_selector, "you can run restorecon")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 23 days

RHEL 8.2 regression: setroubleshoot does not use restorecon plugin

Fixes #342