### PR TITLE
Image refresh for debian-testing

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-2aef0df619856bebc46165115c385e94a7fcec37023fb2a523c571e39e34fd96.qcow2
+debian-testing-5dacff95c7d497af389d8204d436acf121bae7faf541f794cf8c384fc4917cd4.qcow2

--- a/naughty/debian-testing/1585-sbin-faillock-missing
+++ b/naughty/debian-testing/1585-sbin-faillock-missing
@@ -1,3 +1,0 @@
-*testTally*
-*
-bash: line 1: faillock: command not found


### PR DESCRIPTION
Image refresh for debian-testing
 * [x] image-refresh debian-testing
 * [x] Fix `TestLogin.testTally` on debian-testing: https://github.com/cockpit-project/cockpit/pull/15323
 * [x] Blocked on https://github.com/cockpit-project/cockpit-podman/pull/675 