### PR TITLE
naughty: Close 932: udisks 2.9.0 regression: org.freedesktop.UDisks2.VolumeGroup.Delete does not clean up fstab mounts any more for deactivated LV

### DIFF
--- a/naughty/debian-testing/932-udisks-deactivated-lv-cleanup
+++ b/naughty/debian-testing/932-udisks-deactivated-lv-cleanup
@@ -1,4 +1,0 @@
-  File "test/verify/check-storage-hidden", line *, in testHiddenLuks
-    self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_1), "")
-*
-AssertionError: 'UUID=*' != ''

--- a/naughty/rhel-8/932-udisks-deactivated-lv-cleanup
+++ b/naughty/rhel-8/932-udisks-deactivated-lv-cleanup
@@ -1,4 +1,0 @@
-  File "test/verify/check-storage-hidden", line *, in testHiddenLuks
-    self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_1), "")
-*
-AssertionError: 'UUID=*' != ''

--- a/naughty/ubuntu-stable/932-udisks-deactivated-lv-cleanup
+++ b/naughty/ubuntu-stable/932-udisks-deactivated-lv-cleanup
@@ -1,4 +1,0 @@
-  File "test/verify/check-storage-hidden", line *, in testHiddenLuks
-    self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_1), "")
-*
-AssertionError: 'UUID=*' != ''


### PR DESCRIPTION
Known issue which has not occurred in 27 days

udisks 2.9.0 regression: org.freedesktop.UDisks2.VolumeGroup.Delete does not clean up fstab mounts any more for deactivated LV

Fixes #932