### PR TITLE
naughty: Close 68: abrtd doesn't report crash function on fedora 29 (with debuginfo installed)

### DIFF
--- a/naughty/fedora-31/68-abrtd-crash-fn
+++ b/naughty/fedora-31/68-abrtd-crash-fn
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-journal", line *, in testAbrtSegv
-    b.wait_visible(sel)
-*
-Error: timeout

--- a/naughty/fedora-31/68-abrtd-crash-fn-2
+++ b/naughty/fedora-31/68-abrtd-crash-fn-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-journal", line *, in testAbrtDelete
-    b.click(sel)
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 24 days

abrtd doesn't report crash function on fedora 29 (with debuginfo installed)

Fixes #68