### PR TITLE
npm-update: Stop updates to novnc

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -32,6 +32,7 @@ FRAGILE = [
     "react-bootstrap",
     "angular",
     "angular-route",
+    "@novnc/novnc",  # See cockpit/cockpit#14356
 ]
 
 import collections


### PR DESCRIPTION
We need to lock this version down until ` @patternfly/react-console`
won't update.

Closes https://github.com/cockpit-project/cockpit/pull/14437