### PR TITLE
images: Pin ubuntu-stable to 19.10 (eoan) until 20.10 gets opened

### DIFF
--- a/images/scripts/ubuntu-stable.bootstrap
+++ b/images/scripts/ubuntu-stable.bootstrap
@@ -15,4 +15,7 @@ fi
 # release name is the last part of the URL
 rel=${rel##*/}
 
+# Pin release to 19.10 (eoan) while the current stable is 20.04 LTS, as we have a separate image for that (ubuntu-2004)
+rel=eoan
+
 exec $(dirname $0)/lib/debian.bootstrap "$1" "https://cloud-images.ubuntu.com/daily/server/$rel/current/$rel-server-cloudimg-amd64.img"


### PR DESCRIPTION
After 20.04 LTS gets released, we don't want ubuntu-stable to move to
that, as we already have a separate ubuntu-2004 image for that. Let's
rather keep testing 19.10, until 20.10 opens.