### PR TITLE
testmap: Introduce `fedora-testing/dnf-copr` context

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -62,6 +62,7 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-testing',
+            'fedora-testing/dnf-copr',
             'rhel-8-3-distropkg',
         ],
     },


### PR DESCRIPTION
This context will stay in `manual` and it will run tests with dnf from
nightly repos. Since it is based on `fedora-testing` repo it will be run
on every refresh of this image.