### PR TITLE
make-checkout: Fix cleanup failure on non-writable subdirectories

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -30,7 +30,11 @@ REF="$1"
 REV=${2:-"FETCH_HEAD"}
 
 TARGET_DIR="make-checkout-workdir"
-rm -rf "$TARGET_DIR"
+# avoid failures with non-writable subdirectories
+if [ -e "$TARGET_DIR" ]; then
+    chmod -R u+w "$TARGET_DIR"
+    rm -rf "$TARGET_DIR"
+fi
 
 git clone "https://github.com/$REPO" "$TARGET_DIR"
 cd "$TARGET_DIR"


### PR DESCRIPTION
If `$TARGET_DIR` contains any read-only directories, then `rm -rf` will
silently ignore them, but eventually fail with

    rm: cannot remove 'make-checkout-workdir': Directory not empty

Avoid that by ensuring all files are writable first.

----

Spotted [here](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-15315-20210211-101034-fce8fdf9-debian-stable/log.html)