### PR TITLE
images: Drop obsolete centos macro definition with --rhel

### DIFF
--- a/images/scripts/lib/fedora.install
+++ b/images/scripts/lib/fedora.install
@@ -36,12 +36,6 @@ $2"
                 do_install=t
                 ;;
             --rhel)
-                # For RHEL we actually build in EPEL, which is based
-                # on CentOS.  On CentOS, the spec file has both
-                # %centos and %rhel defined, but it gives precedence
-                # to %centos, as it must.  To make it produce the RHEL
-                # packages, we explicitly undefine %centos here.
-                mock_opts="$mock_opts --define='centos 0'"
                 ;;
 	    --)
 		shift


### PR DESCRIPTION
It's been a long time since we built RHEL packages in EPEL; builds
happen in proper RHEL mocks. These should work without the extra macro
definition hack.