### PR TITLE
Show top reasons tests failed unexpectedly

### DIFF
--- a/generate-stats
+++ b/generate-stats
@@ -17,12 +17,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import re
 import sys
 import time
 import sqlite3
 import argparse
 import logging
 import json
+from collections import Counter
 
 # Seconds in two weeks
 TWO_WEEKS = 1209600
@@ -99,6 +101,34 @@ def main():
 
     # Sort tables
     all_tables = sorted(all_tables, key=lambda x: x["data"][0][1], reverse=True)
+
+    # Select unexpected messages
+    messages = cursor.execute("""\
+            SELECT retry_reason, TestRuns.url
+            FROM Failures
+            JOIN TestRuns ON Failures.run = TestRuns.id
+            WHERE TestRuns.time > ? AND
+                retry_reason IS NOT null AND
+                retry_reason IS NOT 'be robust against unstable tests' AND
+                retry_reason IS NOT 'due to failure of test harness or framework';""", (since,)).fetchall()
+
+    messages = [m for m in messages if m[0] is not None]
+    # Replace any numbers > 100 with 0 (usually time stamps or PIDs)
+    messages = [(re.sub(r'\d\d[\d\.]+', '0', m[0]), m[1]) for m in messages]
+
+    # Replace any partial paths like dracut.xf8hG with dracut.xxx
+    messages = [(re.sub(r'(/[^/ \t]{3,}\.)[^/ \t]+', r'\1xxx', m[0]), m[1]) for m in messages]
+
+    data = []
+    for c in Counter([m[0] for m in messages]).most_common():
+        if (c[1] > 1):  # Don't show message that happened just once
+            logs = [m[1] for m in messages if m[0] == c[0]][:2]
+            data.append([c[0], c[1], logs])
+
+    if data:
+        all_tables.insert(0, {"name": "Unexpected messages",
+                              "columns": ["Message", "Count", "Logs"],
+                              "data": data})
 
     print("const tables = {0};".format(json.dumps(all_tables)))
 

--- a/store-failures
+++ b/store-failures
@@ -138,6 +138,11 @@ def find_failed_tests(fp):
             save_message = False
             continue
 
+        # If the issue is known, don't save unexpected messages
+        if line.startswith("ok ") and "SKIP Known issue" in line:
+            save_message = False
+            last_msg = ""
+
         if "FAIL: Test completed, but found unexpected" in line and "raise" not in line:
             save_message = True
 


### PR DESCRIPTION
Adds a new table that looks like this:
![unexpectedmessages](https://user-images.githubusercontent.com/12330670/105018581-78270b00-5a45-11eb-8bfe-3ddc30bc4e4f.png)

These data are currently (and for the next  two weeks won't be usable) due the bug that is being in the second commit.
The second commit I tested as:
```
diff --git store-failures store-failures
index eb88bfe6b..58623ae00 100755
--- store-failures
+++ store-failures
@@ -92,9 +92,7 @@ def main():
 
         with urllib.request.urlopen(raw_log, context=ctx if "logs.cockpit-project.org" in raw_log else None) as fp:
             for (testname, retry_reason) in find_failed_tests(fp):
-                if run_id is None:
-                    run_id = insert_run(cursor, repo, opts.revision, context, url, time)
-                insert_failure(cursor, run_id, testname, retry_reason)
+                print("{0} {1} {2}".format(context, testname, retry_reason))
```
and then running `./store-failures 4113c0923fc98acbbf623b455649735a6fdf5926` and `./store-failures 572864529c9c19fdf9a5627304d63343ff728f4d` both with the new fix and without. One confirms that it does not save known issues and the other one that it still saves unexpected messages on real failures.

The tables, as I said, is unreliable, but there are definitely some messages we should take a look at.