### PR TITLE
testmap: Do not test fedora-31 on cockpit master

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -34,7 +34,6 @@ REPO_BRANCH_CONTEXT = {
             'debian-testing',
             'ubuntu-2004',
             'ubuntu-stable',
-            'fedora-31',
             'fedora-32',
             'fedora-33',
             'fedora-coreos',


### PR DESCRIPTION
We do not release there anymore since https://github.com/cockpit-project/cockpit/pull/14504