### PR TITLE
naughty: Add pattern for kernel oops on fedora-coreos

### DIFF
--- a/naughty/fedora-coreos/948-ip_finish_output-oops
+++ b/naughty/fedora-coreos/948-ip_finish_output-oops
@@ -1,0 +1,2 @@
+Traceback (most recent call last):
+  File "test/verify/check-system-info", line *, in testBasic


### PR DESCRIPTION
Some sshd operation in TestSystemInfo.testBasic causes a kernel oops on
Fedora CoreOS 32. It's not predictable which exact check fails, so just
match on any failure in that particular test for now.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1844318
Known issue #948