### PR TITLE
naughty: Fix fedora-testing symlink

### DIFF
--- a/naughty/fedora-testing
+++ b/naughty/fedora-testing
@@ -1,1 +1,1 @@
-fedora-30
+fedora-31


### PR DESCRIPTION
It was pointing to fedora-30 even though that fedora-testing is now
based on fedora-31.