### PR TITLE
images: Fix mock repos on centos-8-stream

### DIFF
--- a/images/centos-8-stream
+++ b/images/centos-8-stream
@@ -1,1 +1,1 @@
-centos-8-stream-f2aa00ef3f9d7021190d50eaaa8e34d670ccc8cb8d8b49994279e30c780b92e2.qcow2
+centos-8-stream-b4d82d19f3518a6ebe44f42cc0031ccc7b7afab79c3cad2897a8701c0c0fd35a.qcow2

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -338,17 +338,21 @@ config_opts['root'] = u'rhel-8-candidate-x86_64'
 config_opts['macros']['%_topdir'] = '/builddir/build'
 config_opts['macros']['%_rpmfilename'] = '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm'
 EOF
-    else
+    elif [ "${IMAGE#centos-8*}" != "$IMAGE" ]; then
+        # install mock from EPEL
+        dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        dnf install -y rpm-build mock
+        dnf config-manager --set-disabled epel
+
+        # build mock for CentOS stream repo
+        ln -sf centos-stream-x86_64.cfg /etc/mock/default.cfg
+    elif [ "$IMAGE" = "centos-7" ]; then
         # enable epel for mock
         if [ ! -f "$SKIP_REPO_FLAG" ]; then
             mkdir /tmp/dep
             cd /tmp/dep
             $YUM_INSTALL wget
-            if [ "${IMAGE#centos-8-stream}" != "$IMAGE" ]; then
-                wget -T 15 -t 4 http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-            else
-                wget -T 15 -t 4 http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-            fi
+            wget -T 15 -t 4 http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
             yum -y remove wget
             rpm -Uvh epel-release-*.rpm
             cd


### PR DESCRIPTION
mock from EPEL defaults to epel-8-x86_64.cfg (unsurprisingly), but that
doesn't represent what happens on real CentOS 8 Stream builds. Use the
actual centos-stream-x86_64.cfg on that image instead.

Split the centos code into 7 and 8, leave 7 untouched, and update 8 to
do the same simplified installation of mock as the RHEL 8 branch does.

 * [x] image-refresh centos-8-stream
 * [x] Fix check-sosreport for sos 4: https://github.com/cockpit-project/cockpit/pull/15007