### PR TITLE
machine: Avoid shlex.join()

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -293,7 +293,8 @@ class SSHConnection(object):
                 if not quiet:
                     self.message("+", command)
             else:
-                cmd.append(shlex.join(command))
+                # use shlex.join() once Python 3.8 is available everywhere
+                cmd.append(' '.join(shlex.quote(arg) for arg in command))
                 if not quiet:
                     self.message("+", *command)
         else:


### PR DESCRIPTION
Commit 13eff0d5743b introduced that to properly handle argvs. However,
`shlex.join()` only exists since Python 3.8, and thus not yet in
RHEL/CentOS 8.

Replace with the official definition of the join function.
`shlex.quote()` has existed since Python 3.3, and thus is safe to use.

 - [x] unbreak cockpit master tests: https://github.com/cockpit-project/cockpit/pull/15285