### PR TITLE
test-failures: Only select contexts for last two weeks

### DIFF
--- a/generate-stats
+++ b/generate-stats
@@ -68,7 +68,7 @@ def main():
     all_tables.append({"name": "Top failures", "columns": ["Test name", "Count", "Logs"], "data": top10})
 
     # Get failures by OS
-    contexts = cursor.execute("SELECT DISTINCT context FROM TestRuns;").fetchall()
+    contexts = cursor.execute("SELECT DISTINCT context FROM TestRuns WHERE TestRuns.time > ? ;", (since, )).fetchall()
     for context in contexts:
         # For each OS get top 10 failures
         context = context[0]


### PR DESCRIPTION
Otherwise we picked contexts that had no failures in last two weeks and
we hit IndexError.

@martinpitt this fixes empty https://images-cockpit.apps.ci.centos.org/failure-stats.js