### PR TITLE
task: Query default branch via api

### DIFF
--- a/task/__init__.py
+++ b/task/__init__.py
@@ -45,6 +45,7 @@ __all__ = (
     "verbose",
     "stale",
     "redhat_network",
+    "default_branch",
     "PUBLIC_STORES",
     "REDHAT_STORES",
 )
@@ -440,13 +441,13 @@ def branch(context, message, pathspec=".", issue=None, branch=None, push=True, *
     return "{0}:{1}".format(user, branch)
 
 
-def pull(branch, body=None, issue=None, base="master", labels=['bot'], run_tests=True, **kwargs):
+def pull(branch, body=None, issue=None, base=None, labels=['bot'], run_tests=True, **kwargs):
     if "pull" in kwargs:
         return kwargs["pull"]
 
     data = {
         "head": branch,
-        "base": base,
+        "base": default_branch() if base is None else base,
         "maintainer_can_modify": True
     }
     if issue:
@@ -558,3 +559,12 @@ def redhat_network():
 
 
 redhat_network.result = None
+
+
+def default_branch():
+    '''Returns the default branch of a repository
+
+    The default branch should be used as a default base.
+    '''
+
+    return api.get()["default_branch"]

--- a/task/github.py
+++ b/task/github.py
@@ -169,14 +169,16 @@ class GitHub(object):
         if not self._url:
             if not self._base:
                 netloc = os.environ.get("GITHUB_API", "https://api.github.com")
-                self._base = "{0}/repos/{1}/".format(netloc, self.repo)
+                self._base = "{0}/repos/{1}".format(netloc, self.repo)
 
             self._url = urllib.parse.urlparse(self._base)
 
         return self._url
 
     def qualify(self, resource):
-        return urllib.parse.urljoin(self.url.path, resource)
+        if resource is None:
+            return self.url.path
+        return urllib.parse.urljoin("{0}/".format(self.url.path), resource)
 
     def request(self, method, resource, data="", headers=None):
         if headers is None:
@@ -236,7 +238,7 @@ class GitHub(object):
             "data": response.read().decode('utf-8')
         }
 
-    def get(self, resource):
+    def get(self, resource=None):
         headers = {}
         qualified = self.qualify(resource)
         cached = self.cache.read(qualified)

--- a/task/test-task
+++ b/task/test-task
@@ -35,6 +35,9 @@ os.environ["GITHUB_BASE"] = "project/repo"
 
 
 DATA = {
+    "/repos/project/repo": {
+        "default_branch": "main"
+    },
     "/repos/project/repo/issues/3333": {
         "title": "The issue title"
     },


### PR DESCRIPTION
This is a requirement to make pull requests created by scripts work with
different default branches.

----

`osbuild/image-builder-frontend` recently switched to `main` as a default branch and the `npm-update` workflow stopped working because it would try to create a PR against a branch which doesn't exist. With this patch it'll query the default branch from the api.