### PR TITLE
image-download: bring back "fastest ping" selection

### DIFF
--- a/image-download
+++ b/image-download
@@ -71,7 +71,10 @@ def check_curl_args(args):
     head_args = ['--silent', '--head']  # only used for this check
 
     try:
-        return subprocess.check_output(curl_cmd(args + head_args), universal_newlines=True)
+        start = time.time()
+        output = subprocess.check_output(curl_cmd(args + head_args), universal_newlines=True)
+        duration = time.time() - start
+        return output, duration
     except subprocess.CalledProcessError:
         return None
 
@@ -84,33 +87,37 @@ def find(name, stores, latest, quiet):
 
         # First, check if this is an S3 store for which we have a key
         if s3.is_key_present(url):
-            output = check_curl_args([s3.sign_url(url, verb='HEAD')])
-            if output:
+            result = check_curl_args([s3.sign_url(url, verb='HEAD')])
+            if result:
                 show_status(quiet, 'present', store, '(authenticated)')
-                found.append(([s3.sign_url(url)], output, store))  # GET
+                found.append(([s3.sign_url(url)], result, store))  # GET
                 continue
 
         # Next, try to access the URL directly, without further help
         args = [url.geturl()]
-        output = check_curl_args(args)
-        if output:
+        result = check_curl_args(args)
+        if result:
             show_status(quiet, 'present', store)
-            found.append((args, output, store))
+            found.append((args, result, store))
             continue
 
         # If that didn't work, try using our CA_PEM
         args = ['--cacert', CA_PEM, url.geturl()]
-        output = check_curl_args(args)
-        if output:
+        result = check_curl_args(args)
+        if result:
             show_status(quiet, 'present', store)
-            found.append((args, output, store))
+            found.append((args, result, store))
             continue
 
         show_status(quiet, 'absent', store)
 
+    # If we couldn't find the file, but it exists, we're good
+    if not found:
+        return None, None
+
     # Find the most recent version of this file
     def header_date(args):
-        _, output, message = args
+        _, (output, duration), message = args
         try:
             reply_line, headers_alone = output.split('\n', 1)
             last_modified = email.message_from_file(io.StringIO(headers_alone)).get("Last-Modified", "")
@@ -118,12 +125,13 @@ def find(name, stores, latest, quiet):
         except ValueError:
             return ""
 
-    if found and latest:
+    if latest:
         # if we depend on getting the latest info, only download it from that one store
         found.sort(reverse=True, key=header_date)
-        del found[1:]
+    else:
+        found.sort(reverse=False, key=lambda x: x[1][1])
 
-    return found
+    return found[0][0], found[0][2]
 
 
 def download(dest, force, state, quiet, stores):
@@ -148,70 +156,44 @@ def download(dest, force, state, quiet, stores):
     else:
         since = EPOCH
 
-    # returns [(args, HEAD output, store)]
-    stores = find(name, stores, latest=state, quiet=quiet)
+    args, message = find(name, stores, latest=state, quiet=quiet)
 
     # If we couldn't find the file, but it exists, we're good
-    if not stores:
+    if not args:
         if exists:
             return
         raise RuntimeError("image-download: couldn't find file anywhere: {0}".format(name))
 
-    # Start downloading from every store and keep the connection with the fastest throughput
-    procs = []  # [(Popen object, output file)]
-    for (args, _, store) in stores:
-        temp = dest + "." + store.replace('/', '_') + ".partial"
+    show_status(quiet, 'selected', urllib.parse.urljoin(message, name))
 
-        # Adjust the arguments above that worked to make it visible and download real stuff
-        args.append("--show-error")
-        if not quiet and os.isatty(sys.stdout.fileno()):
-            args.append("--progress-bar")
+    temp = dest + ".partial"
+
+    # Adjust the arguments above that worked to make it visible and download real stuff
+    args.append("--show-error")
+    if not quiet and os.isatty(sys.stdout.fileno()):
+        args.append("--progress-bar")
+    else:
+        args.append("--silent")
+    args.append("--remote-time")
+    args.append("--time-cond")
+    args.append(since)
+    args.append("--output")
+    args.append(temp)
+    if os.path.exists(temp):
+        if force:
+            os.remove(temp)
         else:
-            args.append("--silent")
-        args.append("--remote-time")
-        args.append("--time-cond")
-        args.append(since)
-        args.append("--output")
-        args.append(temp)
-        if os.path.exists(temp):
-            if force:
-                os.remove(temp)
-            else:
-                args.append("-C")
-                args.append("-")
+            args.append("-C")
+            args.append("-")
 
-        # Always create the destination file (because --state)
-        else:
-            open(temp, 'a').close()
+    # Always create the destination file (because --state)
+    else:
+        open(temp, 'a').close()
 
-        procs.append((subprocess.Popen(curl_cmd(args)), temp))
-
-    # now see which one downloads fastest
-    time.sleep(7)
-    fastest_store = None
-    max_size = 0
-    for i, (proc, output) in enumerate(procs):
-        s = os.stat(output).st_size
-        if s > max_size:
-            max_size = s
-            fastest_store = i
-
-    show_status(quiet, 'selected',
-                urllib.parse.urljoin(stores[fastest_store][2], name),
-                'is the fastest store', prefix='\n\n')
-
-    # kill all the others
-    for i, (proc, output) in enumerate(procs):
-        if i != fastest_store:
-            proc.kill()
-            proc.wait()
-            os.unlink(output)
-
-    # and wait for the remaining one
-    temp = procs[fastest_store][1]
-    ret = procs[fastest_store][0].wait()
+    curl = subprocess.Popen(curl_cmd(args))
+    ret = curl.wait()
     if ret != 0:
-        raise RuntimeError("curl: unable to download from %s (returned: %s)" % (stores[fastest_store][2], ret))
+        raise RuntimeError("curl: unable to download %s (returned: %s)" % (message, ret))
 
     os.chmod(temp, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 


### PR DESCRIPTION
Functional revert of 2efccf29fab8b237847a0918dc163ba7e4751cd2.

Now that our best mirrors are of similar configuration, switch to the older and much more simple approach of choosing a mirror based on the fastest reply to HEAD, in essence, "fastest ping".

* [x] #1800 