### PR TITLE
npm-update: Drop obsolete fragile modules

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -27,11 +27,6 @@
 FRAGILE = [
     "jquery",
     "patternfly",
-    "paternfly-bootstrap-combobox",
-    # version 0.32.2 switches to babel 7, which causes build failures with our babel 6 build system
-    "react-bootstrap",
-    "angular",
-    "angular-route",
     "@novnc/novnc",  # See cockpit/cockpit#14356
 ]
 


### PR DESCRIPTION
These modules are not being used by anything any more.

---

I checked our other projects, and they don't use any of these any more, except for cockpit itself:

 - [x] Drop obsolete modules from cockpit's package.json: https://github.com/cockpit-project/cockpit/pull/14440
 - [x] Drop patternfly-bootstrap-combobox from cockpit: https://github.com/cockpit-project/cockpit/pull/14441

