### PR TITLE
image-create-rhel-compose: Properly revert bootstrap script from backup

### DIFF
--- a/image-create-rhel-compose
+++ b/image-create-rhel-compose
@@ -28,7 +28,8 @@ else
     install_url=$BASEOS_REPO_URL
 fi
 
-bootstrap_script="$(dirname $0)/images/scripts/$image.bootstrap"
+pushd $(dirname $0)
+bootstrap_script="images/scripts/$image.bootstrap"
 mv $bootstrap_script ${bootstrap_script}.orig
 
 echo "#!/bin/bash
@@ -39,7 +40,6 @@ BASE=\$(dirname \$0)
 " > $bootstrap_script
 chmod +x $bootstrap_script
 
-pushd $(dirname $0)
 ./image-create $image $@
 mv ${bootstrap_script}.orig $bootstrap_script
 mv images/$image images/$final_image


### PR DESCRIPTION
This fixes a minor issue in the image-create-rhel-compose script where the backed up .bootstrap script didn't get renamed back properly after the custom rel-eng image was created.