### PR TITLE
testmap: remove rhel-8-4-distropkg from master

### DIFF
--- a/task/testmap.py
+++ b/task/testmap.py
@@ -36,7 +36,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-coreos',
             'fedora-32/firefox',
             'rhel-8-4',
-            'rhel-8-4-distropkg',
             'centos-8-stream',
         ],
         'rhel-7.9': [


### PR DESCRIPTION
We're about to introduce a change to cockpit which adds a variable
expansion feature to manifest parsing, and we want to use this feature
right away from the manifests in the same version.  This means that
the -distropkg variant is going to be broken until that new version gets
packaged.

Meanwhile, we're about to move over to RHEL 8.5 anyway.

It seems the easiest thing for now is to just drop rhel-8-4-distropkg
from the testmap.