### PR TITLE
naughty: Close 809: ip6tables-restor dumps core on debian-testing

### DIFF
--- a/naughty/debian-testing/809-ip6tables-restore-coredumps
+++ b/naughty/debian-testing/809-ip6tables-restore-coredumps
@@ -1,1 +1,0 @@
-Process * (ip6tables-resto) of user 0 dumped core.

--- a/naughty/debian-testing/809-iptables-restore-coredumps
+++ b/naughty/debian-testing/809-iptables-restore-coredumps
@@ -1,1 +1,0 @@
-Process * (iptables-restor) of user 0 dumped core.


### PR DESCRIPTION
Known issue which has not occurred in 27 days

ip6tables-restor dumps core on debian-testing

Fixes #809