### PR TITLE
naughty: Close 579: Virsh cannot attach iscsi disk device to domain

### DIFF
--- a/naughty/fedora-32/579-virsh-device-attach
+++ b/naughty/fedora-32/579-virsh-device-attach
@@ -1,3 +1,0 @@
-*testAddDisk*
-*
-*ph_is_present("#vm-subVmTest1-disks-vdh-bus"))*


### PR DESCRIPTION
Known issue which has not occurred in 26 days

Virsh cannot attach iscsi disk device to domain

Fixes #579