### PR TITLE
machine: Specify backing format for QEMU disk overlay

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -361,7 +361,7 @@ class VirtMachine(Machine):
         if not self.maintain:
             (unused, self._transient_image) = tempfile.mkstemp(suffix='.qcow2', prefix="", dir=self.run_dir)
             execute("qemu-img", "create", "-q", "-f", "qcow2",
-                    "-o", "backing_file=%s" % self.image_file, self._transient_image)
+                    "-o", "backing_file=%s,backing_fmt=qcow2" % self.image_file, self._transient_image)
             image_to_use = self._transient_image
 
         keys = {


### PR DESCRIPTION
Without this, current (Fedora 32) libvirt fails to auto-detect the
backing format of the transient overlay, and vm-run fails with

    libvirt.libvirtError: Requested operation is not valid:
    format of backing image 'test/images/fedora-31' of image 'tmp/run/qj8pw2wn.qcow2' was not specified in the image metadata

See https://bugzilla.redhat.com/show_bug.cgi?id=1798148 for details.