### PR TITLE
testmap: Make fedora-33 mandatory for performance-graphs

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -162,11 +162,11 @@ REPO_BRANCH_CONTEXT = {
     'martinpitt/performance-graphs': {
         'master': [
             'fedora-32',
+            'fedora-33',
             'rhel-8-3',
         ],
         '_manual': [
             'centos-8-stream',
-            'fedora-33',
         ]
     },
 }


### PR DESCRIPTION
Succeeded in https://github.com/martinpitt/performance-graphs/pull/9