### PR TITLE
testmap: Add manual contexts for cockpit-certificates

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -157,6 +157,8 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'rhel-8-3',
             'centos-8-stream',
+            'fedora-32',
+            'fedora-33',
         ]
     },
     'martinpitt/performance-graphs': {


### PR DESCRIPTION
Fedora-31 is getting EOL slowly, let's tests against something newer.

I would like to drop F31 soon, so lets move away. Any other target is osbuild-composer, but they had some issues with this.