### PR TITLE
machine: Tolerate "domain is not running" errors on destroying

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -562,7 +562,7 @@ class VirtMachine(Machine):
                 with stdchannel_redirected(sys.stderr, os.devnull):
                     self._domain.destroyFlags(libvirt.VIR_DOMAIN_DESTROY_DEFAULT)
             except libvirt.libvirtError as le:
-                if 'not found' not in str(le):
+                if 'not found' not in str(le) and 'not running' not in str(le):
                     raise
         self._cleanup(quick=True)
 


### PR DESCRIPTION
In some cases, `VirtMachine.shutdown()` fails with

    libvirt.libvirtError: Requested operation is not valid: domain is not running

Ignore "not running" errors similarly to how it already ignores "not
found" errors, as these are transient domains.