### PR TITLE
add a new S3 image store in Frankfurt (Linode)

### DIFF
--- a/image-download
+++ b/image-download
@@ -45,9 +45,9 @@ import urllib.parse
 
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir, xdg_config_home
-from lib.stores import PUBLIC_STORES, REDHAT_STORES, CA_PEM
-
+from lib.stores import HYBRID_STORES, PUBLIC_STORES, REDHAT_STORES, CA_PEM
 from lib.testmap import get_test_image
+from lib import s3
 
 DEVNULL = open("/dev/null", "r+")
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
@@ -83,8 +83,23 @@ def find(name, stores, latest, quiet):
     for store in stores:
         url = urllib.parse.urlparse(urllib.parse.urljoin(store, name))
 
-        # First, try the easy case: for OpenShift proxied stores which send
-        # their own SSL cert initially host name has to match that
+        # First, check if this is an S3 store for which we have a key
+        if s3.is_key_present(url):
+            output = check_curl_args([s3.sign_url(url, verb='HEAD')])
+            if output:
+                show_status(quiet, 'present', store, '(authenticated)')
+                found.append(([s3.sign_url(url)], output, store))  # GET
+                continue
+
+        # Next, try to access the URL directly, without further help
+        args = [url.geturl()]
+        output = check_curl_args(args)
+        if output:
+            show_status(quiet, 'present', store)
+            found.append((args, output, store))
+            continue
+
+        # If that didn't work, try using our CA_PEM
         args = ['--cacert', CA_PEM, url.geturl()]
         output = check_curl_args(args)
         if output:
@@ -140,6 +155,7 @@ def download(dest, force, state, quiet, stores):
                 stores = fp.read().strip().split("\n")
         except FileNotFoundError:
             stores = []
+        stores += HYBRID_STORES
         # skip testing public stores for private images
         if not name.startswith("rhel") and not name.startswith("windows"):
             stores += PUBLIC_STORES

--- a/image-upload
+++ b/image-upload
@@ -27,19 +27,20 @@ import urllib.parse
 
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
-from lib.stores import PUBLIC_STORES, REDHAT_STORES, CA_PEM
+from lib.stores import HYBRID_STORES, PUBLIC_STORES, REDHAT_STORES, CA_PEM
+from lib import s3
 
 from task import api
 
 
-def upload(store, source):
-    url = urllib.parse.urlparse(store)
+def upload(dest, source, public):
+    url = urllib.parse.urlparse(dest)
 
     # Start building the command
-    cmd = ["curl", "--progress-bar", "--cacert", CA_PEM, "--fail", "--upload-file", source]
+    cmd = ["curl", "--progress-bar", "--fail", "--upload-file", source]
 
     def try_curl(cmd):
-        print("Uploading to", cmd[-1])
+        print("Uploading to", cmd[-1].split('?')[0])  # hide authentication info
         # Passing through a non terminal stdout is necessary to make progress work
         curl = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         cat = subprocess.Popen(["cat"], stdin=curl.stdout)
@@ -51,12 +52,25 @@ def upload(store, source):
         return ret
 
     # Pass credentials, if present
-    if api.token:
+    if s3.is_key_present(url):
+        # This is an S3 host for which we have a key
+        headers = []
+        if public:
+            headers = [s3.ACL_PUBLIC]
+            cmd.extend(['-H', s3.ACL_PUBLIC])
+        dest = s3.sign_url(url, verb='PUT', headers=headers)
+
+    elif api.token:
         user = url.username or getpass.getuser()
         cmd += ["--user", user + ":" + api.token]
 
-    # First try to use the original store URL, for stores with valid SSL cert on an OpenShift proxy
-    if try_curl(cmd + [store]) == 0:
+    # First try to use the original URL with no extra help
+    if try_curl(cmd + [dest]) == 0:
+        return 0
+
+    # Next, see if our CA_PEM helps, for stores with valid SSL cert on an OpenShift proxy
+    cmd += ['--cacert', CA_PEM]
+    if try_curl(cmd + [dest]) == 0:
         return 0
 
     # Fall back for stores that use our self-signed cockpit certificate
@@ -95,21 +109,28 @@ def main():
         sources.append(source)
 
     for source in sources:
+        basename = os.path.basename(source)
+        public = not any(basename.startswith(pfx) for pfx in ('rhel', 'windows'))
+
         # determine possible stores, unless explicitly given
         stores = args.store
         if not stores:
