### PR TITLE
tests-scan: Use direct test trigger without --amqp

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -36,7 +36,8 @@ __all__ = (
     'Checklist',
     'TESTING',
     'NO_TESTING',
-    'NOT_TESTED'
+    'NOT_TESTED',
+    'NOT_TESTED_DIRECT',
 )
 
 TESTING = "Testing in progress"

--- a/tests-scan
+++ b/tests-scan
@@ -200,7 +200,7 @@ def queue_test(priority, name, number, revision, ref, context, base,
         logging.info("Published '{0}' on '{1}' with command: '{2}'".format(name, revision, command))
 
 
-def prioritize(status, title, labels, priority, context, number):
+def prioritize(status, title, labels, priority, context, number, direct):
     state = status.get("state", None)
     update = {"state": "pending"}
 
@@ -247,7 +247,7 @@ def prioritize(status, title, labels, priority, context, number):
             logging.info("Not updating status for '{0}' on #{1} because of low priority".format(context, number))
             update = None
         else:
-            update["description"] = github.NOT_TESTED
+            update["description"] = github.NOT_TESTED_DIRECT if direct else github.NOT_TESTED
 
     return [priority, update]
 
@@ -397,7 +397,10 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
                 priority = github.NO_TESTING
                 changes = {"description": github.NO_TESTING, "context": context, "state": "pending"}
             else:
-                (priority, changes) = prioritize(status, title, labels, baseline, context, number)
+                # with --amqp (as called from run-queue), trigger tests as NOT_TESTED, as they already get queued;
+                # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
+                # so that the webhook queues them
+                (priority, changes) = prioritize(status, title, labels, baseline, context, number, direct=not amqp)
             if not update or update_status(api, revision, context, status, changes):
                 checkout_ref = ref
                 if project != repo:


### PR DESCRIPTION
The primary way of calling tests-scan is through run-queue: This will
supply an --amqp server and queue the tests by itself. This uses status
`github.NOT_TESTED`, which run-queue will ignore (to avoid
triggering/queueing them again).

However, we also occasionally call tests-scan by hand, for examaple when
removing the no-test label from a PR. That does not really work, as the
tests will then never get into the queue. So far the workaround was to
run an additional `tests-trigger --force` on the PR. But we don't really
need this extra roundtrip -- when calling tests-scan without `--amqp`,
we *always* need something that flips the NO_TESTED to
NOT_TESTED_DIRECT, so tests-scan may just as well do that on its own.

This will also allow us to move test triggering from a webhook to a
workflow, as we plan to do for cockpit soon.