### PR TITLE
Enable picking number of days for stats to be shown

### DIFF
--- a/generate-stats
+++ b/generate-stats
@@ -69,6 +69,9 @@ def main():
             links.append(urls[1][0])
         top10.append([row[0], row[1], links])
 
+    if not top10:
+        top10.append(["No failures in the last {0} days".format(opts.days), 0, []])
+
     all_tables.append({"name": "Top failures", "columns": ["Test name", "Count", "Logs"], "data": top10})
 
     # Get failures by OS

--- a/generate-stats
+++ b/generate-stats
@@ -26,13 +26,15 @@ import logging
 import json
 from collections import Counter
 
-# Seconds in two weeks
-TWO_WEEKS = 1209600
+# Seconds in a day
+DAY = 86400
 
 
 def main():
     parser = argparse.ArgumentParser(description='Generate statistics about failed tests')
     parser.add_argument("--db", default="cockpit-failures.db", help="Database name")
+    parser.add_argument("--days", default=14, type=int,
+                        help="Number of days to take statistics from. Default is %(default)s.")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     opts = parser.parse_args()
 
@@ -43,7 +45,7 @@ def main():
     cursor = db_conn.cursor()
 
     all_tables = []
-    since = time.time() - TWO_WEEKS
+    since = time.time() - opts.days * DAY
 
     # Get all failures sorted by number of occurrences
     top10 = []


### PR DESCRIPTION
If you want to see how many failures there has been in the last 3 days you can just simply do:
```
wget --no-check-certificate https://images-frontdoor.apps.ocp.ci.centos.org/test-failures.db
./generate-stats --db test-failures.db --days 3 > failure-stats.js
firefox failure-stats.html
```