### PR TITLE
naughty: Close 1647: podman regression in rawhide: `build` fails on `bpf create`

### DIFF
--- a/naughty/fedora-33/1647-podman-bpf
+++ b/naughty/fedora-33/1647-podman-bpf
@@ -1,1 +1,0 @@
-bpf create `in-kernel BTF is malformed


### PR DESCRIPTION
Known issue which has not occurred in 27 days

podman regression in rawhide: `build` fails on `bpf create`

Fixes #1647