### PR TITLE
Fix services image refresh

### DIFF
--- a/image-create
+++ b/image-create
@@ -188,8 +188,12 @@ class MachineBuilder:
 
 
 try:
-    testvm.VirtMachine.memory_mb = 2048
-    machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=True)
+    if args.image == 'services':
+        # deploying candlepin needs oodles of memory
+        memory_mb = 3072
+    else:
+        memory_mb = 2048
+    machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, memory_mb=memory_mb, maintain=True)
     builder = MachineBuilder(machine)
     builder.build()
     if not args.no_save:

--- a/images/scripts/services.bootstrap
+++ b/images/scripts/services.bootstrap
@@ -1,1 +1,1 @@
-centos-7.bootstrap
+fedora-coreos.bootstrap

--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -2,23 +2,17 @@
 
 set -ex
 
-YUM_INSTALL="yum --setopt=skip_missing_names_on_install=False -y install"
 SERVER_IP=10.111.112.100
 
-yum -y upgrade
-$YUM_INSTALL docker
-
 # static host name and IP so that peer VMs can find us
-nmcli con add con-name "static-eth1" ifname eth1 type ethernet ip4 "$SERVER_IP/20" ipv4.dns "$SERVER_IP" gw4 "10.111.112.1"
-nmcli con up "static-eth1"
+systemctl enable --now NetworkManager
+nmcli con add con-name "static-mcast1" ifname ens15 type ethernet ip4 "$SERVER_IP/20" ipv4.dns "$SERVER_IP" gw4 "10.111.112.1"
+nmcli con up "static-mcast1"
 hostnamectl set-hostname services.cockpit.lan
-
-systemctl disable firewalld kdump crond
-systemctl enable --now docker
 
 function docker_pull() {
     # we get images from our mirror on quay to work around dockerhub rate limits, see sync-quay
-    docker pull "quay.io/cockpit/$1-$2" && docker tag "quay.io/cockpit/$1-$2" "docker.io/$1/$2"
+    podman pull "quay.io/cockpit/$1-$2" && podman tag "quay.io/cockpit/$1-$2" "docker.io/$1/$2"
 }
 
 #############
