### PR TITLE
testmap: Drop cockpit rhel-8-2 tests, enable rhel-8-3-distropkg

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -38,9 +38,8 @@ REPO_BRANCH_CONTEXT = {
             'fedora-32',
             'fedora-coreos',
             'fedora-31/firefox',
-            'rhel-8-2',
-            'rhel-8-2-distropkg',
             'rhel-8-3',
+            'rhel-8-3-distropkg',
             'centos-8-stream',
         ],
         'rhel-7.9': [
@@ -199,7 +198,7 @@ IMAGE_REFRESH_TRIGGERS = {
         "fedora-31/selenium-chrome@cockpit-project/cockpit",
         "ubuntu-2004@cockpit-project/cockpit",
         "debian-stable@cockpit-project/cockpit",
-        "rhel-8-2@cockpit-project/cockpit",
+        "rhel-8-3@cockpit-project/cockpit",
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",
         "fedora-31/firefox@osbuild/cockpit-composer",
     ]


### PR DESCRIPTION
We'll not change anything in 8.2 any more, let's focus on 8.3 now.

 - [x] Fix cockpit rhel-8-3-distropkg tests: https://github.com/cockpit-project/cockpit/pull/14178