### PR TITLE
npm-update: Also count with group updates when parsing opened PRs

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -88,10 +88,11 @@ def run(specified_package, verbose=False, **kwargs):
         for issue in api.issues(state="open"):
             title = issue["title"]
             if title.startswith("package.json: Update "):
-                package = title.split(" ")[2]
-                pending_updates.append(package)
-                if task.verbose:
-                    sys.stderr.write("Ignoring '{0}' as there is pending PR #{1}\n".format(package, issue["number"]))
+                packages = title.split(" ", 2)[2]
+                for pkg in packages.split(", "):
+                    pending_updates.append(pkg)
+                    if task.verbose:
+                        sys.stderr.write("Ignoring '{0}' as there is pending PR #{1}\n".format(pkg, issue["number"]))
 
     # Force all current dependencies in place
     execute("npm", "install")


### PR DESCRIPTION
Group updates were introduced in b36a4020ac.
Now there is PR with title: (e.g. https://github.com/osbuild/cockpit-composer/pull/1225)
```
package.json: Update @patternfly/react-table, @patternfly/patternfly, @patternfly/react-icons
```
The current code would not ignore anything, as it parses just one
package and even that one has comma in it:
```
Ignoring '@patternfly/react-table,' as there is pending PR #1225
```

With this new change:
```
Ignoring '@patternfly/react-table' as there is pending PR #1225
Ignoring '@patternfly/patternfly' as there is pending PR #1225
Ignoring '@patternfly/react-icons' as there is pending PR #1225
```

Also checking it still works with just one package update: (https://github.com/cockpit-project/cockpit-podman/pull/664)
```
Ignoring 'xterm' as there is pending PR #664
```