### PR TITLE
add xdg_*_home helpers and move some files to ~/.config/cockpit-dev/

### DIFF
--- a/image-download
+++ b/image-download
@@ -122,7 +122,7 @@ def download(dest, force, state, quiet, stores):
 
     if not stores:
         try:
-            with open(xdg_config_home('image-stores'), 'r') as fp:
+            with open(xdg_config_home('cockpit-dev', 'image-stores'), 'r') as fp:
                 stores = fp.read().strip().split("\n")
         except FileNotFoundError:
             stores = []

--- a/image-download
+++ b/image-download
@@ -44,12 +44,10 @@ import fcntl
 import urllib.parse
 
 from machine.machine_core.constants import IMAGES_DIR
-from machine.machine_core.directories import get_images_data_dir
+from machine.machine_core.directories import get_images_data_dir, xdg_config_home
 
 from task import PUBLIC_STORES, REDHAT_STORES, CA_PEM
 from task.testmap import get_test_image
-
-CONFIG = "~/.config/image-stores"
 
 DEVNULL = open("/dev/null", "r+")
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
@@ -123,11 +121,10 @@ def download(dest, force, state, quiet, stores):
     name = os.path.basename(dest)
 
     if not stores:
-        config = os.path.expanduser(CONFIG)
-        if os.path.exists(config):
-            with open(config, 'r') as fp:
+        try:
+            with open(xdg_config_home('image-stores'), 'r') as fp:
                 stores = fp.read().strip().split("\n")
-        else:
+        except FileNotFoundError:
             stores = []
         # skip testing public stores for private images
         if not name.startswith("rhel") and not name.startswith("windows"):

--- a/machine/machine_core/directories.py
+++ b/machine/machine_core/directories.py
@@ -64,7 +64,6 @@ def get_images_data_dir():
         _images_data_dir = get_git_config('--type=path', 'cockpit.bots.images-data-dir')
 
         if _images_data_dir is None:
-            _images_data_dir = os.path.join(os.getenv('XDG_CACHE_HOME', os.path.expanduser("~/.cache")),
-                                            "cockpit-images")
+            _images_data_dir = xdg_cache_home('cockpit-images')
 
     return _images_data_dir

--- a/machine/machine_core/directories.py
+++ b/machine/machine_core/directories.py
@@ -24,6 +24,26 @@ _images_data_dir = None
 _temp_dir = None
 
 
+def xdg_home(subdir, envvar, *components, override=None):
+    path = override and os.getenv(override)
+
+    if not path:
+        directory = os.getenv(envvar)
+        if not directory:
+            directory = os.path.join(os.path.expanduser('~'), subdir)
+        path = os.path.join(directory, *components)
+
+    return path
+
+
+def xdg_config_home(*components, envvar=None):
+    return xdg_home('.config', 'XDG_CONFIG_HOME', *components, override=envvar)
+
+
+def xdg_cache_home(*components, envvar=None):
+    return xdg_home('.config', 'XDG_CACHE_HOME', *components, override=envvar)
+
+
 def get_git_config(*args):
     if not os.path.exists(GIT_DIR):
         return None

--- a/task/github.py
+++ b/task/github.py
@@ -30,6 +30,7 @@ import subprocess
 import re
 
 from . import cache, testmap
+from machine.machine_core.directories import xdg_config_home, xdg_cache_home
 
 __all__ = (
     'GitHub',
@@ -54,8 +55,6 @@ NOT_TESTED = "Not yet tested"
 NOT_TESTED_DIRECT = "Not yet tested (direct trigger)"
 
 ISSUE_TITLE_IMAGE_REFRESH = "Image refresh for {0}"
-
-TOKEN = "~/.config/github-token"
 
 TEAM_CONTRIBUTORS = "Contributors"
 
@@ -130,12 +129,12 @@ class GitHub(object):
         self.token = None
         self.debug = False
         try:
-            with open(os.path.expanduser(TOKEN), "r") as f:
+            with open(xdg_config_home('github-token'), "r") as f:
                 self.token = f.read().strip()
         except FileNotFoundError:
             # fall back to GitHub's CLI token
             try:
-                with open(os.path.expanduser("~/.config/gh/config.yml")) as f:
+                with open(xdg_config_home("gh/config.yml")) as f:
                     match = re.search(r'oauth_token:\s*(\S+)', f.read())
                 if match:
                     self.token = match.group(1)
@@ -144,7 +143,7 @@ class GitHub(object):
 
         # default cache directory
         if not cacher:
-            cacher = cache.Cache(os.path.join(os.getenv('XDG_CACHE_HOME', os.path.expanduser("~/.cache")), "github"))
+            cacher = cache.Cache(xdg_cache_home('github'))
 
         self.cache = cacher
 


### PR DESCRIPTION
Two major things going on here:

First, add some xdg_*_home() helpers.  These functions consolidate the usual logic for finding the user's xdg directory and forming a path based on it
    
 - check the relevant XDG_ environment variable
    
 - default to the usual place relative to ~
    
 - os.path.join() the result with the provided arguments
    
 - ability to provide an environment variable to override the entire thing with a hardcoded path

We also port a few existing users of files in `~/.config/` and `~/.cache/` (with their homegrown handling) to the new APIs.


Second, we move the `github-token` and `image-stores` files out of `~/.config` and into `~/.config/cockpit-dev`.  For `github-token` we provide backwards compatibility with a deprecation warning.

 * [ ] #1766 