### PR TITLE
Eliminate $TEST_DATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,12 @@ then please [allow][1] `qemu-bridge-helper` to access the bridge settings.
 
 ## Image location
 
-Downloaded images are stored into ./images/ by default. This is often
-impractical as you cannot easily clean your tree without losing them, nor can
-they be easily put into a separate container volume.
-
-You can set the `cockpit.bots.images-data-dir` variable with
-`git config` to a directory where to store the pristine virtual machine images.
-For example:
+Downloaded images are stored into ~/.cache/cockpit-images/ by default. If you
+want to change that, you can set the `cockpit.bots.images-data-dir` variable
+with `git config` to a directory where to store the pristine virtual machine
+images.  For example:
 
     $ git config cockpit.bots.images-data-dir /srv/cockpit/images
-
-Alternatively, you can set the `$TEST_DATA` environment variable, then images
-will be put into `$TEST_DATA/images/`. However, this is deprecated and will go
-away soon.
 
 ## Tests
 

--- a/example-task
+++ b/example-task
@@ -29,7 +29,7 @@ sys.dont_write_bytecode = True
 
 import task
 
-# from machine.machine_core.directories import BOTS_DIR, BASE_DIR
+# from machine.machine_core.constants import BOTS_DIR, BASE_DIR
 
 
 def run(argument, verbose=False, **kwargs):

--- a/flakes-refresh
+++ b/flakes-refresh
@@ -29,7 +29,7 @@ sys.dont_write_bytecode = True
 
 import task
 
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 NUMBER_OPEN_ISSUES = 7            # How many issues do we want to have open at a given time?
 

--- a/image-create
+++ b/image-create
@@ -30,7 +30,7 @@ import sys
 import time
 import tempfile
 
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 from machine import testvm
 

--- a/image-refresh
+++ b/image-refresh
@@ -24,7 +24,7 @@ import sys
 import task
 from task import github, testmap
 
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 
 sys.dont_write_bytecode = True

--- a/image-upload
+++ b/image-upload
@@ -25,8 +25,8 @@ import subprocess
 import sys
 import urllib.parse
 
-from machine.machine_core.constants import IMAGES_DIR
-from machine.machine_core.directories import BOTS_DIR, get_images_data_dir
+from machine.machine_core.constants import BOTS_DIR, IMAGES_DIR
+from machine.machine_core.directories import get_images_data_dir
 
 from task import api, PUBLIC_STORES, REDHAT_STORES
 

--- a/learn-tests
+++ b/learn-tests
@@ -38,7 +38,7 @@ sys.dont_write_bytecode = True
 import task
 
 from machine import testvm
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 
 def run(url_or_file, verbose=False, dry=False, **kwargs):

--- a/machine/machine_core/directories.py
+++ b/machine/machine_core/directories.py
@@ -18,7 +18,7 @@
 import os
 import subprocess
 
-from .constants import BOTS_DIR, BASE_DIR, GIT_DIR
+from .constants import GIT_DIR
 
 _images_data_dir = None
 _temp_dir = None
@@ -44,16 +44,7 @@ def get_images_data_dir():
         _images_data_dir = get_git_config('--type=path', 'cockpit.bots.images-data-dir')
 
         if _images_data_dir is None:
-            _images_data_dir = os.path.join(os.environ.get("TEST_DATA", BOTS_DIR), "images")
+            _images_data_dir = os.path.join(os.getenv('XDG_CACHE_HOME', os.path.expanduser("~/.cache")),
+                                            "cockpit-images")
 
     return _images_data_dir
-
-
-def get_temp_dir():
-    global _temp_dir
-
-    if _temp_dir is None:
-        _temp_dir = os.path.join(os.environ.get("TEST_DATA", BASE_DIR), "tmp")
-        os.makedirs(_temp_dir, exist_ok=True)
-
-    return _temp_dir

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -30,7 +30,6 @@ import time
 from .exceptions import Failure, RepeatableFailure
 from .machine import Machine
 from .constants import TEST_DIR, BOTS_DIR
