### PR TITLE
naughty: Close 264: centos-8-stream unprivileged selinux user login fails

### DIFF
--- a/naughty/rhel-8/264-selinux-restricted-user-login
+++ b/naughty/rhel-8/264-selinux-restricted-user-login
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-login", line *, in testSELinuxRestrictedUser
-    b.login_and_go("/system", user="unpriv")


### PR DESCRIPTION
Known issue which has not occurred in 22 days

centos-8-stream unprivileged selinux user login fails

Fixes #264