### PR TITLE
image-create: Put VM image in /var/tmp/

### DIFF
--- a/image-create
+++ b/image-create
@@ -55,14 +55,11 @@ if args.image in ["continuous-atomic", "rhel-atomic", "fedora-coreos", "services
 
 class MachineBuilder:
     def __init__(self, machine):
-        tempdir = testvm.get_temp_dir()
         self.machine = machine
 
-        os.makedirs(tempdir, 0o750, exist_ok=True)
-
-        # Use a tmp filename
+        # Use /var/tmp/ as this is going to be a huge file; /tmp/ is commonly tmpfs
         self.target_file = self.machine.image_file
-        fp, self.machine.image_file = tempfile.mkstemp(dir=tempdir, prefix=self.machine.image, suffix=".qcow2")
+        fp, self.machine.image_file = tempfile.mkstemp(dir="/var/tmp/", prefix=self.machine.image, suffix=".qcow2")
         os.close(fp)
 
     def bootstrap_system(self):

--- a/images/continuous-atomic
+++ b/images/continuous-atomic
@@ -1,1 +1,1 @@
-continuous-atomic-0ff5d3c0b049769bbd0f35749f8a006abb10dbf279f9900cd2b15c7d75e38243.qcow2
+continuous-atomic-0798cc1108bd9d35980c50507b7aac5588dc557d9e90ecc16e41783edc23e4ee.qcow2


### PR DESCRIPTION
At least in our CI, testvm.get_temp_dir() points to a tmpfs file, so
that tests can put VM overlays into RAM and are not affected by slow
I/O. But that doesn't work for image-create, as that's the entire image,
not just the overlay. This often caused the VM to crash due to ENOFS,
particularly during the "fill disk with zeros" phase.

Use /var/tmp/ instead, which is meant for large files.

----

This should fix the large set of failed image builds. I'll trigger one image here as an example, then we can retry the others after landing this.

 * [x] image-refresh continuous-atomic