### PR TITLE
testmap: Add subscription-manager rhel-8-4 tests

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -140,9 +140,9 @@ REPO_BRANCH_CONTEXT = {
     'candlepin/subscription-manager': {
         'master': [
             'rhel-8-3',
+            'rhel-8-4',
         ],
         '_manual': [
-            'rhel-8-4',
         ],
     },
     'skobyda/cockpit-certificates': {


### PR DESCRIPTION
Tests got fixed in https://github.com/candlepin/subscription-manager/pull/2408