### PR TITLE
naughty: add f32 naughty for PAM motd issue

### DIFF
--- a/naughty/fedora-32/1412-motd-wheel
+++ b/naughty/fedora-32/1412-motd-wheel
@@ -1,0 +1,3 @@
+# testSocket (__main__.TestConnection)
+*
+AssertionError: 'systemctl' not found in ''


### PR DESCRIPTION
Fedora 32 carries the PAM patch that drops privileges when checking
motd, without setting additional groups.  This means that it's currently
failing to show motd anywhere at all.

We'll chase that upstream, in the same way as we did for Fedora 33.  In
the meantime, naughty naughty.

See also https://github.com/linux-pam/linux-pam/pull/292
See also https://github.com/cockpit-project/cockpit/pull/14856
Closes #1412