### PR TITLE
naughty: Close 1008: 'tuned-adm recommend' fails with missing module error

### DIFF
--- a/naughty/rhel-8/1008-tuned-missing-module
+++ b/naughty/rhel-8/1008-tuned-missing-module
@@ -1,1 +1,0 @@
-*ModuleNotFoundError: No module named 'utilist'*


### PR DESCRIPTION
Known issue which has not occurred in 26 days

'tuned-adm recommend' fails with missing module error

Fixes #1008