### PR TITLE
naughty: Close 622: check-machines-dbus TestMachinesDBus.testCreate fails on ubuntu-2004 in CI

### DIFF
--- a/naughty/ubuntu-2004/622-Machines-testCreate
+++ b/naughty/ubuntu-2004/622-Machines-testCreate
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/machineslib.py", line *, in testCreate
-    start_vm=True, delete=False))
-  File "test/verify/machineslib.py", line *, in createDownloadAnOSTest
-    dialog.open() \
-*
-subprocess.CalledProcessError: Command 'ps aux * returned non-zero exit status 1.


### PR DESCRIPTION
Known issue which has not occurred in 23 days

check-machines-dbus TestMachinesDBus.testCreate fails on ubuntu-2004 in CI

Fixes #622