### PR TITLE
image-trigger: Drop image-prune

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -41,8 +41,6 @@ REFRESH = {
 import argparse
 import os
 import sys
-import tempfile
-import time
 import subprocess
 
 sys.dont_write_bytecode = True
@@ -60,33 +58,12 @@ def main():
     api = github.GitHub()
 
     try:
-        results = scan(api, opts.image, opts.verbose)
+        scan(api, opts.image, opts.verbose)
     except RuntimeError as ex:
         sys.stderr.write("image-trigger: " + str(ex) + "\n")
         return 1
 
-    for result in results:
-        if result:
-            sys.stdout.write(result + "\n")
-
     return 0
-
-# Prepare an image prune command
-
-
-def scan_for_prune():
-    tasks = []
-    stamp = os.path.join(tempfile.gettempdir(), "cockpit-image-prune.stamp")
-
-    # Don't prune more than once per hour
-    try:
-        mtime = os.stat(stamp).st_mtime
-    except OSError:
-        mtime = 0
-    if mtime < time.time() - 3600:
-        tasks.append("PRIORITY=0000 touch {0} && ./image-prune".format(stamp))
-
-    return tasks
 
 
 def scan(api, force, verbose):
@@ -104,8 +81,6 @@ def scan(api, force, verbose):
             text = "Image refresh for {0}".format(image)
             issue = task.issue(text, text, "image-refresh", image)
             sys.stderr.write("#{0}: image-refresh {1}\n".format(issue["number"], image))
-
-    return scan_for_prune()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We moved image-trigger to a GitHub workflow in commit 25d733ed6b, so
calling image-prune there is not nearly enough any more to regularly run
it on all running bots.

It was moved to cockpit-tasks in
https://github.com/cockpit-project/cockpituous/pull/366