### PR TITLE
testmap: Move subscription-manager to rhel-8-3

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -154,11 +154,8 @@ REPO_BRANCH_CONTEXT = {
     },
     'candlepin/subscription-manager': {
         'master': [
-            'rhel-8-2',
-        ],
-        '_manual': [
             'rhel-8-3',
-        ]
+        ],
     },
     'skobyda/cockpit-certificates': {
         'master': [


### PR DESCRIPTION
I triggered an initial test in https://github.com/candlepin/subscription-manager/pull/2274 . Once that works, I'll trigger it here, too.