### PR TITLE
machine: Drop VirtMachine boot diagnostics

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -516,33 +516,6 @@ class VirtMachine(Machine):
             # Normally only one pass
             break
 
-    def _diagnose_no_address(self):
-        SCRIPT = """
-            spawn virsh -c qemu:///session console $argv
-            set timeout 300
-            expect "Escape character"
-            send "\r"
-            expect " login: "
-            send "root\r"
-            expect "Password: "
-            send "foobar\r"
-            expect " ~]# "
-            send "ip addr\r\n"
-            expect " ~]# "
-            exit 0
-        """
-        expect = subprocess.Popen(["expect", "--", "-", str(self._domain.ID())], stdin=subprocess.PIPE,
-                                  universal_newlines=True)
-        expect.communicate(SCRIPT)
-
-    def wait_boot(self, timeout_sec=120):
-        """Wait for a machine to boot"""
-        try:
-            Machine.wait_boot(self, timeout_sec)
-        except Failure:
-            self._diagnose_no_address()
-            raise
-
     def stop(self, timeout_sec=120):
         if self.maintain:
             self.shutdown(timeout_sec=timeout_sec)


### PR DESCRIPTION
This isn't really helpful. In CI it is responsible for a good deal of
long test run times when rebooting fails, and the diagnostics don't tell
us much about *why* a machine is completely frozen or *why* ssh to it is
broken even though it has a login prompt (the usual two cases that we
observe).

For a local developer, it's even less useful -- due to wrapping virsh
console into expect, the shown console does not react to keyboard input
at all, and furthermore blocks a manual `virsh console`, thus *breaking*
debuggability. It is much more helpful to run with --sit and attach to
the VM directly.

Fixes #507