### PR TITLE
weather: Parse number of days as integer

### DIFF
--- a/tests.html
+++ b/tests.html
@@ -55,7 +55,7 @@
   <script>
     const DAY = 86400;
     const params = new URLSearchParams(window.location.search);
-    const days = params.get('days') || 14;
+    const days = Number(params.get('days') || 14);
     const test = params.get('test');
 
     const days_select = document.getElementById("days");


### PR DESCRIPTION
JS is amazing with dealing with this kind of situations:
```
> "5" +1
"51"

> "5" * 10
50
```

This manifested itself on the page - I was using `days` with just
multiplication and ti worked fine, but there is now also addition and it
does not behave as expected. Reproducible by changing number of days and
then limit lines in graphs disappear.