@@ -27,18 +21,15 @@ function docker_pull() {
 #
 #############
 
-# see https://github.com/freeipa/freeipa-container/issues/348
-rm /usr/libexec/oci/hooks.d/oci-systemd-hook
-
 # see https://quay.io/repository/freeipa/freeipa-server
 # and https://github.com/freeipa/freeipa-container/issues/346
 # there is no :latest so we go with :fedora-rawhide
-docker pull quay.io/freeipa/freeipa-server:fedora-rawhide
+podman pull quay.io/freeipa/freeipa-server:fedora-rawhide
 setsebool -P container_manage_cgroup 1
 mkdir /var/lib/ipa-data
 
-cat <<EOF > /run-freeipa
-docker run -d --rm --name freeipa -ti -h f0.cockpit.lan \
+cat <<EOF > /root/run-freeipa
+podman run -d --rm --name freeipa -ti -h f0.cockpit.lan \
     -e IPA_SERVER_IP=$SERVER_IP \
     -p 53:53/udp -p 53:53 -p 80:80 -p 443:443 -p 389:389 -p 636:636 -p 88:88 -p 464:464 -p 88:88/udp -p 464:464/udp -p 123:123/udp \
     -v /var/lib/ipa-data:/data:Z \
@@ -46,21 +37,21 @@ docker run -d --rm --name freeipa -ti -h f0.cockpit.lan \
     quay.io/freeipa/freeipa-server:fedora-rawhide \
     -U -p foobarfoo -a foobarfoo -n cockpit.lan -r COCKPIT.LAN --setup-dns --no-forwarders --no-ntp
 EOF
-chmod 755 /run-freeipa
-/run-freeipa
+chmod 755 /root/run-freeipa
+/root/run-freeipa
 
-docker logs freeipa -f &
+podman logs -f freeipa &
 LOGS=$!
 
 # so wait until booted and setup is done
-docker exec freeipa sh -ec 'until systemctl --quiet is-system-running; do sleep 5; done'
+podman exec freeipa sh -ec 'until systemctl --quiet is-system-running; do sleep 5; done'
 
-# stop docker logs
-kill $!
+# stop podman logs
+kill $LOGS
 wait || true
 
 # further setup
-docker exec freeipa sh -exc '
+podman exec freeipa sh -exc '
 # Default password expiry of 90 days is impractical
 echo foobarfoo | kinit admin@COCKPIT.LAN
 ipa pwpolicy-mod --minlife=0 --maxlife=1000
@@ -87,8 +78,8 @@ mkdir -p /var/lib/samba-data/config /var/lib/samba-data/data
 # "foobarfoo" password is not accepted:
 # 0000052D: Constraint violation - check_password_restrictions: the password does not meet the complexity criteria!
 # supposed to be disabled with -e NOCOMPLEXITY=true, but that doesn't work
-cat <<EOF > /run-samba-domain
-docker run -d -it --rm --name samba \
+cat <<EOF > /root/run-samba-domain
+podman run -d -it --rm --name samba \
     -e "DOMAIN=COCKPIT.LAN" \
     -e "DOMAINPASS=foobarFoo123" \
     -e "DNSFORWARDER=172.27.0.3" \
@@ -108,14 +99,13 @@ docker run -d -it --rm --name samba \
     -p 636:636 \
     -p 1024-1044:1024-1044 \
     -p 3268-3269:3268-3269 \
-    -v /etc/localtime:/etc/localtime:ro \
-    -v /var/lib/samba-data/data/:/var/lib/samba \
-    -v /var/lib/samba-data/config:/etc/samba/external \
+    -v /var/lib/samba-data/data/:/var/lib/samba:z \
+    -v /var/lib/samba-data/config:/etc/samba/external:z \
     --add-host services.cockpit.lan:$SERVER_IP \
     -h f0.cockpit.lan \
     nowsci/samba-domain
 EOF
-chmod 755 /run-samba-domain
+chmod 755 /root/run-samba-domain
 
 # no need to run the script here; it initializes reasonably fast and we don't have post-setup to do for now
 
@@ -126,52 +116,60 @@ chmod 755 /run-samba-domain
 #
 #############################
 
+# unfortunately the setup only works on RHEL/CentOS 7: https://github.com/candlepin/ansible-role-candlepin/pull/12
+# so we have to run that in a CentOS 7 container
+
+podman run --name=candlepin --publish=8443:8443 --privileged --detach quay.io/centos/centos:centos7 /sbin/init
+
+podman exec -i candlepin sh -eux <<EOF
+# wait until booted
+systemctl start multi-user.target
+YUM_INSTALL="yum --setopt=skip_missing_names_on_install=False -y install"
 # We deploy candlepin via ansible
-$YUM_INSTALL epel-release
-
+\$YUM_INSTALL epel-release
 # Install dependencies
-CANDLEPIN_DEPS="\
-ansible \
-git \
-openssl \
-java-11-openjdk-devel \
-"
+\$YUM_INSTALL ansible git-core openssl java-11-openjdk-devel sudo initscripts gettext
 
-$YUM_INSTALL $CANDLEPIN_DEPS
-
-mkdir -p playbookdir; cd playbookdir;
-
-mkdir -p roles
-git clone https://github.com/candlepin/ansible-role-candlepin.git roles/candlepin
-
-# Run the playbook
-cat > inventory <<- EOF
-[dev]
-localhost
+useradd candlepin
+echo 'candlepin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/candlepin
 EOF
 
-useradd -m admin
-echo admin:foobar | chpasswd
-echo 'admin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/admin
+podman exec -i -u candlepin candlepin sh -eux <<EOF
+cd
+mkdir -p playbookdir/roles/
+git clone --depth=1 https://github.com/candlepin/ansible-role-candlepin.git playbookdir/roles/candlepin
 
-cat > playbook.yml <<- EOF
-- hosts: dev
-
+cat > playbookdir/playbook.yml <<- EOP
+- hosts: localhost
   environment:
     JAVA_HOME: /usr/lib/jvm/java-11/
-
   roles:
      - role: candlepin
-       candlepin_git_pull: True
        candlepin_deploy_args: "-g -a -f -t"
-       candlepin_user: admin
-       candlepin_user_home: /home/admin
-       candlepin_checkout: /home/admin/candlepin
+EOP
+
+# the playbook fails, but comes far enough to start candlepin/tomcat
+ansible-playbook -v --skip-tags 'system_update' playbookdir/playbook.yml
+
+sudo yum clean all
+sudo systemctl enable tomcat
 EOF
 
-ansible-playbook -i inventory -c local -v --skip-tags 'system_update' playbook.yml
+# validate that it works
+curl --insecure --head https://localhost:8443/candlepin/
 
-rm -rf playbookdir
+# copy the certificate to where the tests expect them
+mkdir -p /home/admin/candlepin
+podman cp candlepin:/home/candlepin/candlepin/generated_certs /home/admin/candlepin/
+chown -R admin:admin /home/admin/candlepin/
+
+podman exec candlepin poweroff
+
+cat <<EOF > /root/run-candlepin
+#!/bin/sh
+podman start candlepin
+EOF
+chmod 755 /root/run-candlepin
 
 #############################
 #
@@ -179,14 +177,7 @@ rm -rf playbookdir
 #
 #############################
 
-yum clean all
-
 rm -rf /var/log/journal/*
-echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
-
-# Audit events to the journal
-rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
-rm -rf /var/log/audit/
 
 # reduce image size
 /var/lib/testvm/zero-disk.setup

--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -30,7 +30,7 @@ function docker_pull() {
 # see https://github.com/freeipa/freeipa-container/issues/348
 rm /usr/libexec/oci/hooks.d/oci-systemd-hook
 
-# see https://hub.docker.com/r/freeipa/freeipa-server
+# see https://quay.io/repository/freeipa/freeipa-server
 # and https://github.com/freeipa/freeipa-container/issues/346
 # there is no :latest so we go with :fedora-rawhide
 docker pull quay.io/freeipa/freeipa-server:fedora-rawhide
@@ -43,7 +43,7 @@ docker run -d --rm --name freeipa -ti -h f0.cockpit.lan \
     -p 53:53/udp -p 53:53 -p 80:80 -p 443:443 -p 389:389 -p 636:636 -p 88:88 -p 464:464 -p 88:88/udp -p 464:464/udp -p 123:123/udp \
     -v /var/lib/ipa-data:/data:Z \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-    freeipa/freeipa-server:fedora-rawhide \
+    quay.io/freeipa/freeipa-server:fedora-rawhide \
     -U -p foobarfoo -a foobarfoo -n cockpit.lan -r COCKPIT.LAN --setup-dns --no-forwarders --no-ntp
 EOF
 chmod 755 /run-freeipa

--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -173,19 +173,6 @@ ansible-playbook -i inventory -c local -v --skip-tags 'system_update' playbook.y
 
 rm -rf playbookdir
 
-
-#############################
-#
-# Selenium setup
-#
-#############################
-
-# docker images that we need for integration testing
-docker_pull selenium hub:3
-docker_pull selenium node-chrome-debug:3
-docker_pull selenium node-firefox-debug:3
-
-
 #############################
 #
 # Final tweaks

--- a/images/services
+++ b/images/services
@@ -1,1 +1,1 @@
-services-2dd1f3ed3aab7b3924cdae07cbe1dfa002bc5ae4f000ab841297829e4fd369e1.qcow2
+services-60e27ce47478d6d34aae96f766d1cc423f3c56e9ca3e3e36c58019c0d8cfb270.qcow2


### PR DESCRIPTION
This is some larger reorgnization, I really coudln't find a way to split this up sensibly. Details in the individual commits. This *is* an API break, we'll need to adjust the tests -- but I think it's ultimately more future proof now.

Fixes #1755

 * [x] image-refresh services
 * [x] Adjust cockpit tests: https://github.com/cockpit-project/cockpit/pull/15542 (approved, will land in lockstep)
 * [x] Adjust subscription-manager tests: https://github.com/candlepin/subscription-manager/pull/2504