### PR TITLE
Fix npm-update for grouped modules

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -159,6 +159,9 @@ def run(specified_package, verbose=False, **kwargs):
             else:
                 # only update one dep, so that updates can be tested one by one
                 break
+        else:
+            # if the version was not updated revert package.json changes
+            package_json(orig_package_json, package, orig_version)
 
     if updated_packages and not kwargs["dry"]:
         # Create a pull request from these changes


### PR DESCRIPTION
@patternfly is a group and all modules inside that group should be
updated within the same PR

There was an issue with the following scenario:
    "@patternfly/patternfly": "4.80.3" <- this does not have an update
    "@patternfly/react-console": "4.2.18" <- this can update to 4.2.19

In the first iteration "@patternfly/patternfly" module is checked.
The `package.json` gets updated to contain @patternfly/patternfly: "^4.80.3",
the script does not find update and moves to the second iteration.

In the second iteration @patternfly/react-console package is checked.
The package.json gets updated to @patternfly/react-console: "^4.2.18",
the script *does* find the update, so the new package.json has
@patternfly/react-console: "4.2.19".
Now the `group` is updated to "@patternfly" and the `orig_package_json` get's
set to the updated `package.json`.

The updated `package.json` however contains the @patternfly/patternfly: "^4.80.3"
from the first iteration, which we don't want to include in the update.

This commit fixes this scenario, by making sure that package.json does
not ever contain "^~" symbols.