### PR TITLE
store-failures: When failed on unexpected message store it as well

### DIFF
--- a/store-failures
+++ b/store-failures
@@ -128,8 +128,19 @@ def insert_failure(cursor, run_id, testname, retry_reason):
 
 
 def find_failed_tests(fp):
+    last_msg = ""
+    save_message = False
     for line in fp:
         line = line.decode('utf-8')
+
+        if save_message:
+            last_msg = line.strip()
+            save_message = False
+            continue
+
+        if "FAIL: Test completed, but found unexpected" in line and "raise" not in line:
+            save_message = True
+
         if line.startswith("not ok "):
             # Result line has form like:
             # not ok 24 test/verify/check-foobar TestExample.testBasic [ND] # RETRY 2 (be robust against unstable tests)
@@ -141,7 +152,8 @@ def find_failed_tests(fp):
             fields[4] = fields[4].rstrip("#")
             testname = "{0} {1}".format(fields[3], fields[4])
             m = re_retry.search(line)
-            yield (testname, m and m.group(1) or None)
+            yield (testname, last_msg or (m and m.group(1) or None))
+            last_msg = ""
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Store it instead of retry reason. We don't retry on unexpected messages.

From [this](https://logs.cockpit-project.org/logs/pull-14905-20201116-084431-c57afb4b-fedora-33/log.html) log it would generate: (first is test name, after space is retry reason)
```
test/verify/check-bots-api TestImageCustomize.testResize be robust against unstable tests
test/verify/check-packagekit TestWsUpdate.testBasic be robust against unstable tests
test/verify/check-example TestNondestructiveExample.testTwo Failed to generate stack trace: invalid `Elf' handle
test/verify/check-packagekit TestWsUpdate.testBasic be robust against unstable tests
test/verify/check-packagekit TestWsUpdate.testBasic 
test/verify/check-sosreport TestSOS.testBasic be robust against unstable tests
```

Before anyone asks, that unexpected message was fixed in https://github.com/cockpit-project/cockpit/pull/14925

WDYT @martinpitt and @Gundersanne ? I thought I would create separate table for this data, but then thought about all that hustle with storing all the data we might need and that would need db migration... And this is pretty much for free as for unexpected messages we don't have retry reason anyway. After this I want to update the [page](https://images-frontdoor.apps.ocp.ci.centos.org/failure-stats.html) to also include top 10 most often seen unexpected messages (of course ignoring `be robust against unstable tests`). I think that can help as as there are always some that we just ignore as one-off but they may be more than one off. For example that `Failed to generate stack trace: invalid `Elf' handle` happened many times before, we never really bothered to fix it. Pretty sure it would be on the top of the list now.