### PR TITLE
task: Automatically trigger cockpit-project tests

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -369,7 +369,7 @@ class GitHub(object):
                 yield commit
                 count += 1
 
-    def whitelist(self):
+    def allowlist(self):
         # organizations which are allowed to use our CI (these use branches within the main repo for PRs)
         users = {"candlepin"}
 
@@ -398,7 +398,7 @@ class GitHub(object):
             return True
 
         # User does not have push access, lets check if in `Contributors` group
-        return user in self.whitelist()
+        return user in self.allowlist()
 
 
 class Checklist(object):

--- a/task/github.py
+++ b/task/github.py
@@ -371,7 +371,7 @@ class GitHub(object):
 
     def allowlist(self):
         # organizations which are allowed to use our CI (these use branches within the main repo for PRs)
-        users = {"candlepin"}
+        users = {"candlepin", "cockpit-project"}
 
         # individual persons from https://github.com/orgs/cockpit-project/teams/contributors/members
         teamId = self.teamIdFromName(TEAM_CONTRIBUTORS)

--- a/task/test-github
+++ b/task/test-github
@@ -178,12 +178,12 @@ class TestGitHub(unittest.TestCase):
         self.assertEqual(len(issues), 1)
         self.assertEqual(issues[0]["number"], "7")
 
-    def testWhitelist(self):
-        whitelist = self.api.whitelist()
-        self.assertTrue(len(whitelist) > 0)
-        self.assertEqual(whitelist, set(["one", "two", "three", "candlepin"]))
-        self.assertNotIn("four", whitelist)
-        self.assertNotIn("", whitelist)
+    def testAllowlist(self):
+        allowlist = self.api.allowlist()
+        self.assertTrue(len(allowlist) > 0)
+        self.assertEqual(allowlist, set(["one", "two", "three", "candlepin"]))
+        self.assertNotIn("four", allowlist)
+        self.assertNotIn("", allowlist)
 
     def testTeamIdFromName(self):
         self.assertEqual(self.api.teamIdFromName(github.TEAM_CONTRIBUTORS), 1)

--- a/task/test-github
+++ b/task/test-github
@@ -181,7 +181,7 @@ class TestGitHub(unittest.TestCase):
     def testAllowlist(self):
         allowlist = self.api.allowlist()
         self.assertTrue(len(allowlist) > 0)
-        self.assertEqual(allowlist, set(["one", "two", "three", "candlepin"]))
+        self.assertEqual(allowlist, set(["one", "two", "three", "candlepin", "cockpit-project"]))
         self.assertNotIn("four", allowlist)
         self.assertNotIn("", allowlist)
 


### PR DESCRIPTION
With the advent of GitHub actions, we now have PRs originating from
branches of the main repository (similar to candlepin). Automatically
start these tests.

Note: We do *not* want to generalize this to "is owner of target
repository", but keep control who is using our test infrastructure.
