### PR TITLE
testmap: Update cockpit-composer rhel-8 branch tests

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -129,8 +129,8 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-4',
         ],
         'rhel-8': [
-            'rhel-8-3',
-            'rhel-8-3/firefox',
+            'rhel-8-4',
+            'rhel-8-4/firefox',
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [


### PR DESCRIPTION
rhel-8 branch has been reset to master tag 28, which is the 2nd rhel 8.4 release, test should be update to rhel-8-4 and rhel-8-4/firefox