### PR TITLE
testmap: Automatically run cockpit-podman/ubuntu-stable

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -87,12 +87,11 @@ REPO_BRANCH_CONTEXT = {
             'fedora-32/rawhide',
             'fedora-33',
             'debian-testing',
+            'ubuntu-stable',
         ],
         '_manual': [
             'centos-8-stream',
             'fedora-33/rawhide',
-            # runs in Travis
-            'ubuntu-stable',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
We can't run anything on Travis any more with the free plan, so run
ubuntu-stable tests on our infra instead.