### PR TITLE
machine: Increase DHCP lease time

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -289,7 +289,7 @@ class Machine(ssh_connection.SSHConnection):
         """Sets up a DHCP server on the interface"""
         cmd = "dnsmasq --domain=cockpit.lan " \
               "--interface=\"$(grep -l '{mac}' /sys/class/net/*/address | cut -d / -f 5)\"" \
-              " --bind-dynamic --dhcp-range=" + ','.join(range) + \
+              " --bind-dynamic --dhcp-range=" + ','.join(range) + ",4h" + \
               " && firewall-cmd --add-service=dhcp"
         self.execute(cmd.format(mac=mac))
 


### PR DESCRIPTION
The default is only 1h, which causes e. g. Selenium tests to start
failing if they run longer than that.

Bump it to 4h.