### PR TITLE
naughty: Close 63: rpm-ostreed: DownloadUpdateRpmDiff leaves CachedUpdate property empty

### DIFF
--- a/naughty/continuous-atomic/63-cached-update-stays-empty-1
+++ b/naughty/continuous-atomic/63-cached-update-stays-empty-1
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./test/verify/check-ostree", line *, in testRemoteManagement
-    b.wait_text('table.listing-ct tbody:nth-child(3) div.listing-ct-head h3', name + " bad-version")

--- a/naughty/continuous-atomic/63-cached-update-stays-empty-2
+++ b/naughty/continuous-atomic/63-cached-update-stays-empty-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "./test/verify/check-ostree", line *, in testOstree
-    b.wait_present('table.listing-ct tbody:nth-child(3) i.fa-circle')


### PR DESCRIPTION
Known issue which has not occurred in 26 days

rpm-ostreed: DownloadUpdateRpmDiff leaves CachedUpdate property empty

Fixes #63