### PR TITLE
testmap: Use fedora-32 to build rpms for fedora-coreos

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -179,7 +179,7 @@ REPO_BRANCH_CONTEXT = {
 # The OSTree variants can't build their own packages, so we build in
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
-    "fedora-coreos": "fedora-31",
+    "fedora-coreos": "fedora-32",
     "rhel-atomic": "rhel-7-8",
     "continuous-atomic": "centos-7",
 }


### PR DESCRIPTION
Current Fedora CoreOS images are Fedora 32 based.