### PR TITLE
images: Install dnsmasq on fedora-coreos

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-5b62e9033401f4f562a6cd6b76fede5fb606ee799b1a3f48261158be6dd10d66.qcow2
+fedora-coreos-9a743acdcabb1ed47d565d8843fc00f0d19616c81f00bed149d59f0ad7b1cf19.qcow2

--- a/images/scripts/fedora-coreos.setup
+++ b/images/scripts/fedora-coreos.setup
@@ -14,7 +14,8 @@ echo 'UseDNS no' >> /etc/ssh/sshd_config
 nmcli connection modify 'Wired connection 2' ipv4.method disabled ipv6.method ignore
 
 # pre-install the distro version, which is useful for testing extensions and manual experiments
-rpm-ostree install cockpit-system cockpit-bridge cockpit-networkmanager
+# also pre-install dnsmasq which we need for testing
+rpm-ostree install cockpit-system cockpit-bridge cockpit-networkmanager dnsmasq
 
 # reduce image size
 rpm-ostree cleanup --repomd


### PR DESCRIPTION
We need a DHCP server to make our network tests suitable for downstream
testing, and there is not even systemd-networkd on the default images.

 * [x] image-refresh fedora-coreos