### PR TITLE
testmap: Disable automatic alibaba lorax tests

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -109,7 +109,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-31/tar',
             'fedora-31/live-iso',
             'fedora-31/qcow2',
-            'fedora-31/alibaba',
             'fedora-31/aws',
             'fedora-31/azure',
             'fedora-31/openstack',
@@ -119,7 +118,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-2',
             'rhel-8-2/live-iso',
             'rhel-8-2/qcow2',
-            'rhel-8-2/alibaba',
             'rhel-8-2/aws',
             'rhel-8-2/azure',
             'rhel-8-2/openstack',
@@ -139,6 +137,9 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
+            # alibaba keeps failing with "resource is out of stock in the specified zone"
+            'fedora-31/alibaba',
+            'rhel-8-2/alibaba',
             'centos-8-stream',
             'rhel-7-9',
             'rhel-7-9/live-iso',


### PR DESCRIPTION
These tests have failed for weeks on "resource is out of stock in the
specified zone".

Move them to manual for now.