### PR TITLE
images: Fix CirrOS image rebuild

### DIFF
--- a/images/cirros
+++ b/images/cirros
@@ -1,1 +1,1 @@
-cirros-d5fcb44e05f2dafc7eaab6bce906ba9cc06af51f84f1e7a527fe12102e34bbcf.qcow2
+cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2

--- a/images/scripts/cirros.bootstrap
+++ b/images/scripts/cirros.bootstrap
@@ -3,7 +3,7 @@ set -eux
 
 OUTPUT="$1"
 
-curl https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-i386-disk.img > "$OUTPUT"
+curl -L https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-i386-disk.img > "$OUTPUT"
 
 # prepare a cloud-init iso for disabling network source, to avoid a 90s timeout at boot
 WORKDIR=$(mktemp -d)


### PR DESCRIPTION
There are now some redirections in place; tell curl to follow them.

Also move to the current stable version.

 * [x] image-refresh cirros