### PR TITLE
naughty: Add pattern for podman coredumps

### DIFF
--- a/naughty/fedora-31/805-podman-dumps-core
+++ b/naughty/fedora-31/805-podman-dumps-core
@@ -1,0 +1,3 @@
+Process * (exe) of user 1000 dumped core.
+*
+*rootlessport*

--- a/naughty/fedora-31/805-podman-dumps-core1
+++ b/naughty/fedora-31/805-podman-dumps-core1
@@ -1,0 +1,5 @@
+*Failed to do * ConnectionClosed*
+*
+Core dumps downloaded to *
+*
+wait_js_cond(ph_is_present*\"No containers\"*

--- a/naughty/fedora-32/805-podman-dumps-core
+++ b/naughty/fedora-32/805-podman-dumps-core
@@ -1,0 +1,3 @@
+Process * (exe) of user 1000 dumped core.
+*
+*rootlessport*

--- a/naughty/fedora-32/805-podman-dumps-core1
+++ b/naughty/fedora-32/805-podman-dumps-core1
@@ -1,0 +1,5 @@
+*Failed to do * ConnectionClosed*
+*
+Core dumps downloaded to *
+*
+wait_js_cond(ph_is_present*\"No containers\"*


### PR DESCRIPTION
See known issue #805

In one case we get the actual traceback from `exe` where word
`rootlessport` seems to be the most important one.

In the other case there is not really much we can match to. The varlink
dies, thus disconnects us. Also we save coredump and it always fails
waiting for 'No Containers' string.