### PR TITLE
naughty: Close 629: fedora-32 breaks kdump: Failed to open /usr/lib/systemd/system/kdump-error-handler.service: No such file or directory

### DIFF
--- a/naughty/fedora-31/629-kdump
+++ b/naughty/fedora-31/629-kdump
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    m.wait_boot(timeout_sec=300)
-*
-machine_core.exceptions.Failure: Unable to reach machine *

--- a/naughty/fedora-32/629-kdump
+++ b/naughty/fedora-32/629-kdump
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    m.wait_boot(timeout_sec=300)
-*
-machine_core.exceptions.Failure: Unable to reach machine *


### PR DESCRIPTION
Known issue which has not occurred in 26 days

fedora-32 breaks kdump: Failed to open /usr/lib/systemd/system/kdump-error-handler.service: No such file or directory

Fixes #629