### PR TITLE
naughty: Close 928: Denied NetworkManager write to /var/tmp/dracut.*/systemd-cat while generating initrd image

### DIFF
--- a/naughty/rhel-8/928-selinux-nm-system-cat
+++ b/naughty/rhel-8/928-selinux-nm-system-cat
@@ -1,1 +1,0 @@
-type=1400 audit(*): avc:  denied  { write } * comm="NetworkManager" path="/var/tmp/dracut.*/systemd-cat" * scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0 tclass=fifo_file permissive=0


### PR DESCRIPTION
Known issue which has not occurred in 26 days

Denied NetworkManager write to /var/tmp/dracut.*/systemd-cat while generating initrd image

Fixes #928