### PR TITLE
fix the direct handling to all ssh methods

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -230,7 +230,7 @@ class SSHConnection(object):
             self._start_ssh_master()
 
     def __ssh_direct_opt_var(self, direct=False):
-        return os.getenv("SSH_DIRECT", direct)
+        return os.getenv("TEST_SSH_DIRECT", direct)
 
     def __execution_opts(self, direct=False):
         direct = self.__ssh_direct_opt_var(direct=direct)


### PR DESCRIPTION
Allow to overwrite execution method  and use direct via env var `SSH_DIRECT` and also fix the handling of it in all methods in class instead of just execute.

Reason why:
 1. using Master connection sometimes fails for my tests (maybe timeout of connection)
 2. I have troubles to use master connection inside podman. Unable to find the root cause, maybe some selinux or any restrains of container.