### PR TITLE
testmap: Use fedora-31 and fedora-31/firefox for c-composer

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -151,8 +151,7 @@ REPO_BRANCH_CONTEXT = {
     },
     'osbuild/cockpit-composer': {
         'master': [
-            'fedora-31/chrome',
-            'fedora-31/edge',
+            'fedora-31',
             'fedora-31/firefox',
         ],
         'rhel-8': [
@@ -165,7 +164,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'fedora-31',
+            'fedora-32',
         ],
     },
     'candlepin/subscription-manager': {


### PR DESCRIPTION
C-composer integration test has switched to cockpit's test framework already and test map need update.
Add fedora-32 in manual trigger list to test fedora-32 scenario.