### PR TITLE
testmap: Add manual ubuntu-stable test for cockpit-podman

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -91,6 +91,8 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'centos-8-stream',
+            # runs in Travis
+            'ubuntu-stable',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
cockpit-podman is in Ubuntu now, so let's make sure it stays working.

We'll start with running this through Travis [1], but with that we can
compare results on our infrastructure.

[1] https://github.com/cockpit-project/cockpit-podman/pull/586