### PR TITLE
Make rhel-7-9 lorax tests manually triggered only

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -113,18 +113,16 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-3/tar',
             'rhel-8-3/ci',
         ],
-        'rhel7-extras': [
+        # These can be triggered manually with bots/tests-trigger
+        '_manual': [
             'rhel-7-9',
+            'rhel-7-9/azure',
             'rhel-7-9/live-iso',
             'rhel-7-9/qcow2',
             'rhel-7-9/aws',
             'rhel-7-9/openstack',
             'rhel-7-9/vmware',
             'rhel-7-9/tar',
-        ],
-        # These can be triggered manually with bots/tests-trigger
-        '_manual': [
-            'rhel-7-9/azure',
             'rhel-8-3/osbuild-composer',
             'centos-8-stream',
         ],


### PR DESCRIPTION
They are broken.
See https://github.com/cockpit-project/bots/pull/1363#issuecomment-720923640