### PR TITLE
testmap: Trigger cockpit master tests on centos-7 refreshes

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -17,6 +17,7 @@
 
 import os.path
 
+from machine.machine_core.constants import TEST_OS_DEFAULT
 
 REPO_BRANCH_CONTEXT = {
     'cockpit-project/bots': {
@@ -181,6 +182,10 @@ OSTREE_BUILD_IMAGE = {
 IMAGE_REFRESH_TRIGGERS = {
     "fedora-testing": [
         "fedora-testing@cockpit-project/cockpit"
+    ],
+    # some tests run against centos-7's cockpit-ws for backwards compat testing
+    "centos-7": [
+        TEST_OS_DEFAULT + "@cockpit-project/cockpit",
     ],
     "openshift": [
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",


### PR DESCRIPTION
check-multi-os and check-superuser run centos-7 as auxiliary image to
validate protocol backwards compatibility.