### PR TITLE
Add naughty for libvirt crash in RHEL

### DIFF
--- a/naughty/rhel-8/1374-libvirt-crashes-on-test-teardown
+++ b/naughty/rhel-8/1374-libvirt-crashes-on-test-teardown
@@ -1,0 +1,7 @@
+*TestMachines*
+*
+Process * (libvirtd) of user * dumped core.
+*
+#1  * virCondWait (libvirt.so.0)
+#2  * virThreadPoolWorker (libvirt.so.0)
+#3  * virThreadHelper (libvirt.so.0)


### PR DESCRIPTION
See known issue #1374
Fixes #1374

Note: this is same as #1372 but the regexp differs because rhel images
do not have the debuginfo packages installed.

Should catch crashes similar to https://logs.cockpit-project.org/logs/pull-14869-20201106-110814-e9c545ec-rhel-8-3/log.html#288