### PR TITLE
task: Deal with tokens that cannot access the /user API

### DIFF
--- a/task/__init__.py
+++ b/task/__init__.py
@@ -376,10 +376,11 @@ def find_our_fork(user):
     raise RuntimeError("%s doesn't have a fork of %s" % (user, api.repo))
 
 
-def push_branch(user, branch, force=False):
-    fork_repo = find_our_fork(user)
+def push_branch(user, branch, force=False, push_repo=None):
+    if not push_repo:
+        push_repo = find_our_fork(user)
 
-    url = "https://github.com/{0}".format(fork_repo)
+    url = "https://github.com/{0}".format(push_repo)
     cmd = ["git", "push", url, "+HEAD:refs/heads/{0}".format(branch)]
     if force:
         cmd.insert(2, "-f")
@@ -416,7 +417,7 @@ def branch(context, message, pathspec=".", issue=None, branch=None, push=True, *
 
     # No need to push if we want to add another commits into the same branch
     if push:
-        push_branch(user, branch)
+        push_branch(user, branch, push_repo=fork_repo)
 
     # Comment on the issue if present and we pushed the branch
     if issue and push:

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -358,7 +358,12 @@ def execute(*args):
     # No prompting for passwords
     if "GIT_ASKPASS" not in env:
         env["GIT_ASKPASS"] = "/bin/true"
-    output = subprocess.check_output(args, cwd=BASE_DIR, stderr=subprocess.STDOUT, env=env, universal_newlines=True)
+    try:
+        output = subprocess.check_output(args, cwd=BASE_DIR, stderr=subprocess.STDOUT, env=env, universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        if verbose:
+            sys.stderr.write("! " + str(e))
+        raise
     sys.stderr.write(censored(output))
     return output
 


### PR DESCRIPTION
This is the case with the restricted default tokens in GitHub actions.
With these we want to push the fork to the original repo anyway, as
that's much easier to set up especially for third-party projects (you
need zero credentials setup).
