### PR TITLE
naughty: Add debian-testing pattern for podman commit API regression

### DIFF
--- a/naughty/debian-testing/1635-api-commit-HOME
+++ b/naughty/debian-testing/1635-api-commit-HOME
@@ -1,0 +1,1 @@
+> error: Failed to commit container *: CommitFailure: error resolving name "*": could not get either XDG_CONFIG_HOME or HOME: Internal Server Error


### PR DESCRIPTION
Known issue #1635
Downstream report: https://bugs.debian.org/981813