### PR TITLE
Generate page with graphs for the most common test failures

### DIFF
--- a/failure-stats.html
+++ b/failure-stats.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<meta charset="utf8" />
+<html>
+  <script type="text/javascript" src="failure-stats.js"></script>
+  <style>
+    body {
+        display: grid;
+        grid-template-columns: auto auto;
+    }
+    body > div {
+        margin: 10px;
+    }
+    table {
+        width: 100%;
+    }
+    tr:nth-child(even) {
+        background-color: #f2f2f2;
+    }
+    th, td {
+        padding: 10px;
+        text-align: left;
+    }
+    a:first-child {
+        padding-right: 10px;
+    }
+  </style>
+  <body>
+  </body>
+  <script type="text/javascript">
+    const body = document.querySelector("body");
+    tables.forEach(t => {
+        const wrapper = document.createElement("DIV");
+
+        // Create title of the table
+        const title = document.createElement("H2");
+        title.textContent = t.name;
+        wrapper.appendChild(title);
+
+        // Create table itself
+        const table = document.createElement("TABLE");
+
+        // Create heading
+        let row = document.createElement("TR");
+        t.columns.forEach(c => {
+            const th = document.createElement("TH");
+            th.textContent = c;
+            row.appendChild(th);
+        });
+        table.appendChild(row);
+
+        // Fill the table with data
+        t.data.forEach(r => {
+            row = document.createElement("TR");
+            r.forEach(d => {
+                // Array with logs
+                const td = document.createElement("TD");
+                if (typeof d === "object")
+                    d.forEach(a => {
+                        const ea = document.createElement("A");
+                        ea.textContent = "log";
+                        ea.href = a;
+                        td.appendChild(ea);
+                    });
+                else
+                    td.textContent = d;
+                row.appendChild(td);
+            });
+            table.appendChild(row);
+        });
+
+        wrapper.appendChild(table);
+        body.appendChild(wrapper);
+    });
+  </script>
+</html>

--- a/generate-stats
+++ b/generate-stats
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import time
+import sqlite3
+import argparse
+import logging
+import json
+
+# Seconds in two weeks
+TWO_WEEKS = 1209600
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate statistics about failed tests')
+    parser.add_argument("--db", default="cockpit-failures.db", help="Database name")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    opts = parser.parse_args()
+
+    if opts.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    db_conn = sqlite3.connect(opts.db)
+    cursor = db_conn.cursor()
+
+    all_tables = []
+    since = time.time() - TWO_WEEKS
+
+    # Get all failures sorted by number of occurrences
+    top10 = []
+    rows = cursor.execute("""\
+            SELECT testname, COUNT(run)
+            FROM Failures
+            JOIN TestRuns ON Failures.run = TestRuns.id
+            WHERE TestRuns.time > ?
+            GROUP BY testname
+            ORDER BY COUNT(run) DESC
+            LIMIT 10;""", (since, )).fetchall()
+    for row in rows:
+        urls = cursor.execute("""\
+                SELECT DISTINCT TestRuns.url
+                FROM TestRuns JOIN Failures ON TestRuns.id = Failures.run
+                WHERE testname = ?
+                ORDER BY run DESC
+                LIMIT 2;""", (row[0], )).fetchall()
+        links = [urls[0][0]] if len(urls) > 0 else []
+        if len(urls) > 1:
+            links.append(urls[1][0])
+        top10.append([row[0], row[1], links])
+
+    all_tables.append({"name": "Top failures", "columns": ["Test name", "Count", "Logs"], "data": top10})
+
+    # Get failures by OS
+    contexts = cursor.execute("SELECT DISTINCT context FROM TestRuns;").fetchall()
+    for context in contexts:
+        # For each OS get top 10 failures
+        context = context[0]
+        top10 = []
+        rows = cursor.execute("""\
+                SELECT testname, COUNT(run)
+                FROM Failures
+                JOIN TestRuns ON Failures.run = TestRuns.id
+                WHERE TestRuns.context = ? AND TestRuns.time > ?
+                GROUP BY testname
+                ORDER BY COUNT(run) DESC
+                LIMIT 10;""", (context, since,)).fetchall()
+        for row in rows:
+            urls = cursor.execute("""\
+                    SELECT DISTINCT TestRuns.url
+                    FROM TestRuns JOIN Failures ON TestRuns.id = Failures.run
+                    WHERE testname = ? and context = ?
+                    ORDER BY run DESC
+                    LIMIT 2;""", (row[0], context,)).fetchall()
+            links = [urls[0][0]] if len(urls) > 0 else []
+            if len(urls) > 1:
+                links.append(urls[1][0])
+            top10.append([row[0], row[1], links])
+
+        all_tables.append({"name": "Top failures for " + context,
+                           "columns": ["Test name", "Count", "Logs"],
+                           "data": top10})
+
+    # Sort tables
+    all_tables = sorted(all_tables, key=lambda x: x["data"][0][1], reverse=True)
+
+    print("const tables = {0};".format(json.dumps(all_tables)))
+
+    db_conn.close()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/issues-review
+++ b/issues-review
@@ -56,8 +56,8 @@ def close_issues(api, opts):
         count = len(issues)
         for issue in issues:
             labels = api.get("issues/%i/labels" % issue["number"])
-            enhancement = [l for l in labels if l["name"] == "enhancement"]
-            bug = [l for l in labels if l["name"] == "bug"]
+            enhancement = [la for la in labels if la["name"] == "enhancement"]
+            bug = [la for la in labels if la["name"] == "bug"]
             if bug:
                 print("Closing #%i as stale bug" % issue["number"])
                 api.post("issues/%i/comments" % issue["number"], {"body": bug_msg})

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -263,7 +263,7 @@ class SSHConnection(object):
         elif environment == {}:
             pass
         else:
-            raise Exception("enviroment support dict or list items given: ".format(environment))
+            raise Exception("enviroment support dict or list items given: {0}".format(environment))
         default_ssh_params = [
             "ssh",
             "-p", str(self.ssh_port),

--- a/run-queue
+++ b/run-queue
@@ -64,9 +64,11 @@ def consume_webhook_queue(channel, amqp):
         elif action == 'closed' and pull_request.get('merged', False):
             sha = pull_request['head']['sha']
             db = os.path.join(get_images_data_dir(), "test-failures.db")
-            cmd = ['./store-failures', "--db", db, "--repo", repo, sha]
+            data = os.path.join(get_images_data_dir(), "failure-stats.js")
+            cmd = "./store-failures --db {0} --repo {1} {2} && ./generate-stats --db {0} > {3}".format(
+                db, repo, sha, data)
             body = {
-                "command": " ".join(cmd),
+                "command": cmd,
             }
             channel.basic_publish('', 'statistics', json.dumps(body),
                                   properties=pika.BasicProperties(priority=distributed_queue.MAX_PRIORITY))


### PR DESCRIPTION
This is just a rough draft to show the direction. @martinpitt WDYT of this concept?

The script for generating would be probably part of `store-failures` or at least would call it.

It is just tables for now. For some timeline graphs we would need time information which we don't store in DB. We could have some pie charts or so. Up for discussion.
Surely I want to give it a bit of css love.

How to run:
`./generate-stats --db test-failures.db > data.js`
`firefox index.html`