### PR TITLE
npm-update: Don't update package with pending PR

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -76,6 +76,18 @@ def output(*args):
 
 
 def run(specified_package, verbose=False, **kwargs):
+    api = task.github.GitHub()
+
+    # List pending updates
+    pending_updates = []
+    for issue in api.issues(state="open"):
+        title = issue["title"]
+        if title.startswith("package.json: Update "):
+            package = title.split(" ")[2]
+            pending_updates.append(package)
+            if task.verbose:
+                sys.stderr.write("Ignoring '{0}' as there is pending PR #{1}\n".format(package, issue["number"]))
+
     # Force all current dependencies in place
     execute("npm", "install")
 
@@ -95,6 +107,8 @@ def run(specified_package, verbose=False, **kwargs):
         return "~" + version
 
     for package in packages:
+        if package in pending_updates:
+            continue
 
         orig_version = orig_package_json["dependencies"][package]
         upgradeable_version = prefix(package, orig_version)


### PR DESCRIPTION
Now, when we run npm-update every day, if we get update that we don't
land the same day, we get new PR the next day as well. This has
potential to get very spammy over weekends or during holiday seasons.

See for example https://github.com/cockpit-project/cockpit/pull/14841 and https://github.com/cockpit-project/cockpit/pull/14844

With dry run when I list `pending_updates` it shows `['qunit']`. (because https://github.com/cockpit-project/cockpit/pull/14841 is open)

With the following "patch": (to list all possible candidates)
```
         if new_version != orig_version:
+            print("XXX Updating {0}".format(package))
+            continue
 
             # Write out the original package.json with the updated version
```
without this PR I get:
```
XXX Updating @patternfly/react-table
XXX Updating qunit
XXX Updating @patternfly/patternfly
```

With this PR I get:
```
XXX Updating @patternfly/react-table
XXX Updating @patternfly/patternfly
```