### PR TITLE
testmap: Test cockpit-podman master on rhel-8, not the branch

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -81,13 +81,12 @@ REPO_BRANCH_CONTEXT = {
     },
     'cockpit-project/cockpit-podman': {
         'master': [
+            'rhel-8-3',
+            'rhel-8-4',
             'fedora-32',
             'fedora-32/rawhide',
             'fedora-33',
             'debian-testing',
-        ],
-        'rhel8': [
-            'rhel-8-3',
         ],
         '_manual': [
             'centos-8-stream',


### PR DESCRIPTION
We don't really use the rhel-8 branch for anything.  Releases of
cockpit-podman to RHEL are made by a third party by copying packages
from Fedora into some RHEL modules, apparently.

But it's always good to not break upstream cockpit-podman on RHEL, so
test master there.