### PR TITLE
testmap: Stop testing fedora-31 on c-podman

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -83,7 +83,6 @@ REPO_BRANCH_CONTEXT = {
     },
     'cockpit-project/cockpit-podman': {
         'master': [
-            'fedora-31',
             'fedora-32',
             'fedora-32/rawhide',
             'fedora-33',


### PR DESCRIPTION
We stopped releasing there so we can stop testing it as well.