### PR TITLE
image-trigger: update fedora-testing every 3 days

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -26,7 +26,7 @@ REFRESH = {
     "debian-stable": {},
     "fedora-32": {},
     "fedora-33": {},
-    "fedora-testing": {},
+    "fedora-testing": {"refresh-days": 3},
     "fedora-coreos": {},
     "ubuntu-2004": {},
     "ubuntu-stable": {},


### PR DESCRIPTION
Suggested by Martin.  This will give us a better chance to notice
breaking changes before they make it into the official distro.