### PR TITLE
Fix image-trigger crash

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -48,7 +48,7 @@ import time
 
 sys.dont_write_bytecode = True
 
-from lib.CONSTANTS import BASE_DIR
+from lib.constants import BASE_DIR
 import task
 from task import github
 
@@ -72,9 +72,7 @@ def main():
 
 # Check if the given files that match @pathspec are stale
 # and haven't been updated in @days.
-def stale(days, pathspec, ref="HEAD"):
-    global verbose
-
+def stale(days, pathspec, ref="HEAD", verbose=False):
     def execute(*args):
         if verbose:
             sys.stderr.write("+ " + " ".join(args) + "\n")
@@ -105,7 +103,7 @@ def scan(api, force, verbose):
             perform = image == force
         else:
             days = options.get("refresh-days", DAYS)
-            perform = stale(days, os.path.join("images", image), "origin/master")
+            perform = stale(days, os.path.join("images", image), "origin/master", verbose)
 
         if perform:
             text = "Image refresh for {0}".format(image)


### PR DESCRIPTION
Commit 6d1a16ea03eb197828f introduced a broken import.

The global `verbose` in the copied `stale()` function did not exist.
Pass it as an argument instead.

----

This broke [last night's image refreshes](https://github.com/cockpit-project/bots/runs/2082689556?check_suite_focus=true)

Trivial to reproduce by just calling `./image-trigger`. With this PR it works again:
```
❱❱❱ ./image-trigger 
From https://github.com/cockpit-project/bots
 * branch            master     -> FETCH_HEAD
#1752: image-refresh fedora-32
#1776: image-refresh fedora-33
#1777: image-refresh fedora-34
#1778: image-refresh ubuntu-2004
#1754: image-refresh openshift
#1779: image-refresh rhel-atomic
#1768: image-refresh services
```