### PR TITLE
testmap: Drop RHEL 7 contexts from cockpit-composer RHEL 8 branch

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -147,9 +147,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-2/chrome',
             'rhel-8-2/firefox',
             'rhel-8-2/edge',
-            'rhel-7-8/firefox',
-            'rhel-7-8/chrome',
-            'rhel-7-8/edge',
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [


### PR DESCRIPTION
These don't work any more due to incompatible rpm format, and
structurally don't make sense anyway.