### PR TITLE
naughty: Close 65: RHEL, CentOS, Fedora, Debian, Ubuntu: PCP libraries crash in __pmFindProfile()

### DIFF
--- a/naughty/debian-stable/65-pcp-pmfindprofile-crash
+++ b/naughty/debian-stable/65-pcp-pmfindprofile-crash
@@ -1,1 +1,0 @@
-/usr/*/cockpit-pcp: bridge was killed:

--- a/naughty/debian-testing/65-pcp-pmfindprofile-crash
+++ b/naughty/debian-testing/65-pcp-pmfindprofile-crash
@@ -1,1 +1,0 @@
-/usr/*/cockpit-pcp: bridge was killed:

--- a/naughty/rhel-7/65-pcp-pmfindprofile-crash
+++ b/naughty/rhel-7/65-pcp-pmfindprofile-crash
@@ -1,1 +1,0 @@
-/usr/*/cockpit-pcp: bridge was killed:

--- a/naughty/rhel-8/65-pcp-pmfindprofile-crash
+++ b/naughty/rhel-8/65-pcp-pmfindprofile-crash
@@ -1,1 +1,0 @@
-/usr/*/cockpit-pcp: bridge was killed:

--- a/naughty/ubuntu-stable/65-pcp-pmfindprofile-crash
+++ b/naughty/ubuntu-stable/65-pcp-pmfindprofile-crash
@@ -1,1 +1,0 @@
-/usr/*/cockpit-pcp: bridge was killed:


### PR DESCRIPTION
Known issue which has not occurred in 23 days

RHEL, CentOS, Fedora, Debian, Ubuntu: PCP libraries crash in __pmFindProfile()

Fixes #65