### PR TITLE
debian: install glib from experimental

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-a91ca3ed28ea390860b81affbf4ba9b44648090cba950bbe32d1ebcb2f90ca12.qcow2
+debian-testing-89c655c107f456cb92cc5a4fa74efa03b3cd0521f0ad6af1633d3150cdcf6235.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -92,9 +92,9 @@ if grep -q 'ID=debian' /etc/os-release; then
     # For debugging libvirt crashes
     DEBUG_PACKAGES="\
 libvirt0-dbgsym  \
-libglib2.0-0-dbgsym \
 "
     cat <<EOF | sudo tee /etc/apt/sources.list.d/dbgsym.list
+deb http://deb.debian.org/debian experimental main
 deb http://debug.mirrors.debian.org/debian-debug/ ${RELEASE}-debug main
 EOF
 fi
@@ -144,6 +144,9 @@ fi
 mkdir -p /run/systemd/system
 ln -s /dev/null /run/systemd/system/rtslib-fb-targetctl.service
 systemctl daemon-reload
+
+# get experimental glib
+$APT install libglib2.0-0/experimental libglib2.0-bin/experimental libglib2.0-dev/experimental
 
 # upgrade the system
 $APT dist-upgrade


### PR DESCRIPTION
This is a hack, just to get an image that we can use to test a PR with.

 * [x] image-refresh debian-testing