### PR TITLE
naughty: Close 542: hostnamectl crashes with Assertion 'm->n_ref > 0'

### DIFF
--- a/naughty/rhel-8/542-hostnamectl-assert
+++ b/naughty/rhel-8/542-hostnamectl-assert
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-dashboard", line *, in testEdit
-    self.assertEqual(m.execute("hostnamectl --pretty"), "Horst\n")
-*
-subprocess.CalledProcessError: Command 'hostnamectl --pretty' returned non-zero exit status 1.


### PR DESCRIPTION
Known issue which has not occurred in 23 days

hostnamectl crashes with Assertion 'm->n_ref > 0'

Fixes #542