### PR TITLE
naughty: Close 575: No symlinks for RAID on Fedora 32

### DIFF
--- a/naughty/fedora-32/575-raid-symlink
+++ b/naughty/fedora-32/575-raid-symlink
@@ -1,1 +1,0 @@
-*Failed to get md node for array '*': Failed to read the symbolic link*


### PR DESCRIPTION
Known issue which has not occurred in 24 days

No symlinks for RAID on Fedora 32

Fixes #575