### PR TITLE
image-diff: Avoid "command not found" in output

### DIFF
--- a/image-diff
+++ b/image-diff
@@ -28,11 +28,11 @@ def get_packages(machine):
     #
     # We'd ideally like to get source packages everywhere, but it's a
     # bit more difficult on RPM. (TODO)
-    pkgcmd = """dpkg-query -W -f='${source:Package}\t${version}\n' 2>/dev/null ||
-                rpm -qa --qf '%{NAME}\t%{EVR}\n' 2>/dev/null"""
+    pkgcmd = """if type dpkg-query > /dev/null 2>&1; then
+                    dpkg-query -W -f='${source:Package}\t${version}\n' 2>/dev/null;
+                else rpm -qa --qf '%{NAME}\t%{EVR}\n' 2>/dev/null; fi"""
 
-    output = machine.execute(pkgcmd)
-
+    output = machine.execute(pkgcmd).strip()
     return dict(line.split('\t') for line in output.splitlines())
 
 


### PR DESCRIPTION
Explicitly check if `dpkg-query` exists. Otherwise, on RHEL/CentOS 7
the first line of output is `bash: dpkg-query: command not found`
which breaks the parser.

----

Spotted in the rhel-7-9 image refresh in issue #1726, which has a bit of debugging information. I tested this on centos-7, rhel-8-4, fedora-34, and debian-testing.