### PR TITLE
task: Use new DNS entry for internal image server

### DIFF
--- a/task/__init__.py
+++ b/task/__init__.py
@@ -66,7 +66,7 @@ PUBLIC_STORES = [
 REDHAT_STORES = [
     "https://cockpit-11.e2e.bos.redhat.com:8493",
     # fallback RedHat-internal image server in AWS (internal VPN only)
-    "https://10.29.162.239:8493/",
+    "https://internal-images.cockpit-project.org:8493/",
 ]
 
 api = github.GitHub()


### PR DESCRIPTION
This will make it easier to redeploy the AWS instance and move the IPs
around.

---

For those of you who are inside the Red Hat VPN, https://internal-images.cockpit-project.org:8493/ works fine now.