### PR TITLE
images: Explicitly start firewalld in debian.install

### DIFF
--- a/images/scripts/lib/debian.install
+++ b/images/scripts/lib/debian.install
@@ -87,6 +87,7 @@ if [ -n "$do_install" ]; then
     # avoid random dpkg database locks, they break our package related tests
     systemctl disable apt-daily-upgrade.timer
 
+    systemctl start firewalld
     firewall-cmd --add-service=cockpit --permanent
     # not managed by NM, so enable interface manually
     firewall-cmd --zone=public --permanent --add-interface=eth1


### PR DESCRIPTION
It can happen that the *.install scripts runs before multi-user.target
is active (it only waits for ssh) and firewalld is actually running.
Explicitly start it (which will just wait if it's already being
started), similar to what fedora.install does.

Fixes #520