### PR TITLE
naughty: Close 538: Modprobe kvdo fails: kernel version mismatch

### DIFF
--- a/naughty/rhel-8/538-modprobe-kvdo
+++ b/naughty/rhel-8/538-modprobe-kvdo
@@ -1,1 +1,0 @@
-vdo: ERROR - modprobe: FATAL: Module kvdo not found in directory*


### PR DESCRIPTION
Known issue which has not occurred in 26 days

Modprobe kvdo fails: kernel version mismatch

Fixes #538