### PR TITLE
naughty: Close 948: "ip_finish_output: general protection fault" kernel crash on fedora-coreos

### DIFF
--- a/naughty/fedora-coreos/948-ip_finish_output-oops
+++ b/naughty/fedora-coreos/948-ip_finish_output-oops
@@ -1,2 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-system-info", line *, in testBasic


### PR DESCRIPTION
Known issue which has not occurred in 26 days

"ip_finish_output: general protection fault" kernel crash on fedora-coreos

Fixes #948