-from .directories import get_temp_dir
 
 sys.path.insert(1, BOTS_DIR)
 
@@ -319,7 +318,7 @@ class VirtMachine(Machine):
 
         Machine.__init__(self, image=image, **args)
 
-        self.run_dir = overlay_dir or os.path.join(get_temp_dir(), "run")
+        self.run_dir = overlay_dir or os.getenv("TEST_OVERLAY_DIR", "tmp/run")
 
         self.virt_connection = self._libvirt_connection(hypervisor="qemu:///session")
 

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -23,10 +23,10 @@ import subprocess
 import select
 import errno
 import sys
+import tempfile
 
 from . import exceptions
 from . import timeout as timeoutlib
-from .directories import get_temp_dir
 
 
 class SSHConnection(object):
@@ -135,7 +135,8 @@ class SSHConnection(object):
     def _start_ssh_master(self):
         self._kill_ssh_master()
 
-        control = os.path.join(get_temp_dir(), "ssh-%h-%p-%r-" + str(os.getpid()))
+        control = os.path.join(tempfile.gettempdir(), ".cockpit-test-resources", "ssh-%h-%p-%r-" + str(os.getpid()))
+        os.makedirs(os.path.dirname(control), exist_ok=True)
 
         cmd = [
             "ssh",

--- a/machine/testvm.py
+++ b/machine/testvm.py
@@ -29,7 +29,7 @@ from machine_core.timeout import Timeout
 from machine_core.machine import Machine
 from machine_core.exceptions import Failure, RepeatableFailure
 from machine_core.machine_virtual import VirtMachine, VirtNetwork
-from machine_core.constants import BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
+from machine_core.constants import BASE_DIR, BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
 from machine_core.cli import cmd_cli
 from machine_core.directories import get_images_data_dir, get_temp_dir
 from task.testmap import get_build_image, get_test_image

--- a/machine/testvm.py
+++ b/machine/testvm.py
@@ -19,6 +19,7 @@
 
 import os
 import sys
+import warnings
 
 # ensure that this module path is present
 machine_dir = os.path.dirname(os.path.realpath(__file__))
@@ -31,8 +32,25 @@ from machine_core.exceptions import Failure, RepeatableFailure
 from machine_core.machine_virtual import VirtMachine, VirtNetwork
 from machine_core.constants import BASE_DIR, BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
 from machine_core.cli import cmd_cli
-from machine_core.directories import get_images_data_dir, get_temp_dir
+from machine_core.directories import get_images_data_dir
 from task.testmap import get_build_image, get_test_image
+
+
+_temp_dir = None
+
+
+# FIXME: Only consumer is cockpit's image-prepare; https://github.com/cockpit-project/cockpit/pull/14190
+def get_temp_dir():
+    warnings.warn("get_temp_dir() is obsolete", PendingDeprecationWarning)
+
+    global _temp_dir
+
+    if _temp_dir is None:
+        _temp_dir = os.path.join(BASE_DIR, "tmp")
+        os.makedirs(_temp_dir, exist_ok=True)
+
+    return _temp_dir
+
 
 __all__ = [
     Timeout, Machine, Failure, RepeatableFailure, VirtMachine,

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -31,7 +31,7 @@ import urllib.parse
 
 from . import github
 from . import sink
-from machine.machine_core.directories import BASE_DIR
+from machine.machine_core.constants import BASE_DIR
 
 
 __all__ = (

--- a/task/github.py
+++ b/task/github.py
@@ -143,7 +143,8 @@ class GitHub(object):
 
         # default cache directory
         if not cacher:
-            cacher = cache.Cache(os.path.expanduser("~/.cache/github"))
+            cacher = cache.Cache(os.path.join(os.getenv('XDG_CACHE_HOME', os.path.expanduser("~/.cache")), "github"))
+
         self.cache = cacher
 
         # Create a log for debugging our GitHub access

--- a/task/github.py
+++ b/task/github.py
@@ -141,10 +141,9 @@ class GitHub(object):
             except FileNotFoundError:
                 pass
 
-        # The cache directory is $TEST_DATA/github ~/.cache/github
+        # default cache directory
         if not cacher:
-            data = os.environ.get("TEST_DATA", os.path.expanduser("~/.cache"))
-            cacher = cache.Cache(os.path.join(data, "github"))
+            cacher = cache.Cache(os.path.expanduser("~/.cache/github"))
         self.cache = cacher
 
         # Create a log for debugging our GitHub access

--- a/task/test-policy
+++ b/task/test-policy
@@ -25,7 +25,7 @@ import unittest
 BASE = os.path.dirname(__file__)
 sys.path.insert(1, os.path.join(BASE, ".."))
 
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 
 PCP_CRASH = """

--- a/tests-data
+++ b/tests-data
@@ -40,7 +40,7 @@ sys.dont_write_bytecode = True
 import task
 
 from machine import testvm
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 
 # The number of days of previous closed pull requests to learn from

--- a/tests-policy
+++ b/tests-policy
@@ -35,7 +35,7 @@ sys.dont_write_bytecode = True
 FLAKE_THRESHOLD = 0.4
 
 from task import github
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 from task.testmap import get_test_image
 
 

--- a/tests-score
+++ b/tests-score
@@ -27,7 +27,7 @@ import urllib
 sys.dont_write_bytecode = True
 
 import task
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 
 # This parses the output JSONL format discussed here, where various

--- a/vm-run
+++ b/vm-run
@@ -24,7 +24,7 @@ import subprocess
 import sys
 
 from machine import testvm
-from machine.machine_core.directories import BOTS_DIR
+from machine.machine_core.constants import BOTS_DIR
 
 NETWORK_SCRIPT = b"""
     set -ex


### PR DESCRIPTION
This variable influenced too many files which don't belong together.
Replace its usage with more sensible defaults and better storage
behaviour:

 * Downloaded images: These are precious as a local developer, so put
   them into the XDG cache dir by default: ~/.cache/cockpit-images/.
   With that, there is no configuration needed, and one can clean git
   trees, have multiple checkouts etc. without problems. The path can
   still be changed with either a symlink or the
   cockpit.bots/images-data-dir git config.

   In CI the images are usually on a persistent external volume.
   ~/.cache/cockpit-images now *only* contains images, so it's easier to
   set up the volume without putting a lot of irrelevant crap into it
   (such as overlays, built rpms, lock files, etc.)

 * Ephemeral VM overlays: These should never be put into a container
   volume, and they should be on lightning fast storage (ideally, on
   tmpfs). By default, put them into tmp/run/ to keep the current
   behaviour (without `$TEST_DATA`), but allow bots to change the
   location with `$TEST_OVERLAY_DIR`.

 * GitHub cache: This is safe to share with other bots, but they are not
   particularly precious nor big. So we don't need to special-case them
   for CI. Keep them in ~/.cache/github/, there's no need to override
   that.

 * SSH master control sockets: These must *never ever* be shared with
   other bots. Put them into /tmp/.cockpit-test-resources/, where
   the image/port lock files already live.

Eliminate the usage of get_temp_dir(). It's too unspecific and can't fit
all the diverging use cases above. Still keep a backwards compatible
shim until cockpit drops its usage in all of its branches (see
https://github.com/cockpit-project/cockpit/pull/14190).

----

This can't yet land for CI, but it does work fine locally, so I'm interested in
some feedback.

 - [x] Adjust cockpituous and cockpit/tasks container for ~/.cache/cockpit-images and `$TEST_OVERLAY_DIR`: https://github.com/cockpit-project/cockpituous/pull/329
 - [x] [Announce the change to cockpit-devel](https://lists.fedorahosted.org/archives/list/cockpit-devel@lists.fedorahosted.org/thread/FETLZZHRNMJKZYCKLDUIINXCK4X5ZUSU/)