### PR TITLE
task: Drop user from branch()/pull()

### DIFF
--- a/po-refresh
+++ b/po-refresh
@@ -69,7 +69,6 @@ def run(context, verbose=False, **kwargs):
     subprocess.check_call(cmd, cwd=work)
 
     local_branch = None
-    user = None
     current_manifest = None
     current_linguas = []
     language_map = {}
@@ -139,7 +138,7 @@ def run(context, verbose=False, **kwargs):
                 current_manifest["locales"].pop(locale[2])
             if current_linguas:
                 current_linguas.remove(locale[0])
-            (user, local_branch) = add_and_commit_lang(name, locale[0], "Drop").split(":")
+            local_branch = add_and_commit_lang(name, locale[0], "Drop").split(":")
 
     # HACK: Semicolon in some languages in 'Plural-Forms' header key can break translations
     # https://github.com/mikeedwards/po2json/issues/87
@@ -157,7 +156,7 @@ def run(context, verbose=False, **kwargs):
             if current_linguas:
                 current_linguas.append(locale[0])
                 current_linguas.sort()
-            (user, local_branch) = add_and_commit_lang(name, locale[0], "Add").split(":")
+            local_branch = add_and_commit_lang(name, locale[0], "Add").split(":")
 
     # Here we have logic to only include files that actually
     # changed translations, and reset all the remaining ones
@@ -180,7 +179,7 @@ def run(context, verbose=False, **kwargs):
             task.comment_done(kwargs["issue"], "po-refresh", clean, local_branch, context)
 
         task.push_branch(local_branch)
-        branch = "{0}:{1}".format(user, local_branch)
+        branch = local_branch
 
     if not branch:
         # Nothing to update

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -390,13 +390,12 @@ def branch(context, message, pathspec=".", issue=None, branch=None, push=True, *
         branch = "{0} {1} {2}".format(name, context or "", current).strip()
         branch = branch.replace(" ", "-").replace("--", "-")
 
-    # Tell git about our github token as a user name
+    # Tell git about our github token for authentication
     try:
         subprocess.check_call(["git", "config", "credential.https://github.com.username", api.token])
     except subprocess.CalledProcessError:
         raise RuntimeError("Couldn't configure git config with our API token")
 
-    user = api.repo.split('/')[0]
     clean = "https://github.com/{0}".format(api.repo)
 
     if pathspec is not None:
@@ -416,7 +415,7 @@ def branch(context, message, pathspec=".", issue=None, branch=None, push=True, *
     if issue and push:
         comment_done(issue, name, clean, branch, context)
 
-    return "{0}:{1}".format(user, branch)
+    return branch
 
 
 def pull(branch, body=None, issue=None, base=None, labels=['bot'], run_tests=True, **kwargs):
@@ -468,7 +467,6 @@ def pull(branch, body=None, issue=None, base=None, labels=['bot'], run_tests=Tru
         last_commit_m = execute("git", "show", "--no-patch", "--format=%B")
         last_commit_m += "Closes #" + str(pull["number"])
         execute("git", "commit", "--amend", "-m", last_commit_m)
-        branch = branch.split(":")[1]
         push_branch(branch, force=True)
 
         # Make sure we return the updated pull data

--- a/task/test-task
+++ b/task/test-task
@@ -170,7 +170,7 @@ class TestTask(unittest.TestCase):
     @patch('task.execute', mock_execute)
     def testPullBody(self):
         args = {"title": "Task title"}
-        pull = task.pull("user:branch", body="This is the body", **args)
+        pull = task.pull("branch", body="This is the body", **args)
         self.assertEqual(pull["title"], "Task title")
         self.assertEqual(pull["body"], "This is the body")
 


### PR DESCRIPTION
Commit 1b5a07419eb23e7 dropped using forks for our bots. After that, we
can simplify task.branch() to not parse and return the user name any
more, as it will always be the origin.

Most bots just directly pass the return value to task.pull(), adjust
that to not expect an "username:" prefix any more. po-refresh does some
more processing of the result, adjust that accordingly.