### PR TITLE
po-refresh: Add hack to work around semicolon bug

### DIFF
--- a/po-refresh
+++ b/po-refresh
@@ -140,6 +140,11 @@ def run(context, verbose=False, **kwargs):
                 current_linguas.remove(locale[0])
             (user, local_branch) = add_and_commit_lang(name, locale[0], "Drop").split(":")
 
+    # HACK: Semicolon in some languages in 'Plural-Forms' header key can break translations
+    # https://github.com/mikeedwards/po2json/issues/87
+    # Removing all semicolons is safe way around this
+    output('sed', '-ri', r'/^"Plural-Forms:/ s/;(\\n")$/\1/', *glob.glob("po/*.po"))
+
     # Add languages that got over 50% translated
     files = output("git", "ls-files", "--others", "--exclude-standard", "po/")
     for name in files.splitlines():


### PR DESCRIPTION
Result of one run of po-refresh with this change:
https://github.com/marusak/cockpit/pull/31/commits/b91d036fcc37e27f70538f7bcf8b3e3a456b69a8

Languages it drops the semicolon from: `cs`, `de`, `fr`, `it`, `nl`, `pt_BR`.
The same change I tested in https://github.com/cockpit-project/cockpit/pull/13791 and it worked just fine.

This seems to happen when `.po` files are directly uploaded into weblate. I got exact files from Ludek that seems to cause this and I'll check if this is workflow problem (there is option to rewrite the file) or weblate problem (that it fails to merge translations). That is however outside of what we can affect so this hack is to prevent this from breaking.