### PR TITLE
testmap: Move starter-kit testing from Fedora 30 to 31

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -68,11 +68,10 @@ REPO_BRANCH_CONTEXT = {
     'cockpit-project/starter-kit': {
         'master': [
             'centos-7',
-            'fedora-30',
+            'fedora-31',
             'centos-8-stream',
         ],
         '_manual': [
-            'fedora-31',
         ],
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
I ran `TEST_OS=fedora-31 make check` locally to make sure that this works. If you'd rather go via `_manual` first, I'm happy to do that, too.