### PR TITLE
testmap: Stop testing Cockpit on fedora-30

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -34,7 +34,6 @@ REPO_BRANCH_CONTEXT = {
             'debian-testing',
             'ubuntu-1804',
             'ubuntu-stable',
-            'fedora-30',
             'fedora-31',
             'fedora-coreos',
             'fedora-31/firefox',


### PR DESCRIPTION
We don't release Cockpit to Fedora 30 any more:
https://github.com/cockpit-project/cockpit/pull/13599