### PR TITLE
machine: Avoid warnings from cockpit startup

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -246,7 +246,7 @@ class Machine(ssh_connection.SSHConnection):
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
             systemctl reset-failed 'cockpit*' &&
             systemctl daemon-reload &&
-            systemctl stop cockpit.service &&
+            systemctl stop --quiet cockpit.service &&
             systemctl start cockpit.socket
             """)
         else:
@@ -256,11 +256,11 @@ class Machine(ssh_connection.SSHConnection):
             printf "[Service]
             ExecStartPre=-/bin/sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
             ExecStart=
-            %s --no-tls" `systemctl cat cockpit.service | grep ExecStart=` \
+            %s --no-tls" `grep ExecStart= /lib/systemd/system/cockpit.service` \
                     > /etc/systemd/system/cockpit.service.d/notls.conf &&
             systemctl reset-failed 'cockpit*' &&
             systemctl daemon-reload &&
-            systemctl stop cockpit.service &&
+            systemctl stop --quiet cockpit.service &&
             systemctl start cockpit.socket
             """)
 


### PR DESCRIPTION
Use systemctl stop with --quiet to avoid

    Warning: Stopping cockpit.service, but it can still be activated by:
      cockpit.socket

Don't use systemctl cat, as that complains with

    # Warning: cockpit.service changed on disk, the version systemd has loaded is outdated.
    # This output shows the current version of the unit's original fragment and drop-in files.
    # If fragments or drop-ins were added or removed, they are not properly reflected in this output.
    # Run 'systemctl daemon-reload' to reload units.
    Failed to cat /etc/systemd/system/cockpit.service.d/notls.conf: No such file or directory

This is a lot of unnecessary noise for each test.