### PR TITLE
image-{up,down}load: remove "cockpit-tests" hack

### DIFF
--- a/image-download
+++ b/image-download
@@ -34,7 +34,6 @@ import email
 import io
 import os
 import shutil
-import socket
 import stat
 import subprocess
 import sys
@@ -107,26 +106,7 @@ def find(name, stores, latest, quiet):
             found.append((args, output, store))
             continue
 
-        # Otherwise, the server is expecting the hostname "cockpit-tests".
-        # We need to do a bit of work to make that happen.
-        defport = url.scheme == 'http' and 80 or 443
-
-        try:
-            ai = socket.getaddrinfo(url.hostname, url.port or defport, socket.AF_INET, 0, socket.IPPROTO_TCP)
-        except socket.gaierror:
-            ai = []
-
-        for (family, socktype, proto, canonname, (host, port)) in ai:
-            args = ['--cacert', CA_PEM,
-                    '--resolve', f'cockpit-tests:{host}:{port}',
-                    f'{url.scheme}://cockpit-tests:{port}{url.path}']
-            output = check_curl_args(args)
-            if output:
-                show_status(quiet, 'present', store)
-                found.append((args, output, store))
-                break
-        else:
-            show_status(quiet, 'absent', store)
+        show_status(quiet, 'absent', store)
 
     # Find the most recent version of this file
     def header_date(args):

--- a/image-upload
+++ b/image-upload
@@ -20,7 +20,6 @@
 import argparse
 import getpass
 import os
-import socket
 import subprocess
 import sys
 import urllib.parse
@@ -68,21 +67,10 @@ def upload(dest, source, public):
     if try_curl(cmd + [dest]) == 0:
         return 0
 
-    # Next, see if our CA_PEM helps, for stores with valid SSL cert on an OpenShift proxy
+    # Else, see if our CA_PEM helps
     cmd += ['--cacert', CA_PEM]
     if try_curl(cmd + [dest]) == 0:
         return 0
-
-    # Fall back for stores that use our self-signed cockpit certificate
-    # Parse out the actual address to connect to and override certificate info
-    defport = url.scheme == 'http' and 80 or 443
-    ai = socket.getaddrinfo(url.hostname, url.port or defport, socket.AF_INET, 0, socket.IPPROTO_TCP)
-    for (family, socktype, proto, canonname, sockaddr) in ai:
-        resolve = "cockpit-tests:{1}:{0}".format(*sockaddr)
-        curl_url = "https://cockpit-tests:{0}{1}".format(url.port or defport, url.path)
-        ret = try_curl(cmd + ["--resolve", resolve, curl_url])
-        if ret == 0:
-            return 0
 
     return 1
 


### PR DESCRIPTION
We no longer have any mirror that relies on the "cockpit-tests" DNS
trickery.  Remove it.