### PR TITLE
workflows: Fix daily job name

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -5,7 +5,7 @@ on:
   # can be run manually on https://github.com/cockpit-project/bots/actions
   workflow_dispatch:
 jobs:
-  npm-update:
+  maintenance:
     runs-on: ubuntu-latest
     steps:
       - name: Set up secrets


### PR DESCRIPTION
This job does not only run npm-update, so rename it to something more
generic.