### PR TITLE
Stop using cockpituous forks

### DIFF
--- a/po-refresh
+++ b/po-refresh
@@ -172,12 +172,14 @@ def run(context, verbose=False, **kwargs):
     branch = task.branch(context, "po: Update from Fedora Weblate", pathspec="po/",
                          branch=local_branch, **kwargs)
 
+    api = github.GitHub()
+
     if local_branch and not branch:  # We only introduced/dropped language but otherwise no updates
         if kwargs["issue"]:
-            clean = "https://github.com/{0}".format(task.find_our_fork(user))
+            clean = "https://github.com/{0}".format(api.repo)
             task.comment_done(kwargs["issue"], "po-refresh", clean, local_branch, context)
 
-        task.push_branch(user, local_branch)
+        task.push_branch(local_branch)
         branch = "{0}:{1}".format(user, local_branch)
 
     if not branch:
@@ -188,7 +190,6 @@ def run(context, verbose=False, **kwargs):
     pull = task.pull(branch, labels=['bot', 'no-test', 'release-blocker'], run_tests=False, **kwargs)
 
     # Trigger this pull request
-    api = github.GitHub()
     head = pull["head"]["sha"]
 
     triggers = testmap.tests_for_po_refresh(api.repo)


### PR DESCRIPTION
The cockpituous forks of a project need to get set up manually, pile up
hundreds of stale branches over time, make it difficult to test changes
on  forks, and are an unnecessary part now.

starter-kit, cockpit-{podman,ostree,composer} don't use them at all any
more: they use po-refresh and npm-update with the default GitHub token
and push branches straight to origin. From there they get auto-deleted
when landing pull requests, which avoids piling up cruft.

Let's do the same for the remaining two forks for cockpit (npm-update
and po-refresh) and bots (image-refresh and naughty-prune) for
consistency and simplification . In `task.branch()`, drop the
opportunistic detection of a fork, and always push to origin. Eliminate
the now unnecessary `user` and `push_repo` arguments to `push_branch()`.

-----

 * [x] naughty-prune -- nothing to actually do.. but it uses the same code as image-refresh and npm-update.
 * [x] image-refresh ubuntu-2004 : correctly produced [branch on origin](https://github.com/cockpit-project/bots/commits/image-refresh-ubuntu-2004-20210201-184848)
 - [x] I ran `bots/npm-update` on my fork after committing a moment downgrade, and it produced https://github.com/martinpitt/cockpit/pull/8
 - [x] Run bots/po-refresh (accidentally on origin, not my fork), and it produced https://github.com/cockpit-project/cockpit/pull/15257 -- as expected with a branch on origin, not cockpituous.