### PR TITLE
naughty: Add pattern for broken kdump on fedora-32

### DIFF
--- a/naughty/fedora-32/629-kdump
+++ b/naughty/fedora-32/629-kdump
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-kdump", line *, in testBasic
+    m.wait_boot(timeout_sec=300)
+*
+machine_core.exceptions.Failure: Unable to reach machine *


### PR DESCRIPTION
This slipped through the image refresh because of
https://github.com/cockpit-project/cockpit/issues/13697

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1812393
Known issue #629