### PR TITLE
testmap: Build Fedora CoreOS packages on fedora-33

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -160,7 +160,7 @@ REPO_BRANCH_CONTEXT = {
 # The OSTree variants can't build their own packages, so we build in
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
-    "fedora-coreos": "fedora-32",
+    "fedora-coreos": "fedora-33",
     "rhel-atomic": "rhel-7-9",
 }
 


### PR DESCRIPTION
Current FCOS image is based on Fedora 33 now.

 - [x] Bump cockpit/ws and cockpit/bastion containers to Fedora 33: https://github.com/cockpit-project/cockpit/pull/15072
 - [x] Refresh cockpit/ws container on dockerhub:
 - [x] Refresh fedora-coreos image to pick up F33 based cockpit/ws container: PR #1501