### PR TITLE
naughty: Close 583: rhel-8.2 cockpit crashes in ja/ko/zh locales due to broken translations

### DIFF
--- a/naughty/rhel-8/583-rhel-8.2-broken-translations
+++ b/naughty/rhel-8/583-rhel-8.2-broken-translations
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-pages", line *, in testBasic
-    b.enter_page(page)
-*
-RuntimeError: TypeError: n.replace is not a function


### PR DESCRIPTION
Known issue which has not occurred in 33 days

rhel-8.2 cockpit crashes in ja/ko/zh locales due to broken translations

Fixes #583