### PR TITLE
testmap: Enable manual rhel-8 testing for cockpit-podman

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -90,6 +90,8 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-3',
         ],
         '_manual': [
+            'rhel-8-3',
+            'rhel-8-4',
             'centos-8-stream',
             # runs in Travis
             'ubuntu-stable',


### PR DESCRIPTION
We want to enable this for automatic testing once cockpit-podman is
ready for it.