### PR TITLE
machine: Use unsafe caching on virtual disks

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -93,7 +93,7 @@ TEST_DOMAIN_XML = """
   </features>
   <devices>
     <disk type='file' snapshot='external'>
-      <driver name='qemu' type='qcow2'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
       <source file='{drive}'/>
       <target dev='vda' bus='{disk}'/>
       <serial>ROOT</serial>
@@ -119,7 +119,7 @@ TEST_DOMAIN_XML = """
 
 TEST_DISK_XML = """
 <disk type='file'>
-  <driver name='qemu' type='%(type)s'/>
+  <driver name='qemu' type='%(type)s' cache='unsafe' />
   <source file='%(file)s'/>
   <serial>%(serial)s</serial>
   <address type='drive' controller='0' bus='0' target='2' unit='%(unit)d'/>


### PR DESCRIPTION
This helps a bit on our busy e2e machines which sometimes have a really
bad disk I/O performance.

We don't care about image corruption when the host goes down -- image
creation will just be retried,  and for tests our images are ephemeral
anyway.