### PR TITLE
testmap: Enable fedora-34 for starter-kit

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -66,11 +66,11 @@ REPO_BRANCH_CONTEXT = {
     'cockpit-project/starter-kit': {
         'master': [
             'fedora-33',
+            'fedora-34',
             'centos-8-stream',
         ],
         '_manual': [
             'fedora-32/firefox',
-            'fedora-34',
         ],
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
It succeeded in https://github.com/cockpit-project/starter-kit/pull/428 , but will trigger it again here.