### PR TITLE
naughty: Close 688: SELinux violations for pmdakvm on debugfs and max_mmu_page_hash_collisions

### DIFF
--- a/naughty/fedora-32/688-selinux-pmdakvm
+++ b/naughty/fedora-32/688-selinux-pmdakvm
@@ -1,1 +1,0 @@
-* type=1400 audit(*): avc:  denied * comm="pmdakvm"


### PR DESCRIPTION
Known issue which has not occurred in 23 days

SELinux violations for pmdakvm on debugfs and max_mmu_page_hash_collisions

Fixes #688