### PR TITLE
image-download: add "preferred image store" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ EEVIDIDFSOQ0ABJ2LGTT    009rKOypIoqO44Q3VQGRyYPfugi84zANHF0pOW9f
 The "access key" and "secret key" is unique per-developer and can be
 obtained by talking to Allison.
 
+The images themselves are downloaded from a number of possible mirror
+servers.  A "preferred" mirror can be specified by writing a substring
+(eg. `eu-central-1`) to `~/.config/cockpit-dev/image-store-preference`.
+
 ### Test contexts
 
 For describing tests which we want to run we use __contexts__. A context has the form:

--- a/image-download
+++ b/image-download
@@ -41,6 +41,7 @@ import tempfile
 import time
 import fcntl
 import urllib.parse
+import warnings
 
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir, xdg_config_home
@@ -79,6 +80,20 @@ def check_curl_args(args):
 def find(name, stores, latest, quiet):
     found = []
 
+    try:
+        with open(xdg_config_home('cockpit-dev', 'image-store-preference'), 'r') as fp:
+            pattern = fp.read().strip()
+            matches = [store for store in stores if pattern in store]
+            try:
+                # move it to the front of the list
+                preferred, = matches
+                stores.insert(0, preferred)
+            except ValueError:
+                n_matches = len(matches)
+                warnings.warn(f'image-store-preference matched {n_matches} stores (expecting 1).  ignoring.')
+    except FileNotFoundError:
+        preferred = None
+
     for store in stores:
         url = urllib.parse.urlparse(urllib.parse.urljoin(store, name))
 
@@ -88,6 +103,8 @@ def find(name, stores, latest, quiet):
             if output:
                 show_status(quiet, 'present', store, '(authenticated)')
                 found.append(([s3.sign_url(url)], output, store))  # GET
+                if store == preferred:
+                    break
                 continue
 
         # Next, try to access the URL directly, without further help
@@ -96,6 +113,8 @@ def find(name, stores, latest, quiet):
         if output:
             show_status(quiet, 'present', store)
             found.append((args, output, store))
+            if store == preferred:
+                break
             continue
 
         # If that didn't work, try using our CA_PEM

--- a/image-download
+++ b/image-download
@@ -34,7 +34,6 @@ import email
 import io
 import os
 import shutil
-import socket
 import stat
 import subprocess
 import sys
@@ -105,28 +104,11 @@ def find(name, stores, latest, quiet):
         if output:
             show_status(quiet, 'present', store)
             found.append((args, output, store))
+            if store == preferred:
+                break
             continue
 
-        # Otherwise, the server is expecting the hostname "cockpit-tests".
-        # We need to do a bit of work to make that happen.
-        defport = url.scheme == 'http' and 80 or 443
-
-        try:
-            ai = socket.getaddrinfo(url.hostname, url.port or defport, socket.AF_INET, 0, socket.IPPROTO_TCP)
-        except socket.gaierror:
-            ai = []
-
-        for (family, socktype, proto, canonname, (host, port)) in ai:
-            args = ['--cacert', CA_PEM,
-                    '--resolve', f'cockpit-tests:{host}:{port}',
-                    f'{url.scheme}://cockpit-tests:{port}{url.path}']
-            output = check_curl_args(args)
-            if output:
-                show_status(quiet, 'present', store)
-                found.append((args, output, store))
-                break
-        else:
-            show_status(quiet, 'absent', store)
+        show_status(quiet, 'absent', store)
 
     # Find the most recent version of this file
     def header_date(args):

--- a/image-upload
+++ b/image-upload
@@ -20,7 +20,6 @@
 import argparse
 import getpass
 import os
-import socket
 import subprocess
 import sys
 import urllib.parse
@@ -68,21 +67,10 @@ def upload(dest, source, public):
     if try_curl(cmd + [dest]) == 0:
         return 0
 
-    # Next, see if our CA_PEM helps, for stores with valid SSL cert on an OpenShift proxy
+    # Else, see if our CA_PEM helps
     cmd += ['--cacert', CA_PEM]
     if try_curl(cmd + [dest]) == 0:
         return 0
-
-    # Fall back for stores that use our self-signed cockpit certificate
-    # Parse out the actual address to connect to and override certificate info
-    defport = url.scheme == 'http' and 80 or 443
-    ai = socket.getaddrinfo(url.hostname, url.port or defport, socket.AF_INET, 0, socket.IPPROTO_TCP)
-    for (family, socktype, proto, canonname, sockaddr) in ai:
-        resolve = "cockpit-tests:{1}:{0}".format(*sockaddr)
-        curl_url = "https://cockpit-tests:{0}{1}".format(url.port or defport, url.path)
-        ret = try_curl(cmd + ["--resolve", resolve, curl_url])
-        if ret == 0:
-            return 0
 
     return 1
 


### PR DESCRIPTION
image-download now looks in ~/.config/cockpit-dev/image-store-preference
on each download.  If this file exists, it should contain a substring
which matches the name of a single mirror (for example "eu-central-1").
In that case, this mirror will be tried before the other mirrors, and if
the image is present on it, the other mirrors will be completely
ignored.



bonus: drop the "cockpit-tests" DNS hack