### PR TITLE
images: Drop ubuntu-stable hardcoded version

### DIFF
--- a/images/scripts/ubuntu-stable.bootstrap
+++ b/images/scripts/ubuntu-stable.bootstrap
@@ -15,7 +15,4 @@ fi
 # release name is the last part of the URL
 rel=${rel##*/}
 
-# Pin release to 20.10 (groovy) development series while the current stable is 20.04 LTS, as we have a separate image for that (ubuntu-2004)
-rel=groovy
-
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "https://cloud-images.ubuntu.com/daily/server/$rel/current/$rel-server-cloudimg-amd64.img"


### PR DESCRIPTION
Ubuntu 20.10 ("groovy") has been stable for several months, so drop the
hardcoding. Once 21.04 releases, ubuntu-stable will then once again move
to it automatically, as intended.