### PR TITLE
task: Allow github-actions user

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -370,8 +370,8 @@ class GitHub(object):
                 count += 1
 
     def allowlist(self):
-        # organizations which are allowed to use our CI (these use branches within the main repo for PRs)
-        users = {"candlepin", "cockpit-project"}
+        # bots and organizations which are allowed to use our CI (these use branches within the main repo for PRs)
+        users = {"github-actions[bot]", "candlepin", "cockpit-project"}
 
         # individual persons from https://github.com/orgs/cockpit-project/teams/contributors/members
         teamId = self.teamIdFromName(TEAM_CONTRIBUTORS)

--- a/task/test-github
+++ b/task/test-github
@@ -181,7 +181,7 @@ class TestGitHub(unittest.TestCase):
     def testAllowlist(self):
         allowlist = self.api.allowlist()
         self.assertTrue(len(allowlist) > 0)
-        self.assertEqual(allowlist, set(["one", "two", "three", "candlepin", "cockpit-project"]))
+        self.assertEqual(allowlist, set(["one", "two", "three", "github-actions[bot]", "candlepin", "cockpit-project"]))
         self.assertNotIn("four", allowlist)
         self.assertNotIn("", allowlist)
 


### PR DESCRIPTION
Our projects have workflows which file issues with tasks (such as
naughty-prune). These issues are reported by the "github-actions[bot]"
user.

See issue #1343