### PR TITLE
naughty: Close 338: RHEL 8.2 regression: virt-what crashes

### DIFF
--- a/naughty/rhel-8/338-tuned-no-virt-what
+++ b/naughty/rhel-8/338-tuned-no-virt-what
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-tuned", line *, in testBasic
-    b.wait_text('#system-info-performance .action-trigger', recommended_profile)
-*
-testlib.Error: timeout
-wait_js_cond(ph_text_is("#system-info-performance .action-trigger","virtual-guest"))*


### PR DESCRIPTION
Known issue which has not occurred in 28 days

RHEL 8.2 regression: virt-what crashes

Fixes #338