### PR TITLE
testmap: Add martinpitt/performance-graphs

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -157,7 +157,17 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-3',
             'centos-8-stream',
         ]
-    }
+    },
+    'martinpitt/performance-graphs': {
+        'master': [
+            'fedora-31',
+            'fedora-32',
+        ],
+        '_manual': [
+            'rhel-8-3',
+            'centos-8-stream',
+        ]
+    },
 }
 
 # The OSTree variants can't build their own packages, so we build in


### PR DESCRIPTION
I committed a first set of basic tests. I haven't them run in CI yet, and I'll use the  first PR to fix any potential fallout.