### PR TITLE
Centralize ca.pem path and provide environment override

### DIFF
--- a/image-download
+++ b/image-download
@@ -46,7 +46,7 @@ import urllib.parse
 from machine.machine_core.constants import IMAGES_DIR
 from machine.machine_core.directories import get_images_data_dir
 
-from task import PUBLIC_STORES, REDHAT_STORES
+from task import PUBLIC_STORES, REDHAT_STORES, CA_PEM
 from task.testmap import get_test_image
 
 CONFIG = "~/.config/image-stores"
@@ -62,7 +62,6 @@ else:
 
 def find(name, stores, latest, quiet):
     found = []
-    ca = os.path.join(IMAGES_DIR, "files", "ca.pem")
 
     for store in stores:
         url = urllib.parse.urlparse(store)
@@ -78,7 +77,7 @@ def find(name, stores, latest, quiet):
             def curl(*args):
                 try:
                     cmd = ["curl"] + list(args) + ["--head", "--connect-timeout", "10", "--silent",
-                                                   "--fail", "--cacert", ca, source]
+                                                   "--fail", "--cacert", CA_PEM, source]
                     output = subprocess.check_output(cmd, universal_newlines=True)
                     found.append((cmd, output, store))
                     if not quiet:

--- a/image-upload
+++ b/image-upload
@@ -25,18 +25,17 @@ import subprocess
 import sys
 import urllib.parse
 
-from machine.machine_core.constants import BOTS_DIR, IMAGES_DIR
+from machine.machine_core.constants import IMAGES_DIR
 from machine.machine_core.directories import get_images_data_dir
 
-from task import api, PUBLIC_STORES, REDHAT_STORES
+from task import api, PUBLIC_STORES, REDHAT_STORES, CA_PEM
 
 
 def upload(store, source):
-    ca = os.path.join(BOTS_DIR, "images", "files", "ca.pem")
     url = urllib.parse.urlparse(store)
 
     # Start building the command
-    cmd = ["curl", "--progress-bar", "--cacert", ca, "--fail", "--upload-file", source]
+    cmd = ["curl", "--progress-bar", "--cacert", CA_PEM, "--fail", "--upload-file", source]
 
     def try_curl(cmd):
         print("Uploading to", cmd[-1])

--- a/images/debian-stable
+++ b/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-3c980dded056b236c65344110dc575f0fcc4bdc1cb81bcb815cc00af972106e0.qcow2
+debian-stable-e3045a3389bd1648d1e3477e5b8df03f74e4492ea23600fabf1d17bd7e69fbd8.qcow2

--- a/pr-tests
+++ b/pr-tests
@@ -21,12 +21,10 @@ import sys
 import urllib.request
 import ssl
 import json
-import os
 
-from machine.machine_core.constants import IMAGES_DIR
 import task
 
-logs_ssl_cockpit = ssl.create_default_context(cafile=os.path.join(IMAGES_DIR, "files", "ca.pem"))
+logs_ssl_cockpit = ssl.create_default_context(cafile=task.CA_PEM)
 
 
 def ssl_context_for(log_url):

--- a/store-failures
+++ b/store-failures
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import ssl
 import sys
 import sqlite3
@@ -28,8 +27,7 @@ import re
 
 from datetime import datetime
 
-from task import github
-from machine.machine_core.constants import IMAGES_DIR
+from task import github, CA_PEM
 
 # regexp for retry reason in a "not ok" line
 re_retry = re.compile(r"# RETRY .* \(([^)]+)\)")
@@ -46,9 +44,8 @@ def main():
     if opts.verbose:
         logging.basicConfig(level=logging.DEBUG)
 
-    ca = os.path.join(IMAGES_DIR, "files", "ca.pem")
     ctx = ssl.create_default_context()
-    ctx.load_verify_locations(cafile=ca)
+    ctx.load_verify_locations(cafile=CA_PEM)
 
     db_conn = sqlite3.connect(opts.db)
     cursor = db_conn.cursor()

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -31,7 +31,7 @@ import urllib.parse
 
 from . import github
 from . import sink
-from machine.machine_core.constants import BASE_DIR
+from machine.machine_core.constants import BASE_DIR, IMAGES_DIR
 
 
 __all__ = (
@@ -46,11 +46,15 @@ __all__ = (
     "stale",
     "redhat_network",
     "default_branch",
+    "CA_PEM",
     "PUBLIC_STORES",
     "REDHAT_STORES",
 )
 
 sys.dont_write_bytecode = True
+
+# Cockpit image/log server CA
+CA_PEM = os.getenv("COCKPIT_CA_PEM", os.path.join(IMAGES_DIR, "files", "ca.pem"))
 
 # Servers which have public images
 PUBLIC_STORES = [


### PR DESCRIPTION
This will make it easier to run bots with changed credentials, like in
https://github.com/cockpit-project/cockpituous/pull/373

 - [x] builds on top of PR #1614 
 * [x] image-refresh debian-stable

I manually tested all the modified scripts here. But once this is unblocked, I'll do an image refresh to at least self-validate image-{download,upload}