### PR TITLE
Workflows: Fetch full history to have timestamps of files

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Trigger image refreshes
         run: ./image-trigger


### PR DESCRIPTION
`image-trigger` needs correct timestamps. With `fetch-depth: 1` all
files have timestamp when the repo was cloned.

Also see https://github.com/actions/checkout/issues/364