### PR TITLE
naughty: Close 1662: SELinux complaining when osbuild is removing the machine-id for an image that seems to be in tmp

### DIFF
--- a/naughty/rhel-8/1662-selinux-osbuild-composer-machine-id
+++ b/naughty/rhel-8/1662-selinux-osbuild-composer-machine-id
@@ -1,1 +1,0 @@
-avc:  denied  { unlink } for  pid=1 comm="systemd" name="machine-id"


### PR DESCRIPTION
Known issue which has not occurred in 28 days

SELinux complaining when osbuild is removing the machine-id for an image that seems to be in tmp

Fixes #1662