### PR TITLE
github-upload-action-secrets: Trim whitespace from secrets

### DIFF
--- a/github-upload-action-secrets
+++ b/github-upload-action-secrets
@@ -76,7 +76,7 @@ def main():
         if opts.verbose:
             print("Encrypting and uploading", path, "to", opts.receiver)
         with open(path) as f:
-            enc = encrypt(pubkey["key"], f.read())
+            enc = encrypt(pubkey["key"], f.read().strip())
         payload = {"key_id": pubkey["key_id"], "encrypted_value": enc, "visibility": "all"}
         api.put(resource + "/actions/secrets/" + secret_name, payload)
 


### PR DESCRIPTION
So that you can use the secrets as part of a string like
`token:${{ secrets.MY_TOKEN }}@github.com` without having to worry about
line breaks.