### PR TITLE
[no-test] images: Pre-install podman on Debian/Ubuntu images

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-43d6c8ee52633dfa747ec0abecfc65a9fdf90fb06b327e362982ccdecd119387.qcow2
+debian-testing-2aef0df619856bebc46165115c385e94a7fcec37023fb2a523c571e39e34fd96.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -59,6 +59,7 @@ ltrace \
 iproute2 \
 mdadm \
 nfs-server \
+podman \
 qemu-kvm \
 socat \
 systemd-coredump \
@@ -82,10 +83,17 @@ case "$RELEASE" in
     buster)
         # timesyncd got split out in Ubuntu 20.04 and Debian 11
         TEST_PACKAGES="${TEST_PACKAGES/systemd-timesyncd /}"
+        # no podman package yet
+        TEST_PACKAGES="${TEST_PACKAGES/podman /}"
         ;;
     bullseye)
         # freeipa got dropped from testing: https://tracker.debian.org/pkg/freeipa
         IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
+        ;;
+    focal)
+        # no podman package yet
+        TEST_PACKAGES="${TEST_PACKAGES/podman /}"
+        ;;
 esac
 
 if grep -q 'ID=debian' /etc/os-release; then

--- a/images/ubuntu-stable
+++ b/images/ubuntu-stable
@@ -1,1 +1,1 @@
-ubuntu-stable-ed4f1772750fa13723ace12df426fcc2dbb5f657e5827a6dacb75a9453841ef5.qcow2
+ubuntu-stable-4a58e2a79b03d4b27ddc2d8cd9c6836b68adf2e8b59fe9dd358d3f1cfd933cb6.qcow2


### PR DESCRIPTION
The Fedora images already had podman pre-installed for a long time. This
will allow us to test cockpit-podman more robustly.

----

Motivated by https://github.com/cockpit-project/bots/pull/1636 and https://github.com/cockpit-project/bots/pull/1633 .

 * [x] image-refresh debian-testing
 * [x] image-refresh ubuntu-stable