### PR TITLE
Add script to upload GitHub action secrets

### DIFF
--- a/github-upload-action-secrets
+++ b/github-upload-action-secrets
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+#
+# Upload encrypted secrets to GitHub
+# With this the secrets can be used by GitHub actions:
+# https://developer.github.com/v3/actions/secrets/#create-or-update-an-organization-secret
+#
+# Secrets are uploaded to the organization by default:
+#
+#   https://github.com/organizations/cockpit-project/settings/secrets
+#
+# For testing, you can upload it to a particular project with --receiver OWNER/REPO
+
+#   https://github.com/OWNER/REPO/settings/secrets
+#
+# This file is part of Cockpit.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import os
+import sys
+from base64 import b64encode
+
+from nacl import encoding, public
+
+import task
+
+
+def encrypt(public_key: str, secret_value: str) -> str:
+    """Encrypt a Unicode string using the public key."""
+
+    public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
+    sealed_box = public.SealedBox(public_key)
+    encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+    return b64encode(encrypted).decode("utf-8")
+
+
+def main():
+    api = task.github.GitHub()
+
+    # get organization of the current repo
+    org = api.get('/repos/' + api.repo)["organization"]["login"]
+
+    parser = argparse.ArgumentParser(description='Upload encrypted action secrets to GitHub')
+    parser.add_argument('-r', '--receiver', default=org, metavar="[ORGNAME | OWNER/REPO]",
+                        help="The organization or repository which will receive the secrets; default: %(default)s")
+    parser.add_argument('-v', '--verbose', action="store_true", default=False,
+                        help="Print verbose information")
+    parser.add_argument("secrets_dir", help="directory with one file per secret")
+    opts = parser.parse_args()
+
+    if '/' in opts.receiver:
+        # repository
+        resource = '/repos/' + opts.receiver
+    else:
+        # organization
+        resource = '/orgs/' + opts.receiver
+
+    pubkey = api.get(resource + "/actions/secrets/public-key")
+
+    for secret_name in os.listdir(opts.secrets_dir):
+        path = os.path.join(opts.secrets_dir, secret_name)
+        if opts.verbose:
+            print("Encrypting and uploading", path, "to", opts.receiver)
+        with open(path) as f:
+            enc = encrypt(pubkey["key"], f.read())
+        payload = {"key_id": pubkey["key_id"], "encrypted_value": enc, "visibility": "all"}
+        api.put(resource + "/actions/secrets/" + secret_name, payload)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/task/github.py
+++ b/task/github.py
@@ -269,6 +269,17 @@ class GitHub(object):
         self.cache.mark()
         return json.loads(response['data'])
 
+    def put(self, resource, data, accept=[]):
+        response = self.request("PUT", resource, json.dumps(data), {"Content-Type": "application/json"})
+        status = response['status']
+        if (status < 200 or status >= 300) and status not in accept:
+            raise GitHubError(self.qualify(resource), response)
+        self.cache.mark()
+        if response['data']:
+            return json.loads(response['data'])
+        else:
+            return None
+
     def delete(self, resource, accept=[]):
         response = self.request("DELETE", resource, "", {"Content-Type": "application/json"})
         status = response['status']


### PR DESCRIPTION
These encrypted secrets can be used by GitHub actions. By default we
want them at the organization level, so that all projects of the org can
share them. For testing, non-generic secrets, or third-party projects
without an organization they can also be uploaded to a repository.

See https://developer.github.com/v3/actions/secrets for details.