### PR TITLE
images: Move ubuntu-stable to groovy

### DIFF
--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -83,7 +83,7 @@ case "$RELEASE" in
         COCKPIT_DEPS="${COCKPIT_DEPS/libvirt-dbus /}"
         TEST_PACKAGES="${TEST_PACKAGES/systemd-timesyncd /}"
         ;;
-    eoan|buster)
+    buster)
         # timesyncd got split out in Ubuntu 20.04 and Debian 11
         TEST_PACKAGES="${TEST_PACKAGES/systemd-timesyncd /}"
         ;;
@@ -133,12 +133,6 @@ for p in lxd snapd landscape-common accountsservice open-vm-tools ufw cloud-init
 # HACK: debian-stable image got /usr/bin/qemu-img removed, even though qemu-utils package is installed
 if [ "$1" = "debian-stable" ]; then
     $APT install --reinstall -y qemu-utils
-fi
-
-# HACK https://launchpad.net/bugs/1850281: disable pmlogger for image build, to avoid package install failure
-if [ "$1" = "ubuntu-stable" ]; then
-    mkdir -p /run/systemd/system/pmlogger.service.d
-    printf '[Service]\nType=simple\nExecStart=\nExecStart=/bin/true\n' > /run/systemd/system/pmlogger.service.d/disable.conf
 fi
 
 # python3-rtslib-fb postinst starts rtslib-fb-targetctl.service , but that may fail due to kernel being upgraded

--- a/images/scripts/ubuntu-stable.bootstrap
+++ b/images/scripts/ubuntu-stable.bootstrap
@@ -15,7 +15,7 @@ fi
 # release name is the last part of the URL
 rel=${rel##*/}
 
-# Pin release to 19.10 (eoan) while the current stable is 20.04 LTS, as we have a separate image for that (ubuntu-2004)
-rel=eoan
+# Pin release to 20.10 (groovy) development series while the current stable is 20.04 LTS, as we have a separate image for that (ubuntu-2004)
+rel=groovy
 
 exec $(dirname $0)/lib/debian.bootstrap "$1" "https://cloud-images.ubuntu.com/daily/server/$rel/current/$rel-server-cloudimg-amd64.img"

--- a/images/scripts/ubuntu-stable.install
+++ b/images/scripts/ubuntu-stable.install
@@ -4,12 +4,8 @@ set -e
 
 /var/lib/testvm/debian.install "$@"
 
-# HACK: With our restricted network during tests, systemd-networkd-wait-online
-# takes ages and waits for two minutes. This makes waiting for docker.service time out.
-systemctl mask systemd-networkd-wait-online.service
-
 # HACK: broken virt-builder image; locale defaults to en_US (which is ISO-8859-1)
 update-locale LANG=C.UTF-8
 
-# make libpwquality less aggressive, so that our "foobar" password works
-printf 'dictcheck = 0\nminlen = 6\n' >> /etc/security/pwquality.conf
+# HACK: nftables backend does not currently work with libvirt: https://launchpad.net/bugs/1799095
+sed -i 's/FirewallBackend=nftables/FirewallBackend=iptables/' /etc/firewalld/firewalld.conf

--- a/images/ubuntu-stable
+++ b/images/ubuntu-stable
@@ -1,1 +1,1 @@
-ubuntu-stable-f3576bdde3e947df6cb8df664416db389068eb10046365fcdcb064e7c1a73651.qcow2
+ubuntu-stable-ccc02426450368fdfc42ec0ca8d8f2cecfdc3ca12122e77d67084dc0943fb1aa.qcow2

--- a/naughty/ubuntu-stable/70-pxe-boot-logs-serial-console-libvirt
+++ b/naughty/ubuntu-stable/70-pxe-boot-logs-serial-console-libvirt
@@ -1,1 +1,0 @@
-subprocess.CalledProcessError: Command 'sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'' returned non-zero exit status 1.

--- a/naughty/ubuntu-stable/932-udisks-deactivated-lv-cleanup
+++ b/naughty/ubuntu-stable/932-udisks-deactivated-lv-cleanup
@@ -1,0 +1,4 @@
+  File "test/verify/check-storage-hidden", line *, in testHiddenLuks
+    self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_1), "")
+*
+AssertionError: 'UUID=*' != ''


### PR DESCRIPTION
19.10 (eoan) is EOL now, so instead test the current development series.

Fixes #1096

 * [x] image-refresh ubuntu-stable

Land this together with https://github.com/cockpit-project/cockpit/pull/14457