### PR TITLE
GitHub token improvements and cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ actions with the tests-trigger utility in this directory.
 
 ### Setup
 
-You need a GitHub token in ~/.config/github-token.  You can create one
-for your account at
+You need a GitHub token in ~/.config/github-token or from
+the [GitHub CLI](https://cli.github.com/) configuration in
+~/.config/gh/config.yml.  You can create one for your account at
 
     https://github.com/settings/tokens
 

--- a/image-upload
+++ b/image-upload
@@ -19,7 +19,6 @@
 
 import argparse
 import getpass
-import errno
 import os
 import socket
 import subprocess
@@ -29,9 +28,7 @@ import urllib.parse
 from machine.machine_core.constants import IMAGES_DIR
 from machine.machine_core.directories import BOTS_DIR, get_images_data_dir
 
-from task import PUBLIC_STORES, REDHAT_STORES
-
-TOKEN = "~/.config/github-token"
+from task import api, PUBLIC_STORES, REDHAT_STORES
 
 
 def upload(store, source):
@@ -53,15 +50,10 @@ def upload(store, source):
             sys.stderr.write("image-upload: unable to upload image: {0}\n".format(cmd[-1]))
         return ret
 
-    # Parse the user name and token, if present
-    user = url.username or getpass.getuser()
-    try:
-        with open(os.path.expanduser(TOKEN), "r") as gt:
-            token = gt.read().strip()
-        cmd += ["--user", user + ":" + token]
-    except IOError as exc:
-        if exc.errno == errno.ENOENT:
-            pass
+    # Pass credentials, if present
+    if api.token:
+        user = url.username or getpass.getuser()
+        cmd += ["--user", user + ":" + api.token]
 
     # First try to use the original store URL, for stores with valid SSL cert on an OpenShift proxy
     if try_curl(cmd + [store]) == 0:

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -54,8 +54,6 @@ sys.dont_write_bytecode = True
 # Servers which have public images
 PUBLIC_STORES = [
     "https://images-cockpit.apps.ci.centos.org/",
-    # instance in fedorainfracloud.org
-    "https://209.132.184.41:8493/",
 ]
 
 # Servers which have the private RHEL/Windows images

--- a/task/github.py
+++ b/task/github.py
@@ -129,14 +129,17 @@ class GitHub(object):
         self.token = None
         self.debug = False
         try:
-            gt = open(os.path.expanduser(TOKEN), "r")
-            self.token = gt.read().strip()
-            gt.close()
-        except IOError as exc:
-            if exc.errno == errno.ENOENT:
+            with open(os.path.expanduser(TOKEN), "r") as f:
+                self.token = f.read().strip()
+        except FileNotFoundError:
+            # fall back to GitHub's CLI token
+            try:
+                with open(os.path.expanduser("~/.config/gh/config.yml")) as f:
+                    match = re.search(r'oauth_token:\s*(\S+)', f.read())
+                if match:
+                    self.token = match.group(1)
+            except FileNotFoundError:
                 pass
-            else:
-                raise
 
         # The cache directory is $TEST_DATA/github ~/.cache/github
         if not cacher:

--- a/task/github.py
+++ b/task/github.py
@@ -137,7 +137,6 @@ class GitHub(object):
                 pass
             else:
                 raise
-        self.available = self.token and True or False
 
         # The cache directory is $TEST_DATA/github ~/.cache/github
         if not cacher:

--- a/tests-policy
+++ b/tests-policy
@@ -66,7 +66,7 @@ def main():
         if image and output:
             number = check_known_issue(api, output, image)
 
-        if number and api and api.available:
+        if number and api and api.token:
             try:
                 post_github(api, number, output, image)
             except (socket.error, RuntimeError):
@@ -396,7 +396,7 @@ def issue_comments(api, number):
 def post_github(api, number, output, image):
 
     # Ignore this if we were not given a token
-    if not api or not api.available:
+    if not api or not api.token:
         return
 
     context = "verify/{0}".format(image)


### PR DESCRIPTION
This does some code cleanup and adds a fallback to reading the token from GitHub CLI's config.

I tested it pretty carefully with image-upload and test-trigger with all token configs, but I'll do an image refresh just to be sure.

 * [x] image-refresh centos-7