### PR TITLE
testmap: Enable RHEL test in martinpitt/performance-graphs

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -162,9 +162,9 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'fedora-31',
             'fedora-32',
+            'rhel-8-3',
         ],
         '_manual': [
-            'rhel-8-3',
             'centos-8-stream',
         ]
     },


### PR DESCRIPTION
It succeeded in https://github.com/martinpitt/performance-graphs/pull/2