### PR TITLE
testmap: enable rhel-8-4 testing for cockpit-composer

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -128,8 +128,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-32',
             'fedora-32/firefox',
             'fedora-33',
-            'rhel-8-3',
-            'rhel-8-3/firefox',
+            'rhel-8-4',
         ],
         'rhel-8': [
             'rhel-8-3',
@@ -137,6 +136,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
+            'rhel-8-3',
         ],
     },
     'candlepin/subscription-manager': {


### PR DESCRIPTION
cockpit-composer will now be releasing into rhel 8.4 so the 8.4 tests are now enabled. I will update the `rhel-8` branch tests to 8.4 once I release into the nightlies and update the branch. https://github.com/osbuild/cockpit-composer/pull/1189 shows a successful rhel-8-4 test run.

Also, what is the purpose of the `_manual` tests section? I was able to manually trigger the rhel-8-4 test even though it is not in the `_manual` tests section.