### PR TITLE
images: Apply crypttab workaround to rhel-8-4-distropkg

### DIFF
--- a/images/scripts/rhel-8-4-distropkg.install
+++ b/images/scripts/rhel-8-4-distropkg.install
@@ -3,3 +3,6 @@
 set -e
 
 /var/lib/testvm/fedora.install --rhel "$@"
+
+# HACK: missing /etc/crypttab file upsets storage page: https://github.com/cockpit-project/cockpit/issues/15100
+touch /etc/crypttab


### PR DESCRIPTION
Commit ca7ef1fba0a which introduced rhel-8-4-distropkg landed in
parallel with commit e61562e3ad6d9d which moved the rhel-8-4 image to a
cloud image. The latter introduced a workaround which was missing in
thhe -distropkg version.