### PR TITLE
machine_core: Write SSHConnection messages to stderr

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -53,9 +53,8 @@ class SSHConnection(object):
 
     def message(self, *args):
         """Prints args if in verbose mode"""
-        if not self.verbose:
-            return
-        print(" ".join(args))
+        if self.verbose:
+            sys.stderr.write(" ".join(args) + '\n')
 
     # wait until we can execute something on the machine. ie: wait for ssh
     def wait_execute(self, timeout_sec=120):


### PR DESCRIPTION
On CI, test's stdout and err are combined into a single log. As print()
has internal buffering, that often leads to garbled output where
messages like "qemu-img create..." appear in the middle of stdout lines.

Write the messages to stderr instead. Cockpit's testlib.py writes its
messages there also, and so does Python's standard logging module.

This also avoids potentially breaking the TAP protocol on stdout with
debug/progress messages.