### PR TITLE
naughty: Close 474: SELinux is preventing abrt-dump-journal-oops from create 

### DIFF
--- a/naughty/fedora-30/474-selinux-create-abrt-dump-journal-oops
+++ b/naughty/fedora-30/474-selinux-create-abrt-dump-journal-oops
@@ -1,1 +1,0 @@
-* type=1400 * avc:  denied  { create } for * comm="abrt-dump-journ"


### PR DESCRIPTION
Known issue which has not occurred in 25 days

SELinux is preventing abrt-dump-journal-oops from create 

Fixes #474