### PR TITLE
testmap: Run Fedora 32 on podman master

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -85,11 +85,11 @@ REPO_BRANCH_CONTEXT = {
     'cockpit-project/cockpit-podman': {
         'master': [
             'fedora-31',
+            'fedora-32',
             'rhel-8-2',
         ],
         '_manual': [
             'centos-8-stream',
-            'fedora-32',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
Tested in https://github.com/cockpit-project/cockpit-podman/pull/326

When this lands, F32 should be marked as required in cockpit-podman.