### PR TITLE
refresh for debian-testing

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-0f3600ac5729e1e760c8a15096a56fcc4b8d60f69d3868ab0195bf63892b04c8.qcow2
+debian-testing-43d6c8ee52633dfa747ec0abecfc65a9fdf90fb06b327e362982ccdecd119387.qcow2

--- a/naughty/debian-testing/1585-sbin-faillock-missing
+++ b/naughty/debian-testing/1585-sbin-faillock-missing
@@ -1,0 +1,3 @@
+*testTally*
+*
+bash: line 1: faillock: command not found


### PR DESCRIPTION
fixes the faillock stuff

Pushed a new one because

```
! [remote rejected] image-refresh-debian-testing-20210122-031212 -> image-refresh-debian-testing-20210122-031212 (permission denied)
```

 - [x] Fix/get https://github.com/cockpit-project/cockpit/pull/15217 approved and land in lockstep

See #1569