### PR TITLE
naughty: Add pattern for SELinux violations for pmdakvm

### DIFF
--- a/naughty/fedora-32/688-selinux-pmdakvm
+++ b/naughty/fedora-32/688-selinux-pmdakvm
@@ -1,0 +1,1 @@
+* type=1400 audit(*): avc:  denied * comm="pmdakvm"


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1817361
Known issue #688

---

Example: https://logs.cockpit-project.org/logs/pull-13793-20200326-063338-ea0c7bd5-fedora-32/log.html#191