### PR TITLE
naughty: Close 1092: kexec_file_load failed: Accessing a corrupted shared library w/ 5.7.9-200.fc32.x86_64

### DIFF
--- a/naughty/fedora-31/1092-kexec_file_load-corrupted
+++ b/naughty/fedora-31/1092-kexec_file_load-corrupted
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-*
-  File "test/verify/check-kdump", line *, in testBasic
-    b.wait_in_text("#app", "Service is running")
-*
-testlib.Error: timeout

--- a/naughty/fedora-32/1092-kexec_file_load-corrupted
+++ b/naughty/fedora-32/1092-kexec_file_load-corrupted
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-*
-  File "test/verify/check-kdump", line *, in testBasic
-    b.wait_in_text("#app", "Service is running")
-*
-testlib.Error: timeout

--- a/naughty/fedora-33/1092-kexec_file_load-corrupted
+++ b/naughty/fedora-33/1092-kexec_file_load-corrupted
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-*
-  File "test/verify/check-kdump", line *, in testBasic
-    b.wait_in_text("#app", "Service is running")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 26 days

kexec_file_load failed: Accessing a corrupted shared library w/ 5.7.9-200.fc32.x86_64

Fixes #1092