### PR TITLE
Fix npm-update for patternfly

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -25,7 +25,11 @@
 # Dependencies where minor updates break, only bump microversion
 FRAGILE = [
     "jquery",
-    "patternfly",
+]
+
+# Dependencies which have to be updated in lockstep, not individually
+GROUP = [
+    "@patternfly"
 ]
 
 import collections
@@ -107,8 +111,17 @@ def run(specified_package, verbose=False, **kwargs):
             return "^" + version
         return "~" + version
 
+    group = None
+
     for package in packages:
         if package in pending_updates:
+            continue
+
+        # once we updated the first member of a group, only consider other group members
+        if group and group not in package:
+            if task.verbose:
+                sys.stderr.write("Ignoring '{0}' as it does not belong to current update group {1}\n"
+                                 .format(package, group))
             continue
 
         orig_version = orig_package_json["dependencies"][package]
@@ -126,12 +139,25 @@ def run(specified_package, verbose=False, **kwargs):
         new_version = package_json()["dependencies"][package].lstrip("^~")
 
         if new_version != orig_version:
-
             # Write out the original package.json with the updated version
             package_json(orig_package_json, package, new_version)
             updated_packages.append(package)
-            # only update one dep, so that updates can be tested one by one
-            break
+
+            # part of a group?
+            if not group:
+                for g in GROUP:
+                    if g in package:
+                        group = g
+                        if task.verbose:
+                            sys.stderr.write("Updated package '{0}' is in group {1}\n".format(package, group))
+                        break
+
+            if group:
+                # run the next iteration to the updated package.json
+                orig_package_json = package_json()
+            else:
+                # only update one dep, so that updates can be tested one by one
+                break
 
     if updated_packages and not kwargs["dry"]:
         # Create a pull request from these changes

--- a/npm-update
+++ b/npm-update
@@ -74,17 +74,19 @@ def output(*args):
 
 
 def run(specified_package, verbose=False, **kwargs):
-    api = task.github.GitHub()
-
-    # List pending updates
     pending_updates = []
-    for issue in api.issues(state="open"):
-        title = issue["title"]
-        if title.startswith("package.json: Update "):
-            package = title.split(" ")[2]
-            pending_updates.append(package)
-            if task.verbose:
-                sys.stderr.write("Ignoring '{0}' as there is pending PR #{1}\n".format(package, issue["number"]))
+
+    if not kwargs["dry"]:
+        api = task.github.GitHub()
+
+        # List pending updates
+        for issue in api.issues(state="open"):
+            title = issue["title"]
+            if title.startswith("package.json: Update "):
+                package = title.split(" ")[2]
+                pending_updates.append(package)
+                if task.verbose:
+                    sys.stderr.write("Ignoring '{0}' as there is pending PR #{1}\n".format(package, issue["number"]))
 
     # Force all current dependencies in place
     execute("npm", "install")

--- a/npm-update
+++ b/npm-update
@@ -27,7 +27,6 @@
 FRAGILE = [
     "jquery",
     "patternfly",
-    "@novnc/novnc",  # See cockpit/cockpit#14356
 ]
 
 import collections

--- a/npm-update
+++ b/npm-update
@@ -75,6 +75,7 @@ def output(*args):
 
 def run(specified_package, verbose=False, **kwargs):
     pending_updates = []
+    updated_packages = []
 
     if not kwargs["dry"]:
         api = task.github.GitHub()
@@ -128,27 +129,25 @@ def run(specified_package, verbose=False, **kwargs):
 
             # Write out the original package.json with the updated version
             package_json(orig_package_json, package, new_version)
-            if not kwargs["dry"]:
-                # Create a pull request from these changes
-                title = "package.json: Update {0} package dependency".format(package)
-                branch = task.branch(package, title, pathspec="package.json", **kwargs)
+            updated_packages.append(package)
+            # only update one dep, so that updates can be tested one by one
+            break
 
-                # List of files that probably touch this package
-                lines = output("git", "grep", "-w", package)
-                comment = "Please manually check features related to these files:\n\n```\n{0}```".format(lines)
+    if updated_packages and not kwargs["dry"]:
+        # Create a pull request from these changes
+        title = "package.json: Update " + ', '.join(updated_packages)
+        branch = task.branch(updated_packages[0], title, pathspec="package.json", **kwargs)
 
-                if branch:
-                    kwargs["title"] = title
-                    pull = task.pull(branch, **kwargs)
+        # List of files that probably touch this package
+        lines = output("git", "grep", "-Ew", '|'.join(updated_packages))
+        comment = "Please manually check features related to these files:\n\n```\n{0}```".format(lines)
 
-                    task.comment(pull, comment)
-                    break
-            else:
-                # in dry mode, still only update one dep, so that updates can be tested one by one
-                break
+        kwargs["title"] = title
+        pull = task.pull(branch, **kwargs)
 
-    # Undo our changes
-    if not kwargs["dry"]:
+        task.comment(pull, comment)
+
+        # Undo our changes
         package_json(orig_package_json)
 
 

--- a/npm-update
+++ b/npm-update
@@ -22,8 +22,7 @@
 #  * [ ] npm-update patternfly
 #
 
-# Dependencies that are either fragile (minor updates break)
-# or are part of our public Javascript API and need caution
+# Dependencies where minor updates break, only bump microversion
 FRAGILE = [
     "jquery",
     "patternfly",


### PR DESCRIPTION
This avoids the repeated mess that we are getting with trying to update individual PF dependencies, like in https://github.com/cockpit-project/cockpit-podman/pull/661 or https://github.com/cockpit-project/cockpit/pull/15184 .

On current cockpit-podman I get:
```
$ bots/npm-update --dry -v
+ @patternfly/react-table@4.20.15
Updated package '@patternfly/react-table' is in group @patternfly
Ignoring 'docker-names' as it does not belong to current update group @patternfly

+ @patternfly/react-core@4.90.2
Ignoring 'xterm' as it does not belong to current update group @patternfly
Ignoring 'react' as it does not belong to current update group @patternfly
Ignoring 'react-dom' as it does not belong to current update group @patternfly
Ignoring 'prop-types' as it does not belong to current update group @patternfly
Ignoring 'moment' as it does not belong to current update group @patternfly
Ignoring 'react-scrollable-anchor' as it does not belong to current update group @patternfly

+ @patternfly/patternfly@4.80.3
Ignoring 'throttle-debounce' as it does not belong to current update group @patternfly

$ git diff
```
```diff
--- package.json
+++ package.json
@@ -48,9 +48,9 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.70.2",
-    "@patternfly/react-core": "4.84.4",
-    "@patternfly/react-table": "4.19.45",
+    "@patternfly/patternfly": "4.80.3",
+    "@patternfly/react-core": "4.90.2",
+    "@patternfly/react-table": "4.20.15",
     "docker-names": "1.1.1",
     "moment": "2.29.1",
     "prop-types": "15.7.2",
```

After committing that and a moment downgrade, I get

```
+ moment@2.29.1
```
and it updates only that.

I ran both on my fork without `--dry`, and you can see the results here:

- https://github.com/martinpitt/cockpit-podman/pull/4
- https://github.com/martinpitt/cockpit-podman/pull/6

I also ran it again when everything is current, and it is a successful no-op as expected.
