### PR TITLE
testmap: Declare cockpit rhel-8-4-distropkg test

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -59,7 +59,7 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'fedora-testing',
             'fedora-testing/dnf-copr',
-            'rhel-8-3-distropkg',
+            'rhel-8-4-distropkg',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
Drop the manual rhel-8-3-distropkg, as it's already a part of the master
tests.