### PR TITLE
Add publish-queue, add inspect-queue --secrets-dir

### DIFF
--- a/inspect-queue
+++ b/inspect-queue
@@ -27,7 +27,7 @@ from task import distributed_queue
 
 def main():
     parser = argparse.ArgumentParser(description='Read and print messages from the queue without acknowleding them')
-    parser.add_argument('--amqp', default='localhost:5671',
+    parser.add_argument('--amqp', default=distributed_queue.DEFAULT_AMQP_SERVER,
                         help='The host:port of the AMQP server to consume from (default: %(default)s)')
     parser.add_argument('--secrets-dir', default=distributed_queue.DEFAULT_SECRETS_DIR,
                         help='Directory with ca.pem and amqp-client.{pem,key} (default: %(default)s)')

--- a/inspect-queue
+++ b/inspect-queue
@@ -29,9 +29,12 @@ def main():
     parser = argparse.ArgumentParser(description='Read and print messages from the queue without acknowleding them')
     parser.add_argument('--amqp', default='localhost:5671',
                         help='The host:port of the AMQP server to consume from (default: %(default)s)')
+    parser.add_argument('--secrets-dir', default=distributed_queue.DEFAULT_SECRETS_DIR,
+                        help='Directory with ca.pem and amqp-client.{pem,key} (default: %(default)s)')
     opts = parser.parse_args()
 
-    with distributed_queue.DistributedQueue(opts.amqp, ['public', 'rhel', 'statistics'], passive=True) as q:
+    with distributed_queue.DistributedQueue(opts.amqp, ['public', 'rhel', 'statistics'],
+                                            secrets_dir=opts.secrets_dir, passive=True) as q:
         def print_queue(queue):
             if q.declare_results[queue] is None:
                 print("queue {} does not exist".format(queue))

--- a/publish-queue
+++ b/publish-queue
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import sys
+
+import pika
+
+from task import distributed_queue
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Publish a command (read from stdin) to an AMQP task queue')
+    parser.add_argument('-q', '--queue', required=True,
+                        help='Queue name where to submit the command')
+    parser.add_argument('--amqp', default=distributed_queue.DEFAULT_AMQP_SERVER,
+                        help='The host:port of the AMQP server to consume from (default: %(default)s)')
+    parser.add_argument('--secrets-dir', default=distributed_queue.DEFAULT_SECRETS_DIR,
+                        help='Directory with ca.pem and amqp-client.{pem,key} (default: %(default)s)')
+    parser.add_argument('--create', action='store_true',
+                        help='Create the queue if it does not exist yet')
+    opts = parser.parse_args()
+
+    with distributed_queue.DistributedQueue(opts.amqp, [opts.queue], secrets_dir=opts.secrets_dir,
+                                            passive=not opts.create) as q:
+        command = sys.stdin.read().strip()
+        q.channel.basic_publish('', opts.queue, body='{"command": "%s"}' % command,
+                                properties=pika.BasicProperties(priority=distributed_queue.MAX_PRIORITY))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/run-queue
+++ b/run-queue
@@ -133,7 +133,7 @@ Subject: cockpituous: run-queue crash on %s
 # Consume from the task queue (endpoint)
 def main():
     parser = argparse.ArgumentParser(description='Bot: read a single test command from the queue and execute it')
-    parser.add_argument('--amqp', default='localhost:5671',
+    parser.add_argument('--amqp', default=distributed_queue.DEFAULT_AMQP_SERVER,
                         help='The host:port of the AMQP server to consume from (default: %(default)s)')
     opts = parser.parse_args()
 

--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -33,6 +33,7 @@ logging.getLogger("pika").propagate = False
 __all__ = (
     'DistributedQueue',
     'DEFAULT_SECRETS_DIR',
+    'DEFAULT_AMQP_SERVER',
     'BASELINE_PRIORITY',
     'MAX_PRIORITY',
     'no_amqp',
@@ -42,6 +43,7 @@ BASELINE_PRIORITY = 5
 MAX_PRIORITY = 9
 # see https://github.com/cockpit-project/cockpituous/blob/master/tasks/cockpit-tasks-webhook.yaml
 DEFAULT_SECRETS_DIR = '/run/secrets/webhook'
+DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
 
 arguments = {
     'rhel': {


### PR DESCRIPTION
This CLI tool will allow us to write workflows that interact with our
tests, for example submit `store-tests` command to the statistics queue
for daily master tests.

-----
This is a prerequisite for both [daily master test runs](https://issues.redhat.com/browse/COCKPIT-751), as well as queueing integration tests after the "build-dist" workflow.

The two working together:
```
$ echo 'echo hello' | ./publish-queue -q statistics --secrets-dir ~/redhat/ci-secrets/webhook/

$ ./inspect-queue --secrets-dir ~/redhat/ci-secrets/webhook/ 
public queue:
queue public is empty
rhel queue:
queue rhel is empty
statistics queue:
{"command": "./store-tests --db /cache/images/test-results.db --repo cockpit-project/cockpit 8592582f455a4c67b0a431440b64649c43df12a3"}
{"command": "echo hello"}
```

The store-tests is of course from some test; the publish-queue entry is from the command above.

 - [x] Fix run-local.sh to not rely on internal default `--amqp`: https://github.com/cockpit-project/cockpituous/pull/386