### PR TITLE
testmap: Run starter-kit tests on fedora-33

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -55,7 +55,7 @@ REPO_BRANCH_CONTEXT = {
     },
     'cockpit-project/starter-kit': {
         'master': [
-            'fedora-32',
+            'fedora-33',
             'centos-8-stream',
         ],
         '_manual': [


### PR DESCRIPTION
We ran out of free Travis credits a while ago, so let's run it on our
CI instead.