### PR TITLE
tests-scan: Expose base branch in test environment

### DIFF
--- a/tests-scan
+++ b/tests-scan
@@ -143,7 +143,7 @@ def tests_invoke(priority, name, number, revision, ref, context, base,
 
     checkout = "PRIORITY={priority:04d} ./make-checkout --verbose --repo={repo}"
     invoke = "../tests-invoke --pull-number {pull_number} --revision {revision} --repo {github_base}"
-    test_env = "TEST_OS={image}"
+    test_env = "TEST_OS={image} BASE_BRANCH={base}"
     wrapper = "./publish-wrapper --repo {github_base} --test-name {name}-{current} " \
               "--github-context {github_context} --revision {revision}"
 


### PR DESCRIPTION
This is so tests know against what branch the PR being tested is being run.