### PR TITLE
naughty: Close 904: boot failure with fips=1: endless loop of Core dump to |/bin/false pipe failed

### DIFF
--- a/naughty/rhel-8/904-fips-boot-failure
+++ b/naughty/rhel-8/904-fips-boot-failure
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line *, in testFIPS
-    self.machine.wait_reboot()
-*
-* Timeout waiting for system to reboot properly


### PR DESCRIPTION
Known issue which has not occurred in 21 days

boot failure with fips=1: endless loop of Core dump to |/bin/false pipe failed

Fixes #904