### PR TITLE
testmap: Add testmap injection

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -139,11 +139,6 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream',
         ]
     },
-    'cockpit-project/cockpituous': {
-        '_manual': [
-            'unit-tests',
-        ]
-    }
 }
 
 # The OSTree variants can't build their own packages, so we build in
@@ -200,7 +195,13 @@ def projects():
 
 def tests_for_project(project):
     """Return branch -> contexts map."""
-    return REPO_BRANCH_CONTEXT.get(project, {})
+    res = REPO_BRANCH_CONTEXT.get(project, {})
+    # allow bots/cockpituous integration tests to inject a new context
+    inject = os.getenv("COCKPIT_TESTMAP_INJECT")
+    if inject:
+        branch, context = inject.split('/', 1)
+        res.setdefault(branch, []).append(context)
+    return res
 
 
 def tests_for_image(image):


### PR DESCRIPTION
This is useful for cockpituous' self-tests so that they can use the same
tests-scan workflow as production [1], without having to play extra tricks
with tests-scan. That approach would not work at all for writing similar
integration self-tests for bots, as doing tests-trigger races with the
*real* bots (the bots repo has an issues webhook trigger, unlike
cockpituous).

This replaces the `_manual` trigger for cockpituous.

[1] https://github.com/cockpit-project/cockpituous/pull/376

 -  [x] get it to work with https://github.com/cockpit-project/cockpituous/pull/376