### PR TITLE
task: Support compressed journal files in log.html

### DIFF
--- a/task/log.html
+++ b/task/log.html
@@ -149,7 +149,7 @@ var tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
 var tap_result = /^(ok|not ok) ([0-9]+) (.*)(?: # duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
 var tap_skipped = /^ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # SKIP (.*$)/gm;
 var image_file = /([A-Za-z0-9\-\.]+\.png)$/gm;
-var journal_file = /Journal extracted to ([A-Za-z0-9\-\.]+\.log)$/gm;
+var journal_file = /Journal extracted to ([A-Za-z0-9\-\.]+\.log(?:\.[gx]z)?)$/gm;
 var test_header_start = "# ----------------------------------------------------------------------"
 
 var entry_template = $("#TestEntry").html();

--- a/task/log.html
+++ b/task/log.html
@@ -148,8 +148,8 @@
 var tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
 var tap_result = /^(ok|not ok) ([0-9]+) (.*)(?: # duration: ([0-9]+s))?(?: # SKIP .*)?$$/gm;
 var tap_skipped = /^ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # SKIP (.*$)/gm;
-var image_file = /([A-Za-z0-9\-\.]+)\.(png)$/gm;
-var journal_file = /(Journal extracted to )([A-Za-z0-9\-\.]+)\.(log)$/gm;
+var image_file = /([A-Za-z0-9\-\.]+\.png)$/gm;
+var journal_file = /Journal extracted to ([A-Za-z0-9\-\.]+\.log)$/gm;
 var test_header_start = "# ----------------------------------------------------------------------"
 
 var entry_template = $("#TestEntry").html();
@@ -261,13 +261,11 @@ function extract(text) {
             }
             while (m = image_file.exec(segment)) {
                 // we have an image link
-                entry.screenshots.push({screenshot_html: Mustache.render(screenshot_template,
-                                                                        { screenshot: m[1] + "." + m[2] })
+                entry.screenshots.push({screenshot_html: Mustache.render(screenshot_template, { screenshot: m[1] })
                                        });
             }
             while (m = journal_file.exec(segment)) {
-                entry.journals.push({journal_html: Mustache.render(journal_template,
-                                                                   { journal: m[2] + "." + m[3] })
+                entry.journals.push({journal_html: Mustache.render(journal_template, { journal: m[1] })
                                     });
             }
             entry.failed = !entry.passed && !entry.skipped;


### PR DESCRIPTION
I want to start compressing the journals for cockpit test results, as they are really big. They take up 60% of our total log space and compress really well. E. g. [this log](https://logs.cockpit-project.org/logs/pull-13753-20200318-211658-f19f90d1-ubuntu-1804/TestRealms-testIpa-ubuntu-1804-127.0.0.2-2901-FAIL.log) is 19.1 MB, and gzip shrinks it to 380 kB.