### PR TITLE
naughty: Close 971: gnutls 3.6.14 broken in FIPS mode: FIPS140-2 self testing part 2 failed

### DIFF
--- a/naughty/fedora-31/971-gnutls-fips
+++ b/naughty/fedora-31/971-gnutls-fips
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line *, in testFIPS
-    self.login_and_go("/dashboard")
-*
-    self.wait_visible("#login")
-*
-testlib.Error: timeout

--- a/naughty/fedora-31/971-gnutls-fips-firefox
+++ b/naughty/fedora-31/971-gnutls-fips-firefox
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line *, in testFIPS
-    self.login_and_go("/dashboard")
-*
-RuntimeError: timed out waiting for page load

--- a/naughty/fedora-32/971-gnutls-fips
+++ b/naughty/fedora-32/971-gnutls-fips
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line *, in testFIPS
-    self.login_and_go("/dashboard")
-*
-    self.wait_visible("#login")
-*
-testlib.Error: timeout

--- a/naughty/fedora-33/971-gnutls-fips
+++ b/naughty/fedora-33/971-gnutls-fips
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line *, in testFIPS
-    self.login_and_go("/dashboard")
-*
-    self.wait_visible("#login")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 26 days

gnutls 3.6.14 broken in FIPS mode: FIPS140-2 self testing part 2 failed

Fixes #971