### PR TITLE
naughty: Close 576: tangd dumps core on Fedora 32 and RHEL 8.2

### DIFF
--- a/naughty/fedora-31/576-tangd-coredump
+++ b/naughty/fedora-31/576-tangd-coredump
@@ -1,3 +1,0 @@
-*testClevisTang*
-*
-*warning: Empty reply from server*

--- a/naughty/fedora-32/576-tangd-coredump
+++ b/naughty/fedora-32/576-tangd-coredump
@@ -1,3 +1,0 @@
-*testClevisTang*
-*
-*warning: Empty reply from server*

--- a/naughty/rhel-8/576-tangd-coredump
+++ b/naughty/rhel-8/576-tangd-coredump
@@ -1,3 +1,0 @@
-*testClevisTang*
-*
-*warning: Empty reply from server*


### PR DESCRIPTION
Known issue which has not occurred in 31 days

tangd dumps core on Fedora 32 and RHEL 8.2

Fixes #576