### PR TITLE
testmap: Add rhel-8-3-distropkg test

### DIFF
--- a/images/scripts/rhel-8-3-distropkg.install
+++ b/images/scripts/rhel-8-3-distropkg.install
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+set -e
+
+/var/lib/testvm/fedora.install --rhel "$@"

--- a/task/testmap.py
+++ b/task/testmap.py
@@ -39,8 +39,8 @@ REPO_BRANCH_CONTEXT = {
             'fedora-coreos',
             'fedora-31/firefox',
             'rhel-8-2',
-            'rhel-8-3',
             'rhel-8-2-distropkg',
+            'rhel-8-3',
             'centos-8-stream',
         ],
         'rhel-7.9': [
@@ -55,6 +55,7 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-testing',
+            'rhel-8-3-distropkg',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
It's time to move to rhel-8-3 as the primary RHEL 8 image.

Declare it as manual test for now, until cockpit's tests get adjusted
for this new context.