### PR TITLE
testmap: Move rhel-8.3 to manual for c-podman

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -79,9 +79,9 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'fedora-31',
             'fedora-32',
-            'rhel-8-3',
         ],
         '_manual': [
+            'rhel-8-3',
             'centos-8-stream',
         ],
     },


### PR DESCRIPTION
We are switching to a new API and this change won't reach 8.3.