### PR TITLE
testmap: Build rhel-atomic rpms on rhel-7-9

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -175,7 +175,7 @@ REPO_BRANCH_CONTEXT = {
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
     "fedora-coreos": "fedora-32",
-    "rhel-atomic": "rhel-7-8",
+    "rhel-atomic": "rhel-7-9",
     "continuous-atomic": "centos-7",
 }
 


### PR DESCRIPTION
This makes sure that it works with the next stable release. This is also
the last remaining consumer of the rhel-7-8 image.