### PR TITLE
task: Allow osbuild organization

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -392,7 +392,7 @@ class GitHub(object):
 
     def allowlist(self):
         # bots and organizations which are allowed to use our CI (these use branches within the main repo for PRs)
-        users = {"github-actions[bot]", "candlepin", "cockpit-project"}
+        users = {"github-actions[bot]", "candlepin", "cockpit-project", "osbuild"}
 
         # individual persons from https://github.com/orgs/cockpit-project/teams/contributors/members
         teamId = self.teamIdFromName(TEAM_CONTRIBUTORS)

--- a/task/test-github
+++ b/task/test-github
@@ -181,7 +181,8 @@ class TestGitHub(unittest.TestCase):
     def testAllowlist(self):
         allowlist = self.api.allowlist()
         self.assertTrue(len(allowlist) > 0)
-        self.assertEqual(allowlist, set(["one", "two", "three", "github-actions[bot]", "candlepin", "cockpit-project"]))
+        self.assertEqual(allowlist, set(["one", "two", "three", "github-actions[bot]", "candlepin",
+                                         "cockpit-project", "osbuild"]))
         self.assertNotIn("four", allowlist)
         self.assertNotIn("", allowlist)
 


### PR DESCRIPTION
This fixes tests not running for cockpit-composer npm-update PRs, like
in https://github.com/osbuild/cockpit-composer/pull/1234