### PR TITLE
images: Fix centos-8-stream image build

### DIFF
--- a/images/centos-8-stream
+++ b/images/centos-8-stream
@@ -1,1 +1,1 @@
-centos-8-stream-e8ab5d97504f653788b1ceeb7f72e2fa269fb3c7462fa722f5f956a60c84e88d.qcow2
+centos-8-stream-f2aa00ef3f9d7021190d50eaaa8e34d670ccc8cb8d8b49994279e30c780b92e2.qcow2

--- a/images/scripts/centos-8-stream.bootstrap
+++ b/images/scripts/centos-8-stream.bootstrap
@@ -2,6 +2,7 @@
 set -eux
 
 URL=https://cloud.centos.org/centos/8-stream/x86_64/images/
-LATEST_DAILY=$(curl -s "$URL" | sed -n '/<a href=.*GenericCloud.*qcow2/ { s/^.*href="//; s_".*$__; p }')
+DAILIES=$(curl -s "$URL" | sed -n '/<a href=.*GenericCloud.*qcow2/ { s/^.*href="//; s_".*$__; p }')
+LATEST_DAILY=$(echo "$DAILIES" | sort -u | tail -n1)
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$LATEST_DAILY"

--- a/naughty/rhel-8/1366-kernel-install-failure
+++ b/naughty/rhel-8/1366-kernel-install-failure
@@ -1,0 +1,19 @@
+Traceback (most recent call last):
+*
+subprocess.CalledProcessError: Command 'set -e
+. /etc/os-release
+touch /boot/vmlinuz-42.0.0; mkdir -p /lib/modules/42.0.0/
+if type update-grub >/dev/null 2>&1; then
+    update-grub  # Debian/Ubuntu
+else
+    if [ "$ID" = rhel -o "$ID" = centos ] && [ "${VERSION_ID#7}" != "$VERSION_ID" ]; then
+        new-kernel-pkg --package kernel --install 42.0.0  # RHEL/CentOS 7
+    else
+        kernel-install add 42.0.0 /boot/vmlinuz-42.0.0 2>/dev/null # Fedora/RHEL >= 8
+    fi
+fi
+grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg ||
+  grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
+  ( grub2-editenv list | grep -q kernelopts.*nosmt &&
+    grep -q '^options.*$kernelopts' /boot/loader/entries/*42.0.0*.conf )
+' returned non-zero exit status 2.


### PR DESCRIPTION
Get along with multiple image matches, and select the latest one.

Fixes #1356

 * [x] image-refresh centos-8-stream
 * [x] Report/naughty kernel-install regression: https://bugzilla.redhat.com/show_bug.cgi?id=1894026
 * [x] Fix broken CirrOS tests on rhel-8.3 branch: https://github.com/cockpit-project/cockpit/pull/14983
 * [x] Fix testConfigureBeforeInstall regression: https://github.com/cockpit-project/cockpit/pull/14995