### PR TITLE
naughty: Close 1635: podman regression in Debian testing: could not get either XDG_CONFIG_HOME or HOME: Internal Server Error

### DIFF
--- a/naughty/debian-testing/1635-api-commit-HOME
+++ b/naughty/debian-testing/1635-api-commit-HOME
@@ -1,1 +1,0 @@
-> error: Failed to commit container *: CommitFailure: error resolving name "*": could not get either XDG_CONFIG_HOME or HOME: Internal Server Error


### PR DESCRIPTION
Known issue which has not occurred in 24 days

podman regression in Debian testing: could not get either XDG_CONFIG_HOME or HOME: Internal Server Error

Fixes #1635