### PR TITLE
lorax: Only run composer-cli tests with osbuild-composer

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -99,7 +99,6 @@ REPO_BRANCH_CONTEXT = {
     },
     'weldr/lorax': {
         'master': [
-            'fedora-32',
             'fedora-32/osbuild-composer',
         ],
         'rhel8-branch': [


### PR DESCRIPTION
lorax-composer has been removed in Fedora 34, only run the tests with
osbuild-composer.