### PR TITLE
naughty: Close 337: RHEL 8 regression: avc: denied { search } for comm="timedatex"

### DIFF
--- a/naughty/rhel-8/337-selinux-timedatex-search
+++ b/naughty/rhel-8/337-selinux-timedatex-search
@@ -1,1 +1,0 @@
-* type=1400 audit(*): avc:  denied  { search } for * comm="timedatex"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

RHEL 8 regression: avc: denied { search } for comm="timedatex"

Fixes #337