### PR TITLE
testmap: Drop cockpit-composer service image trigger

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -168,7 +168,6 @@ IMAGE_REFRESH_TRIGGERS = {
         "debian-stable@cockpit-project/cockpit",
         "rhel-8-4@cockpit-project/cockpit",
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",
-        "fedora-33/firefox@osbuild/cockpit-composer",
     ]
 }
 


### PR DESCRIPTION
Composer has dropped selenium tests long ago, it does not use the
services image for anything.