### PR TITLE
stores: drop the internal-images mirror

### DIFF
--- a/lib/stores
+++ b/lib/stores
@@ -2,4 +2,3 @@ hybrid	https://cockpit-images.eu-central-1.linodeobjects.com/
 hybrid	https://cockpit-images.us-east-1.linodeobjects.com/
 public	https://images-frontdoor.apps.ocp.ci.centos.org/
 redhat	https://cockpit-11.e2e.bos.redhat.com:8493/
-redhat	https://internal-images.cockpit-project.org:8493/


### PR DESCRIPTION
Drop internal-images.cockpit-project.org.

This mirror only existed as a backup for rhel images incase the e2e
cluster went offline, and for that we now have the S3 mirrors.  It also
suffered from the name being resolvable to an internal IP from outside
the VPN leading to having to wait for the timeout (...as 10.x got
blackholed) before image-download could proceed, when not connected to
VPN.