### PR TITLE
naughty: Fix patterns with unsafe "*" lines

### DIFF
--- a/naughty/debian-stable/1372-libvirt-crashes-on-test-teardown
+++ b/naughty/debian-stable/1372-libvirt-crashes-on-test-teardown
@@ -1,8 +1,6 @@
 *TestMachines*
 *
-Process * (libvirtd) of user * dumped core.
-*
+Process * (libvirtd) of user * dumped core.*
 #1  * virQEMUDriverGetConfig (libvirt_driver_qemu.so)
 *
 #3  * virStateStop (libvirt.so.0)
-*

--- a/naughty/example/123-log-and-traceback
+++ b/naughty/example/123-log-and-traceback
@@ -1,0 +1,3 @@
+> log: phase coils are misaligned by*
+Traceback (most recent call last):
+  File "test/verify/check-warp-drive", line *, in testCoils

--- a/naughty/fedora-33/798-libvirtd-coredump
+++ b/naughty/fedora-33/798-libvirtd-coredump
@@ -1,5 +1,4 @@
 *testLibvirt*
 *
-Process * (libvirtd) of user 0 dumped core.
-*
+Process * (libvirtd) of user 0 dumped core.*
 *virObjectUnref*

--- a/naughty/fedora-34/1735-realm-ad-authconfig
+++ b/naughty/fedora-34/1735-realm-ad-authconfig
@@ -1,8 +1,5 @@
-*Authenticated as user: Administrator@COCKPIT.LAN
-*
-*/usr/sbin/authconfig: No such file or directory
-*
+*Authenticated as user: Administrator@COCKPIT.LAN*
+*/usr/sbin/authconfig: No such file or directory*
 realm: Couldn't join realm: Enabling SSSD in nsswitch.conf and PAM failed.
-Traceback (most recent call last):
-*
+Traceback (most recent call last):*
   File "test/verify/check-system-realms", line *

--- a/naughty/fedora-34/1735-realm-ad-authconfig-2
+++ b/naughty/fedora-34/1735-realm-ad-authconfig-2
@@ -1,6 +1,4 @@
-> log: Failed to join domain: cockpit.lan: Enabling SSSD in nsswitch.conf and PAM failed.
-*
-Traceback (most recent call last):
-*
+> log: Failed to join domain: cockpit.lan: Enabling SSSD in nsswitch.conf and PAM failed.*
+Traceback (most recent call last):*
   File "test/verify/check-system-realms", line *, in testQualifiedUsers
     b.wait_popdown("realms-op")

--- a/naughty/rhel-8/1374-libvirt-crashes-on-test-teardown
+++ b/naughty/rhel-8/1374-libvirt-crashes-on-test-teardown
@@ -1,7 +1,6 @@
 *TestMachines*
 *
-Process * (libvirtd) of user * dumped core.
-*
+Process * (libvirtd) of user * dumped core.*
 #1  * virCondWait (libvirt.so.0)
 #2  * virThreadPoolWorker (libvirt.so.0)
 #3  * virThreadHelper (libvirt.so.0)

--- a/naughty/rhel-8/1691-pmlogger-start-failure
+++ b/naughty/rhel-8/1691-pmlogger-start-failure
@@ -1,5 +1,3 @@
-Job for pmlogger.service failed because the service did not take the steps required by its unit configuration.
-*
-Traceback (most recent call last):
-*
+Job for pmlogger.service failed because the service did not take the steps required by its unit configuration.*
+Traceback (most recent call last):*
   File "test/verify/check-metrics", line *, in testBasic

--- a/naughty/rhel-8/1711-sub-man-missing-product
+++ b/naughty/rhel-8/1711-sub-man-missing-product
@@ -1,5 +1,3 @@
-warning: [Errno 20] Not a directory: '/etc/pki/product'
-*
-Traceback (most recent call last):
-*
+warning: [Errno 20] Not a directory: '/etc/pki/product'*
+Traceback (most recent call last):*
   File "integration-tests/check-subscriptions", *

--- a/naughty/rhel-8/798-libvirtd-coredump
+++ b/naughty/rhel-8/798-libvirtd-coredump
@@ -1,5 +1,4 @@
 *testLibvirt*
 *
-Process * (libvirtd) of user 0 dumped core.
-*
+Process * (libvirtd) of user 0 dumped core.*
 *virObjectUnref*

--- a/naughty/rhel-8/838-libvirtd-dumps-core
+++ b/naughty/rhel-8/838-libvirtd-dumps-core
@@ -1,3 +1,2 @@
-Process * (libvirtd) of user * dumped core.
-*
+Process * (libvirtd) of user * dumped core.*
 *qemuStateStop*

--- a/task/test-policy
+++ b/task/test-policy
@@ -95,6 +95,31 @@ class TestPolicy(unittest.TestCase):
         (output, unused) = proc.communicate(PCP_CRASH)
         self.assertEqual(output, PCP_KNOWN)
 
+    def testLineGlob(self):
+        script = os.path.join(BOTS_DIR, "tests-policy")
+        cmd = [script, "--offline", "verify/example"]
+        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
+        (output, unused) = proc.communicate("""
+> log: phase coils are misaligned by 0.34 micron
+> warning: this will explode in your face
+Some other mubo-jumbo
+Traceback (most recent call last):
+  File "test/verify/check-warp-drive", line 34, in testCoils
+     self.assertTrue(all_in_order)
+not ok 1 test/verify/check-warp-drive TestDrive.testCoils
+""")
+        self.assertIn("\nok 1 test/verify/check-warp-drive TestDrive.testCoils # SKIP Known issue #123", output)
+
+        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
+        (output, unused) = proc.communicate("""
+> log: phase coils are misaligned by 0.34 micron
+Traceback (most recent call last):
+  File "test/verify/check-warp-drive", line 34, in testCoils
+     self.assertTrue(all_in_order)
+not ok 1 test/verify/check-warp-drive TestDrive.testCoils
+""")
+        self.assertIn("\nok 1 test/verify/check-warp-drive TestDrive.testCoils # SKIP Known issue #123", output)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Our naughties commonly use this pattern:

some expected log message
*
Traceback..

But this does not match if there are *no* lines between the log message
and the Traceback. This is because the fnmatch still considers the (not
quite obvious) \n line break, and thus a log like

blabla
some expected log message
Traceback foo..
        File ...

does *not* match the above pattern. The solution is to put the asterisk
at the end of the previous line:

some expected log message*
Traceback..

which will then correctly match zero or more lines in between.
    
Add a unit test to illustrate and validate this.

Fix all affected naughty patterns accordingly.

This will fix [this test failure](https://logs.cockpit-project.org/logs/pull-15504-20210311-122809-4ac70864-fedora-34/log.html#285-2).
