### PR TITLE
naughty: Close 1442: kdump doesn't reboot successfully after crash

### DIFF
--- a/naughty/rhel-8/1442-kdump-failed-reboot
+++ b/naughty/rhel-8/1442-kdump-failed-reboot
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "/usr/lib64/python3.9/unittest/case.py", line *, in _callTestMethod
-    method()
-  File "test/verify/check-kdump", line *, in testBasic
-    m.wait_boot(timeout_sec=300)
-  File "ssh_connection.py", line *, in wait_boot
-    raise exceptions.Failure("Unable to reach machine {0} via ssh: {1}:{2}".format(


### PR DESCRIPTION
Known issue which has not occurred in 25 days

kdump doesn't reboot successfully after crash

Fixes #1442