### PR TITLE
naughty: Close 577: Mount cannot add `ac` option to nfs

### DIFF
--- a/naughty/fedora-32/577-mount-fails-with-ac
+++ b/naughty/fedora-32/577-mount-fails-with-ac
@@ -1,1 +1,0 @@
-*mount point not mounted or bad option*


### PR DESCRIPTION
Known issue which has not occurred in 30 days

Mount cannot add `ac` option to nfs

Fixes #577