-            # these images are not freely redistributable, keep them Red Hat internal
-            b = os.path.basename(source)
-            if b.startswith("rhel") or image.startswith("windows"):
-                stores = REDHAT_STORES
-            else:
-                stores = PUBLIC_STORES
+            stores = list(HYBRID_STORES)
 
+            # these images are not freely redistributable, keep them Red Hat internal
+            if public:
+                stores.extend(PUBLIC_STORES)
+            else:
+                stores.extend(REDHAT_STORES)
+
+        success = False
         for store in stores:
-            ret = upload(store, source)
+            dest = urllib.parse.urljoin(store, basename)
+            ret = upload(dest, source, public)
             if ret == 0:
-                return ret
-        else:
+                success = True
+
+        if not success:
             # all stores failed, so return last exit code
             return ret
 

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+
+# This file is public domain (CC0-1.0)
+
+# Adapted from examples in
+# https://s3.amazonaws.com/doc/s3-developer-guide/RESTAuthentication.html
+
+import base64
+import hmac
+import os.path
+import sys
+import time
+import urllib.parse
+from .directories import xdg_config_home
+
+__all__ = (
+    "ACL_PUBLIC",
+    "is_key_present",
+    "sign_url",
+)
+
+ACL_PUBLIC = 'x-amz-acl:public-read'
+
+
+def split_bucket(url):
+    return url.hostname.split('.', 1)
+
+
+def get_key_filename(endpoint):
+    s3_key_dir = xdg_config_home('cockpit-dev/s3-keys', envvar='COCKPIT_S3_KEY_DIR')
+    return os.path.join(s3_key_dir, endpoint)
+
+
+def is_key_present(url):
+    try:
+        bucket, endpoint = split_bucket(url)
+    except ValueError:
+        # happens if there is no '.' in the hostname
+        return False
+
+    return os.path.exists(get_key_filename(endpoint))
+
+
+def sign_url(url, verb='GET', headers=[], duration=12 * 60 * 60):
+    bucket, endpoint = split_bucket(url)
+    access, secret = open(get_key_filename(endpoint)).read().split()
+
+    expires = int(time.time()) + duration
+    headers = ''.join(f'{h}\n' for h in headers)
+
+    h = hmac.HMAC(secret.encode('ascii'), digestmod='sha1')
+    h.update(f'{verb}\n\n\n{expires}\n{headers}/{bucket}{url.path}'.encode('ascii'))
+    signature = urllib.parse.quote_plus(base64.b64encode(h.digest()))
+
+    query = f'AWSAccessKeyId={access}&Expires={expires}&Signature={signature}'
+    return url._replace(query=query).geturl()
+
+
+def main():
+    prognam, cmd, uri = sys.argv
+
+    url = urllib.parse.urlparse(uri)
+    if cmd == 'get':
+        print(sign_url(url))
+    elif cmd == 'put':
+        print(sign_url(url, verb='PUT'))
+    elif cmd == 'put-public':
+        print('-H{ACL_PUBLIC}', sign_url(url, verb='PUT', headers=[ACL_PUBLIC]))
+    else:
+        sys.exit(f'unknown command {cmd}')
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/stores
+++ b/lib/stores
@@ -1,3 +1,5 @@
+hybrid	https://cockpit-images.eu-central-1.linodeobjects.com/
+hybrid	https://cockpit-images.us-east-1.linodeobjects.com/
 public	https://images-frontdoor.apps.ocp.ci.centos.org/
 redhat	https://cockpit-11.e2e.bos.redhat.com:8493/
 redhat	https://internal-images.cockpit-project.org:8493/

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -35,6 +35,9 @@ PUBLIC_STORES = [url for scope, url in ALL_STORES if scope == 'public']
 # Servers which have the private RHEL/Windows images
 REDHAT_STORES = [url for scope, url in ALL_STORES if scope == 'redhat']
 
+# Servers which can host either public or private images (via ACL specification)
+HYBRID_STORES = [url for scope, url in ALL_STORES if scope == 'hybrid']
+
 
 def redhat_network():
     '''Check if we can access the Red Hat network


### PR DESCRIPTION
This adds support for S3 image stores and adds one hosted at Linode in Frankfurt.

This server is *substantially* faster for me than the American ones, and should also be nice for most other members of our predominantly-central-European developer team.

Let's test some uploads from the bots!

 * [x] image-refresh fedora-coreos
 * [x] image-refresh cirros
 * [x] image-refresh rhel-8-4