### PR TITLE
machine: fix shell quoting on m.execute()

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -22,6 +22,7 @@ import socket
 import subprocess
 import select
 import errno
+import shlex
 import sys
 import tempfile
 
@@ -247,7 +248,8 @@ class SSHConnection(object):
         Either specify @command or @script
 
         Arguments:
-            command: The string to execute by /bin/sh.
+            command: The string to execute by /bin/sh; or
+                     an argument list execute without shell interpretation
             script: A multi-line script to execute in /bin/sh
             input: Input to send to the command
             environment: Additional environment variables
@@ -291,7 +293,7 @@ class SSHConnection(object):
                 if not quiet:
                     self.message("+", command)
             else:
-                cmd += command
+                cmd.append(shlex.join(command))
                 if not quiet:
                     self.message("+", *command)
         else:


### PR DESCRIPTION
SSHConnection.execute() has existing support for passing the command as
a list instead of a string.  This seems like it might get a
subprocess-like interface for protecting you from the shell, but in
practice the list items are just passed as separate commandline
arguments to ssh, which will concatenate them and run them as a shell
command anyway.

Fix that by using shlex.join() to properly escape each string, and pass
the result as a single argument to ssh.

This behaviour was previously undocumented, so add it to the docstring.

 * [ ] cockpit-project/cockpit#15239