### PR TITLE
images: Fix enabling SSH password authentication for current Fedora CoreOS

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-f2a7bfeaa389d65a9db9678d4acc3bf6d49eebd48367031db3cc5d54cd5a9380.qcow2
+fedora-coreos-1fee8574599538c0ae7b795a542bace397c28842cfacac8c122de4f7942dd3dc.qcow2

--- a/images/scripts/fedora-coreos.setup
+++ b/images/scripts/fedora-coreos.setup
@@ -9,10 +9,6 @@ podman pull docker.io/cockpit/ws
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config.d/10-no-usedns.conf
 
-# HACK: Enable ssh password authentication; see https://github.com/coreos/fedora-coreos-tracker/issues/138
-# Move this to Ignition once a knob exists
-rm -f /etc/ssh/sshd_config.d/04-disable-passwords.conf
-
 # pre-install the distro version, which is useful for testing extensions and manual experiments
 # also pre-install dnsmasq which we need for testing
 rpm-ostree install cockpit-system cockpit-bridge cockpit-networkmanager dnsmasq

--- a/images/scripts/lib/cockpit-ci.fcc
+++ b/images/scripts/lib/cockpit-ci.fcc
@@ -2,7 +2,7 @@
 # Download compiler from https://github.com/coreos/fcct/releases
 # Build with fcct-x86_64-unknown-linux-gnu --pretty --output images/scripts/lib/cockpit-ci.ign images/scripts/lib/cockpit-ci.fcc
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: admin
@@ -20,6 +20,16 @@ passwd:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUOtNJdBEXyKxBB898rdT54ULjMGuO6v4jLXmRsdRhR5Id/lKNc9hsdioPWUePgYlqML2iSV72vKQoVhkyYkpcsjr3zvBny9+5xej3+TBLoEMAm2hmllKPmxYJDU8jQJ7wJuRrOVOnk0iSNF+FcY/yaQ0owSF02Nphx47j2KWc0IjGGlt4fl0fmHJuZBA2afN/4IYIIsEWZziDewVtaEjWV3InMRLllfdqGMllhFR+ed2hQz9PN2QcapmEvUR4UCy/mJXrke5htyFyHi8ECfyMMyYeHwbWLFQIve4CWix9qtksvKjcetnxT+WWrutdr3c9cfIj/c0v/Zg/c4zETxtp cockpit-test
 storage:
   files:
+    # enable ssh password authentication
+    # https://docs.fedoraproject.org/en-US/fedora-coreos/authentication/#_enabling_ssh_password_authentication
+    - path: /etc/ssh/sshd_config.d/02-enable-passwords.conf
+      mode: 0644
+      contents:
+        inline: |
+          # Fedora CoreOS disables SSH password login by default.
+          # Enable it.
+          # This file must sort before 04-disable-passwords.conf.
+          PasswordAuthentication yes
     # don't hang/fail on non-existing DHCP on eth1 on boot
     # similar to images/scripts/network-ifcfg-eth1 for Fedora/RHEL images
     - path: /etc/NetworkManager/system-connections/eth1.nmconnection

--- a/images/scripts/lib/cockpit-ci.ign
+++ b/images/scripts/lib/cockpit-ci.ign
@@ -1,16 +1,6 @@
 {
   "ignition": {
-    "config": {
-      "replace": {
-        "source": null,
-        "verification": {}
-      }
-    },
-    "security": {
-      "tls": {}
-    },
-    "timeouts": {},
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "passwd": {
     "users": [
@@ -37,12 +27,16 @@
   "storage": {
     "files": [
       {
-        "group": {},
-        "path": "/etc/NetworkManager/system-connections/eth1.nmconnection",
-        "user": {},
+        "path": "/etc/ssh/sshd_config.d/02-enable-passwords.conf",
         "contents": {
-          "source": "data:,%5Bconnection%5D%0Aid%3Deth1%0Atype%3Dethernet%0Ainterface-name%3Deth1%0A%0A%5Bipv4%5D%0Amethod%3Ddisabled%0A%0A%5Bipv6%5D%0Amethod%3Dignore%0A",
-          "verification": {}
+          "source": "data:,%23%20Fedora%20CoreOS%20disables%20SSH%20password%20login%20by%20default.%0A%23%20Enable%20it.%0A%23%20This%20file%20must%20sort%20before%2004-disable-passwords.conf.%0APasswordAuthentication%20yes%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/NetworkManager/system-connections/eth1.nmconnection",
+        "contents": {
+          "source": "data:,%5Bconnection%5D%0Aid%3Deth1%0Atype%3Dethernet%0Ainterface-name%3Deth1%0A%0A%5Bipv4%5D%0Amethod%3Ddisabled%0A%0A%5Bipv6%5D%0Amethod%3Dignore%0A"
         },
         "mode": 384
       }


### PR DESCRIPTION
The default disabling file got renamed to 40-disable-passwords.conf.
Replace this with the new official recipe from the documentation.

Fixes #1046

 * [x] image-refresh fedora-coreos
 * [x] adjust check-login tests: https://github.com/cockpit-project/cockpit/pull/14331