### PR TITLE
DONTMERGE debug cockpituous test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
           repository: cockpit-project/cockpituous
           path: cockpituous
 
+      - uses: mxschmitt/action-tmate@v3
+
       - name: Test local CI deployment
         if: steps.changes.outputs.changed
         run: |

--- a/npm-update
+++ b/npm-update
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pwned
 
 # This file is part of Cockpit.
 #


### PR DESCRIPTION
Test [fails repeatedly](https://github.com/cockpit-project/bots/pull/1660/checks?check_run_id=1871579295) with

    curl: (35) error:0407008A:rsa routines:RSA_padding_check_PKCS1_type_1:invalid padding

in the image-upload test, even though the explicit curl succeeded. I
have serious trouble reproducing this locally, debugging on the gh
machine.