### PR TITLE
testmap: Drop martinpitt/performance-graphs

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -160,16 +160,6 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream',
         ]
     },
-    'martinpitt/performance-graphs': {
-        'master': [
-            'fedora-32',
-            'fedora-33',
-            'rhel-8-3',
-        ],
-        '_manual': [
-            'centos-8-stream',
-        ]
-    },
 }
 
 # The OSTree variants can't build their own packages, so we build in


### PR DESCRIPTION
This project is part of cockpit proper now.