### PR TITLE
naughty: Drop exact line number from 897 pattern

### DIFF
--- a/naughty/fedora-31/897-sssd-ad-auth-2
+++ b/naughty/fedora-31/897-sssd-ad-auth-2
@@ -1,5 +1,5 @@
 Traceback (most recent call last):
-  File "test/verify/check-realms", line 273, in testUnqualifiedUsers
+  File "test/verify/check-realms", line *, in testUnqualifiedUsers
     self.login_and_go("/system", user=self.admin_user)
 *
 RuntimeError: timed out waiting for page load

--- a/naughty/fedora-32/897-sssd-ad-auth-2
+++ b/naughty/fedora-32/897-sssd-ad-auth-2
@@ -1,5 +1,5 @@
 Traceback (most recent call last):
-  File "test/verify/check-realms", line 273, in testUnqualifiedUsers
+  File "test/verify/check-realms", line *, in testUnqualifiedUsers
     self.login_and_go("/system", user=self.admin_user)
 *
 RuntimeError: timed out waiting for page load


### PR DESCRIPTION
The test often changes, and then this won't match any more.