### PR TITLE
naughty: Add more patterns for subscription-manager failure

### DIFF
--- a/naughty/rhel-7/773-rhsmd-import-error-2
+++ b/naughty/rhel-7/773-rhsmd-import-error-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-packagekit", line *, in testAvailableUpdates
+    b.wait_not_present(".container-fluid div.blank-slate-pf")
+*
+testlib.Error: timeout

--- a/naughty/rhel-7/773-rhsmd-import-error-3
+++ b/naughty/rhel-7/773-rhsmd-import-error-3
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-packagekit", line *, in testNoUpdates
+    b.wait_present(".content-header-extra button")
+*
+testlib.Error: timeout


### PR DESCRIPTION
With the pkg/lib/packagekit.js backports from [1], the tests pass the
System page notification checks again, but still fail on the
Subscriptions page (as that still uses the old and broken API).

Thus add two more patterns to represent that. The older patterns can be
removed after merging [1].

[1] https://github.com/cockpit-project/cockpit/pull/14113