### PR TITLE
Fix BOTS_DIR imports harder

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -23,7 +23,7 @@ import shutil
 import subprocess
 import sys
 from task import github
-from machine.machine_core.directories import BASE_DIR
+from machine.machine_core.constants import BASE_DIR
 
 sys.dont_write_bytecode = True
 

--- a/naughty-prune
+++ b/naughty-prune
@@ -29,7 +29,7 @@ import time
 sys.dont_write_bytecode = True
 
 import task
-from machine.machine_core.directories import BASE_DIR
+from machine.machine_core.constants import BASE_DIR
 
 # Number of days after which a known issue is treated as stale
 DAYS = 21

--- a/npm-update
+++ b/npm-update
@@ -44,7 +44,7 @@ import subprocess
 sys.dont_write_bytecode = True
 
 import task
-from machine.machine_core.directories import BASE_DIR
+from machine.machine_core.constants import BASE_DIR
 
 
 def package_json(data=None, package=None, version=None):

--- a/po-refresh
+++ b/po-refresh
@@ -26,7 +26,7 @@ import sys
 sys.dont_write_bytecode = True
 
 import task
-from machine.machine_core.directories import BASE_DIR
+from machine.machine_core.constants import BASE_DIR
 
 
 def run(context, verbose=False, **kwargs):

--- a/tests-invoke
+++ b/tests-invoke
@@ -24,7 +24,7 @@ import sys
 import time
 
 from task import github
-from machine.machine_core.directories import BASE_DIR
+from machine.machine_core.constants import BASE_DIR
 
 sys.dont_write_bytecode = True
 


### PR DESCRIPTION
Commit 8a96eba0c50f did not catch all of it.

---

This didn't actually break most scripts, but it did break make-checkout really hard: https://logs.cockpit-project.org/logs/pull-950-20200605-080349-8c850103-fedora-32-cockpit-project-cockpit/log.html