### PR TITLE
Check for github teams in appropriate org

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ You can also invoke bots/tests/trigger from any project checkout, in which case
 you don't need the explicit `--repo` -- it will default to the GitHub origin of
 the current directory's project.
 
-### Testing a pull request by a non-whitelisted user
+### Testing a pull request by a non-allowed user
 
-If you want to run all tests on pull request #1234 that has been
-opened by someone who is not in our white-list, run tests-trigger
-with `--allow`:
+If you want to run all tests on pull request #1234 that has been opened by someone
+who does not have push access to the repository nor isn't in the 'Contributors' team,
+run tests-trigger with `--allow`:
 
     $ ./tests-trigger --allow [...]
 

--- a/issue-scan
+++ b/issue-scan
@@ -128,13 +128,12 @@ def tasks_for_issues(issues_data):
     else:
         api = github.GitHub()
         issues = api.issues(state="open")
-    whitelist = api.whitelist()
 
     for issue in issues:
         if issue["title"].strip().startswith("WIP"):
             continue
         login = issue.get("user", {}).get("login", {})
-        if login not in whitelist:
+        if not api.is_user_allowed(login):
             continue
 
         #

--- a/task/github.py
+++ b/task/github.py
@@ -380,6 +380,15 @@ class GitHub(object):
         else:
             raise KeyError("Team {0} not found".format(name))
 
+    def is_user_allowed(self, user):
+        # Firstly check if user has push access
+        data = self.get("/repos/{0}/collaborators/{1}/permission".format(self.repo, user)) or {}
+        if data.get("permission") in ["admin", "write"]:
+            return True
+
+        # User does not have push access, lets check if in `Contributors` group
+        return user in self.whitelist()
+
 
 class Checklist(object):
     def __init__(self, body=None):

--- a/tests-scan
+++ b/tests-scan
@@ -292,7 +292,6 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
     else:
         pulls = api.pulls()
 
-    whitelist = api.whitelist()
     for pull in pulls:
         title = pull["title"]
         number = pull["number"]
@@ -300,6 +299,8 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
         statuses = api.statuses(revision)
         login = pull["head"]["user"]["login"]
         base = pull["base"]["ref"]  # The branch this pull request targets
+
+        allowed = api.is_user_allowed(login)
 
         logging.info("Processing #{0} titled '{1}' on revision {2}".format(number, title, revision))
 
@@ -387,11 +388,11 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
 
             ref = "pull/%d/head" % number
 
-            # For unmarked and untested status, user must be in whitelist
+            # For unmarked and untested status, user must be allowed
             # Not this only applies to this specific commit. A new status
             # will apply if the user pushes a new commit.
             status = todos[context]
-            if login not in whitelist and status.get("description", github.NO_TESTING) == github.NO_TESTING:
+            if not allowed and status.get("description", github.NO_TESTING) == github.NO_TESTING:
                 priority = github.NO_TESTING
                 changes = {"description": github.NO_TESTING, "context": context, "state": "pending"}
             else:

--- a/tests-trigger
+++ b/tests-trigger
@@ -15,11 +15,11 @@ def trigger_pull(api, opts):
         sys.stderr.write("{0} is not a pull request.\n".format(opts.pull))
         return 1
 
-    # triggering is manual, so don't prevent triggering a user that isn't on the whitelist
-    # but issue a warning in case of an oversight
+    # triggering is manual, so don't prevent triggering a user that does not have push access
+    # nor isn't in the 'Contributors' group, but issue a warning in case of an oversight
     login = pull["head"]["user"]["login"]
-    if not opts.allow and login not in api.whitelist():
-        sys.stderr.write("Pull request author '{0}' isn't whitelisted. Override with --allow.\n".format(login))
+    if not opts.allow and not api.is_user_allowed(login):
+        sys.stderr.write("Pull request author '{0}' isn't allowed. Override with --allow.\n".format(login))
         return 1
 
     revision = pull['head']['sha']
@@ -71,7 +71,7 @@ def main():
     parser.add_argument('-f', '--force', action="store_true",
                         help='Force setting the status even if the program logic thinks it shouldn''t be done')
     parser.add_argument('-a', '--allow', action='store_true', dest='allow',
-                        help="Allow triggering for users that aren't whitelisted")
+                        help="Allow triggering for users that aren't allowed")
     parser.add_argument('--requeue', action="store_true",
                         help='Re-queue pending test requests (workaround for occasionally ignored webhook events)')
     parser.add_argument('--repo', help="The repository to trigger the robots in", default=None)


### PR DESCRIPTION
When PR is opened in a different organization than `cockpit-project` and
we check if user is in `Contributors` group, we should check this group
in the given org and not always in `cockpit-project`.