### PR TITLE
Use SHA instead of `pull/N/head` for checking out PRs

### DIFF
--- a/image-prune
+++ b/image-prune
@@ -74,7 +74,7 @@ def get_refs(open_pull_requests=True, offline=False):
             if images:
                 sha = p["head"]["sha"]
                 considerable[sha] = images
-                subprocess.call(["git", "fetch", "origin", "pull/{0}/head".format(p["number"])])
+                subprocess.call(["git", "fetch", "origin", "{0}".format(sha)])
                 refs["pull request #{} ({})".format(p["number"], p["title"])] = sha
 
     git_cmd = "show-ref" if offline else "ls-remote"

--- a/task/github.py
+++ b/task/github.py
@@ -371,6 +371,12 @@ class GitHub(object):
                 yield commit
                 count += 1
 
+    def getHead(self, pr):
+        pull = self.get("pulls/{0}".format(pr))
+        if pull:
+            return pull.get("head", {}).get("sha")
+        return None
+
     def allowlist(self):
         # bots and organizations which are allowed to use our CI (these use branches within the main repo for PRs)
         users = {"github-actions[bot]", "candlepin", "cockpit-project"}

--- a/tests-scan
+++ b/tests-scan
@@ -386,7 +386,8 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
                 project = "/".join(repo_branch[:2])
                 branch = repo_branch[2]
 
-            ref = "pull/%d/head" % number
+            # Note: Don't use `pull/<pr_number>/head` as it may point to an old revision
+            ref = revision
 
             # For unmarked and untested status, user must be allowed
             # Not this only applies to this specific commit. A new status
@@ -410,7 +411,9 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
                     bots_ref = None if repo == project else ref
                 else:
                     if bots_pr:
-                        bots_ref = "pull/%d/head" % bots_pr
+                        # Note: Don't use `pull/<pr_number>/head` as it may point to an old revision
+                        bots_api = github.GitHub(repo="cockpit-project/bots")
+                        bots_ref = bots_api.getHead(bots_pr) or "xxx"  # Make sure we fail when cannot get the head
                     else:
                         bots_ref = "master"
 


### PR DESCRIPTION
Github has a bug, when `pull/N/head` can get out of sync and point to some
older revision. Using `get fetch origin SHA` works fine.