### PR TITLE
naughty: Add pattern for AVC denial for sosreport on rhel-8-3

### DIFF
--- a/naughty/rhel-8/1447-selinux-sos
+++ b/naughty/rhel-8/1447-selinux-sos
@@ -1,0 +1,1 @@
+type=1400 audit(*): avc:  denied  { getattr } * comm="systemd-tmpfile" path="/var/tmp/sos*/sosreport*/etc/security/opasswd


### PR DESCRIPTION
Known issue: #1447

Fixes denials as seen  [here](https://logs.cockpit-project.org/logs/pull-15007-20201204-171445-0e60c05b-rhel-8-3/log.html#132) or [here](https://logs.cockpit-project.org/logs/pull-15008-20201204-210427-64be6687-rhel-8-3/log.html#234)