### PR TITLE
task: Stop testing starter-kit on centos-7

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -59,7 +59,6 @@ REPO_BRANCH_CONTEXT = {
     },
     'cockpit-project/starter-kit': {
         'master': [
-            'centos-7',
             'fedora-32',
             'centos-8-stream',
         ],


### PR DESCRIPTION
RPMs built on Fedora 32 do not work any more in CentOS 7 due to changed
RPM binary format (zstd compression).

starter-kit is already tested on CentOS 8, which is enough.