### PR TITLE
testmap: Add rhel-8-3 into cockpit-composer test scenario and remove fedora-31/firefox

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -138,9 +138,10 @@ REPO_BRANCH_CONTEXT = {
     'osbuild/cockpit-composer': {
         'master': [
             'fedora-31',
-            'fedora-31/firefox',
             'fedora-32',
             'fedora-32/firefox',
+            'rhel-8-3',
+            'rhel-8-3/firefox',
         ],
         'rhel-8': [
             'rhel-8-2/chrome',
@@ -152,10 +153,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'rhel-8-3',
-            'rhel-8-3/chrome',
-            'rhel-8-3/firefox',
-            'rhel-8-3/edge',
         ],
     },
     'candlepin/subscription-manager': {


### PR DESCRIPTION
`rhel-8-3` and `rhel-8-3/firefox` test passed in [PR #991](https://github.com/osbuild/cockpit-composer/pull/991)