### PR TITLE
naughty: libvirtd core dump affects RHEL 8 too

### DIFF
--- a/naughty/rhel-8/798-libvirtd-coredump
+++ b/naughty/rhel-8/798-libvirtd-coredump
@@ -1,0 +1,5 @@
+*testLibvirt*
+*
+Process * (libvirtd) of user 0 dumped core.
+*
+*virObjectUnref*


### PR DESCRIPTION
See issue #798

Example: https://logs.cockpit-project.org/logs/pull-14039-20200513-184145-f4bbaec5-rhel-8-2-distropkg/log.html