### PR TITLE
images: Fix long fedora-coreos boot times

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-9a2b8f7e1787daea5d2c7f38589074c3a30b3e6d2593dfeb0f5ecab73b706048.qcow2
+fedora-coreos-753900c1c7646eafa834d34457ebb63b1f656a0ecf045c367f12585bf93b0ae2.qcow2

--- a/images/scripts/lib/cockpit-ci.fcc
+++ b/images/scripts/lib/cockpit-ci.fcc
@@ -30,16 +30,16 @@ storage:
           # Enable it.
           # This file must sort before 04-disable-passwords.conf.
           PasswordAuthentication yes
-    # don't hang/fail on non-existing DHCP on eth1 on boot
+    # don't hang/fail on non-existing DHCP on ens15 (second interface for mcast) on boot
     # similar to images/scripts/network-ifcfg-eth1 for Fedora/RHEL images
-    - path: /etc/NetworkManager/system-connections/eth1.nmconnection
+    - path: /etc/NetworkManager/system-connections/mcast1.nmconnection
       mode: 0600
       contents:
         inline: |
           [connection]
-          id=eth1
+          id=mcast1
           type=ethernet
-          interface-name=eth1
+          interface-name=ens15
 
           [ipv4]
           method=disabled

--- a/images/scripts/lib/cockpit-ci.ign
+++ b/images/scripts/lib/cockpit-ci.ign
@@ -34,9 +34,9 @@
         "mode": 420
       },
       {
-        "path": "/etc/NetworkManager/system-connections/eth1.nmconnection",
+        "path": "/etc/NetworkManager/system-connections/mcast1.nmconnection",
         "contents": {
-          "source": "data:,%5Bconnection%5D%0Aid%3Deth1%0Atype%3Dethernet%0Ainterface-name%3Deth1%0A%0A%5Bipv4%5D%0Amethod%3Ddisabled%0A%0A%5Bipv6%5D%0Amethod%3Dignore%0A"
+          "source": "data:,%5Bconnection%5D%0Aid%3Dmcast1%0Atype%3Dethernet%0Ainterface-name%3Dens15%0A%0A%5Bipv4%5D%0Amethod%3Ddisabled%0A%0A%5Bipv6%5D%0Amethod%3Dignore%0A"
         },
         "mode": 384
       }


### PR DESCRIPTION
The current image uses persistent network names, so our previous
eth1.nmconnection was not matching any more, and boot hanged for 90s for
NetworkManager-wait-online. Adjust the matched interface name, and name
the connection more neutrally as "mcast1" (as that's the purpose of that
second interface).

 * [x] image-refresh fedora-coreos