### PR TITLE
make-checkout: Drop --reference-if-able

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -63,9 +63,7 @@ def main():
     if os.path.exists(TARGET_DIR):
         shutil.rmtree(TARGET_DIR)
 
-    cache = os.getenv('XDG_CACHE_HOME', ".")
-    execute("git", "clone", "--reference-if-able", "{}/{}".format(cache, api.repo),
-            "https://github.com/{}".format(api.repo), TARGET_DIR)
+    execute("git", "clone", "https://github.com/{}".format(api.repo), TARGET_DIR)
     execute("git", "fetch", "origin", opts.ref, cwd=TARGET_DIR, error_on_fail=False)
     execute("git", "checkout", "--detach", opts.revision, cwd=TARGET_DIR, error_on_fail=False)
 


### PR DESCRIPTION
This only creates "warning" noise in logs, since repos are no longer
cached by the tasks container.