### PR TITLE
images: Adjust fedora-coreos network config to current release

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-9a743acdcabb1ed47d565d8843fc00f0d19616c81f00bed149d59f0ad7b1cf19.qcow2
+fedora-coreos-e85f44c91bc23abbc12575e4ecfb09dc27cf6e8e0f38eb143c31507d9336d40b.qcow2

--- a/images/scripts/fedora-coreos.setup
+++ b/images/scripts/fedora-coreos.setup
@@ -9,10 +9,6 @@ podman pull docker.io/cockpit/ws
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-# don't hang/fail on non-existing DHCP on eth1 on boot
-# similar to images/scripts/network-ifcfg-eth1 for Fedora/RHEL images
-nmcli connection modify 'Wired connection 2' ipv4.method disabled ipv6.method ignore
-
 # pre-install the distro version, which is useful for testing extensions and manual experiments
 # also pre-install dnsmasq which we need for testing
 rpm-ostree install cockpit-system cockpit-bridge cockpit-networkmanager dnsmasq

--- a/images/scripts/lib/cockpit-ci.fcc
+++ b/images/scripts/lib/cockpit-ci.fcc
@@ -1,6 +1,6 @@
 # Documentation: https://github.com/coreos/fcct/blob/master/docs/configuration-v1_0.md
 # Download compiler from https://github.com/coreos/fcct/releases
-# Build with fcct-x86_64-unknown-linux-gnu -input images/scripts/lib/cockpit-ci.fcc -pretty -output images/scripts/lib/cockpit-ci.ign
+# Build with fcct-x86_64-unknown-linux-gnu --pretty --output images/scripts/lib/cockpit-ci.ign images/scripts/lib/cockpit-ci.fcc
 variant: fcos
 version: 1.0.0
 passwd:
@@ -18,6 +18,24 @@ passwd:
       password_hash: $6$mNBJSioSQeVZR.Hp$B7T3O2owkci1XYj5CDOUNotUKNAT7mNDHRi8lqdoThFt7YZQKDmbmX7INado6YniSbyA1YJx0lWbT3GHsoAaJ0
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUOtNJdBEXyKxBB898rdT54ULjMGuO6v4jLXmRsdRhR5Id/lKNc9hsdioPWUePgYlqML2iSV72vKQoVhkyYkpcsjr3zvBny9+5xej3+TBLoEMAm2hmllKPmxYJDU8jQJ7wJuRrOVOnk0iSNF+FcY/yaQ0owSF02Nphx47j2KWc0IjGGlt4fl0fmHJuZBA2afN/4IYIIsEWZziDewVtaEjWV3InMRLllfdqGMllhFR+ed2hQz9PN2QcapmEvUR4UCy/mJXrke5htyFyHi8ECfyMMyYeHwbWLFQIve4CWix9qtksvKjcetnxT+WWrutdr3c9cfIj/c0v/Zg/c4zETxtp cockpit-test
+storage:
+  files:
+    # don't hang/fail on non-existing DHCP on eth1 on boot
+    # similar to images/scripts/network-ifcfg-eth1 for Fedora/RHEL images
+    - path: /etc/NetworkManager/system-connections/eth1.nmconnection
+      mode: 0600
+      contents:
+        inline: |
+          [connection]
+          id=eth1
+          type=ethernet
+          interface-name=eth1
+
+          [ipv4]
+          method=disabled
+
+          [ipv6]
+          method=ignore
 systemd:
   units:
     # this is a really saddening way of turning off the VM after setup

--- a/images/scripts/lib/cockpit-ci.ign
+++ b/images/scripts/lib/cockpit-ci.ign
@@ -34,7 +34,20 @@
       }
     ]
   },
-  "storage": {},
+  "storage": {
+    "files": [
+      {
+        "group": {},
+        "path": "/etc/NetworkManager/system-connections/eth1.nmconnection",
+        "user": {},
+        "contents": {
+          "source": "data:,%5Bconnection%5D%0Aid%3Deth1%0Atype%3Dethernet%0Ainterface-name%3Deth1%0A%0A%5Bipv4%5D%0Amethod%3Ddisabled%0A%0A%5Bipv6%5D%0Amethod%3Dignore%0A",
+          "verification": {}
+        },
+        "mode": 384
+      }
+    ]
+  },
   "systemd": {
     "units": [
       {


### PR DESCRIPTION
Latest CoreOS does not like it when new network interfaces appear after
the initial boot. Move the configuration of eth1 from the .setup script
to the initial bootstrap by putting the NM device config into the
Ignition config.

Also the latest Ignition compiler now uses GNU CLI syntax,  adjust the
comment how to build it.

Fixes #708

 * [x] image-refresh fedora-coreos
 * [x] Skip dhclient-modifying tests on fedora-coreos: https://github.com/cockpit-project/cockpit/pull/13851
 * [x] Adjust error messages on ostree: https://github.com/cockpit-project/cockpit-ostree/pull/74