### PR TITLE
naughty: Close 471: sssd_be and sssd crash with SIGABRT in sss_ptr_hash_check_type()

### DIFF
--- a/naughty/rhel-8/471-sssd-abrt
+++ b/naughty/rhel-8/471-sssd-abrt
@@ -1,1 +1,0 @@
-Process *sssd* of user 0 dumped core


### PR DESCRIPTION
Known issue which has not occurred in 23 days

sssd_be and sssd crash with SIGABRT in sss_ptr_hash_check_type()

Fixes #471