### PR TITLE
po-refresh: Don't fail when nothing to update

### DIFF
--- a/po-refresh
+++ b/po-refresh
@@ -180,6 +180,10 @@ def run(context, verbose=False, **kwargs):
         task.push_branch(user, local_branch)
         branch = "{0}:{1}".format(user, local_branch)
 
+    if not branch:
+        # Nothing to update
+        return
+
     # Create a pull request from these changes
     pull = task.pull(branch, labels=['bot', 'no-test', 'release-blocker'], run_tests=False, **kwargs)
 

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -460,13 +460,7 @@ def pull(branch, body=None, issue=None, base=None, labels=['bot'], run_tests=Tru
         if body:
             data["body"] = body
 
-    pull = api.post("pulls", data, accept=[422])
-
-    # If we were refused to grant maintainer_can_modify, then try without
-    if "errors" in pull:
-        if pull["errors"][0]["field"] == "fork_collab":
-            data["maintainer_can_modify"] = False
-        pull = api.post("pulls", data)
+    pull = api.post("pulls", data)
 
     # Update the pull request
     label(pull, labels)


### PR DESCRIPTION
There are 3 cases we need to count with:
1. Some language was added/dropped
2. No language was added/dropped but some language was updated
3. Some language was added/dropped and some language was updated

All of these are handled correctly. However there is special case that
nothing was added/dropped nor there is nothing to update. In this case
it would fail, as `branch` would be `None` and when we would try to
create pull request we would get error message:
```
{'message': "Invalid request.\n\nFor 'properties/head', nil is not a string.", 'documentation_url': 'https://docs.github.com/rest/reference/pulls#create-a-pull-request'}
```
and we would try to get `number` property from this.

This was broken in 234053cfc4. (See the `if branch/elif local_branch)

Fixes broken po refresh in c-podman: https://github.com/cockpit-project/cockpit-podman/actions/runs/461677922