### PR TITLE
s3: add support for v4 request signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,24 @@ When generating a new personal access token, the scope only needs to
 encompass `public_repo` (or `repo` if you're accessing a private repo).
 
 If you'd like to download Red Hat-only internal images from S3, you'll
-need to create a key file in `~/.config/cockpit-dev/s3-keys/[endpoint]`.
-The contents of this file should be a single line containing the "access
-key" and the "secret key" separated by whitespace.
+need to create a key file in `~/.config/cockpit-dev/s3-keys/[domain]`.
+The `[domain]` can be any non-toplevel domain which contains the S3 URL
+in question.  The contents of this file should be a single line
+containing the "access key" and the "secret key" separated by
+whitespace.
 
-For the currently configured mirrors this means that you'd expect to
-have the following files:
+For the currently configured mirrors this means that you'd likely have the
+following file:
 
+- `~/.config/cockpit-dev/s3-keys/linodeobjects.com`
+
+For more control, you could also use the following:
+
+- `~/.config/cockpit-dev/s3-keys/cockpit-images.eu-central-1.linodeobjects.com`
 - `~/.config/cockpit-dev/s3-keys/eu-central-1.linodeobjects.com`
-- `~/.config/cockpit-dev/s3-keys/us-east-1.linodeobjects.com`
+- either of the above, with `us-east` instead of `eu-central`
 
-each each file would be a single line which looks like
+each file would be a single line which looks like
 
 ```
 EEVIDIDFSOQ0ABJ2LGTT    009rKOypIoqO44Q3VQGRyYPfugi84zANHF0pOW9f

--- a/image-download
+++ b/image-download
@@ -87,7 +87,7 @@ def find(name, stores, latest, quiet):
 
         # First, check if this is an S3 store for which we have a key
         if s3.is_key_present(url):
-            result = check_curl_args([s3.sign_url(url, verb='HEAD')])
+            result = check_curl_args([s3.sign_url(url, method='HEAD')])
             if result:
                 show_status(quiet, 'present', store, '(authenticated)')
                 found.append(([s3.sign_url(url)], result, store))  # GET

--- a/image-download
+++ b/image-download
@@ -87,10 +87,10 @@ def find(name, stores, latest, quiet):
 
         # First, check if this is an S3 store for which we have a key
         if s3.is_key_present(url):
-            result = check_curl_args([s3.sign_url(url, method='HEAD')])
+            result = check_curl_args(s3.sign_curl(url, method='HEAD'))
             if result:
                 show_status(quiet, 'present', store, '(authenticated)')
-                found.append(([s3.sign_url(url)], result, store))  # GET
+                found.append((s3.sign_curl(url), result, store))  # GET
                 continue
 
         # Next, try to access the URL directly, without further help

--- a/image-upload
+++ b/image-upload
@@ -44,7 +44,7 @@ def upload(dest, source, public):
         headers = []
         if public:
             headers = [s3.ACL_PUBLIC]
-        cmd += s3.sign_url(url, verb='PUT', headers=headers)
+        cmd += s3.sign_url(url, method='PUT', headers=headers)
 
     elif api.token:
         user = url.username or getpass.getuser()

--- a/image-upload
+++ b/image-upload
@@ -38,41 +38,33 @@ def upload(dest, source, public):
     # Start building the command
     cmd = ["curl", "--progress-bar", "--fail", "--upload-file", source]
 
-    def try_curl(cmd):
-        print("Uploading to", cmd[-1].split('?')[0])  # hide authentication info
-        # Passing through a non terminal stdout is necessary to make progress work
-        curl = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        cat = subprocess.Popen(["cat"], stdin=curl.stdout)
-        curl.stdout.close()
-        ret = curl.wait()
-        cat.wait()
-        if ret != 0:
-            sys.stderr.write("image-upload: unable to upload image: {0}\n".format(cmd[-1]))
-        return ret
-
     # Pass credentials, if present
     if s3.is_key_present(url):
         # This is an S3 host for which we have a key
         headers = []
         if public:
             headers = [s3.ACL_PUBLIC]
-            cmd.extend(['-H', s3.ACL_PUBLIC])
-        dest = s3.sign_url(url, verb='PUT', headers=headers)
+        cmd += s3.sign_url(url, verb='PUT', headers=headers)
 
     elif api.token:
         user = url.username or getpass.getuser()
-        cmd += ["--user", user + ":" + api.token]
+        cmd += ["--user", user + ":" + api.token, '--cacert', CA_PEM, dest]
 
-    # First try to use the original URL with no extra help
-    if try_curl(cmd + [dest]) == 0:
-        return 0
+    else:
+        # No credentials?  That's not going to work...
+        sys.stderr.write(f"image-upload: no credentials for {dest}")
+        return 1
 
-    # Else, see if our CA_PEM helps
-    cmd += ['--cacert', CA_PEM]
-    if try_curl(cmd + [dest]) == 0:
-        return 0
+    print("Uploading to", dest, file=sys.stderr)
+    curl = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    cat = subprocess.Popen(["cat"], stdin=curl.stdout)
+    curl.stdout.close()
+    ret = curl.wait()
+    cat.wait()
+    if ret != 0:
+        sys.stderr.write(f"image-upload: unable to upload image: {dest}\n")
 
-    return 1
+    return ret
 
 
 def main():

--- a/image-upload
+++ b/image-upload
@@ -40,11 +40,13 @@ def upload(dest, source, public):
 
     # Pass credentials, if present
     if s3.is_key_present(url):
-        # This is an S3 host for which we have a key
-        headers = []
-        if public:
-            headers = [s3.ACL_PUBLIC]
-        cmd += s3.sign_url(url, method='PUT', headers=headers)
+        headers = {s3.ACL: s3.PUBLIC} if public else {}
+
+        # slightly magic: image filenames always end with -{sha256}.qcow2
+        assert source.endswith('.qcow2')
+        hash_value = source[-70:-6]
+
+        cmd += s3.sign_curl(url, method='PUT', headers=headers, checksum=hash_value)
 
     elif api.token:
         user = url.username or getpass.getuser()

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -4,22 +4,34 @@
 
 # Adapted from examples in
 # https://s3.amazonaws.com/doc/s3-developer-guide/RESTAuthentication.html
+# and
+# https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
 
 import base64
+import hashlib
 import hmac
 import os.path
 import sys
 import time
 import urllib.parse
+from typing import Dict, List
+
 from .directories import xdg_config_home
 
 __all__ = (
+    "ACL",
     "ACL_PUBLIC",
+    "PUBLIC",
     "is_key_present",
+    "sign_curl",
+    "sign_request",
     "sign_url",
 )
 
-ACL_PUBLIC = 'x-amz-acl:public-read'
+ACL = 'x-amz-acl'
+PUBLIC = 'public-read'
+ACL_PUBLIC = f'{ACL}:{PUBLIC}'
+SHA256_NIL = hashlib.sha256(b'').hexdigest()
 
 
 def get_key(hostname):
@@ -43,6 +55,44 @@ def get_key(hostname):
 def is_key_present(url: urllib.parse.ParseResult) -> bool:
     """Checks if an S3 key is available for the given url"""
     return get_key(url.hostname) is not None
+
+
+def sign_request(url: urllib.parse.ParseResult, method='GET', checksum=SHA256_NIL, headers={}) -> Dict[str, str]:
+    """Signs an AWS request using the AWS4-HMAC-SHA256 algorithm
+
+    Returns a dictionary of extra headers which need to be sent along with the request.
+    If the method is PUT then the checksum of the data to be uploaded must be provided.
+    @headers, if given, are a dict of additional headers to be signed (eg: `x-amz-acl`)
+    """
+    access_key, secret_key = get_key(url.hostname)
+
+    amzdate = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
+
+    headers = headers.copy()  # don't modify the user's copy, or the default
+    headers.update({'host': url.hostname, 'x-amz-content-sha256': checksum, 'x-amz-date': amzdate})
+    headers_str = ''.join(f'{k}:{v}\n' for k, v in sorted(headers.items()))
+    headers_list = ';'.join(sorted(headers))
+
+    credential_scope = f'{amzdate[:8]}/any/s3/aws4_request'
+    signing_key = f'AWS4{secret_key}'.encode('ascii')
+    for item in credential_scope.split('/'):
+        signing_key = hmac.new(signing_key, item.encode('ascii'), hashlib.sha256).digest()
+
+    algorithm = 'AWS4-HMAC-SHA256'
+    canonical_request = f'{method}\n{url.path}\n{url.query}\n{headers_str}\n{headers_list}\n{checksum}'
+    request_hash = hashlib.sha256(canonical_request.encode('ascii')).hexdigest()
+    string_to_sign = f'{algorithm}\n{amzdate}\n{credential_scope}\n{request_hash}'
+    signature = hmac.new(signing_key, string_to_sign.encode('ascii'), hashlib.sha256).hexdigest()
+    headers['Authorization'] = f'{algorithm} Credential={access_key}/{credential_scope},' \
+        f'SignedHeaders={headers_list},Signature={signature}'
+
+    return headers
+
+
+def sign_curl(url: urllib.parse.ParseResult, method='GET', checksum=SHA256_NIL, headers={}) -> List[str]:
+    """Same as sign_request() but formats the result as an argument list for curl, including the url"""
+    headers = sign_request(url, method=method, checksum=checksum, headers=headers)
+    return [f'-H{key}:{value}' for key, value in headers.items()] + [url.geturl()]
 
 
 def sign_url(url: urllib.parse.ParseResult, method='GET', headers=[], duration=12 * 60 * 60) -> str:

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -26,7 +26,6 @@ __all__ = (
     "is_key_present",
     "sign_curl",
     "sign_request",
-    "sign_url",
 )
 
 ACL = 'x-amz-acl'

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -45,7 +45,7 @@ def is_key_present(url: urllib.parse.ParseResult) -> bool:
     return get_key(url.hostname) is not None
 
 
-def sign_url(url: urllib.parse.ParseResult, verb='GET', headers=[], duration=12 * 60 * 60) -> str:
+def sign_url(url: urllib.parse.ParseResult, method='GET', headers=[], duration=12 * 60 * 60) -> str:
     """Returns a "pre-signed" url for the given method and headers"""
     access, secret = get_key(url.hostname)
     bucket = url.hostname.split('.')[0]
@@ -54,7 +54,7 @@ def sign_url(url: urllib.parse.ParseResult, verb='GET', headers=[], duration=12 
     headers = ''.join(f'{h}\n' for h in headers)
 
     h = hmac.HMAC(secret.encode('ascii'), digestmod='sha1')
-    h.update(f'{verb}\n\n\n{expires}\n{headers}/{bucket}{url.path}'.encode('ascii'))
+    h.update(f'{method}\n\n\n{expires}\n{headers}/{bucket}{url.path}'.encode('ascii'))
     signature = urllib.parse.quote_plus(base64.b64encode(h.digest()))
 
     query = f'AWSAccessKeyId={access}&Expires={expires}&Signature={signature}'
@@ -68,9 +68,9 @@ def main():
     if cmd == 'get':
         print(sign_url(url))
     elif cmd == 'put':
-        print(sign_url(url, verb='PUT'))
+        print(sign_url(url, method='PUT'))
     elif cmd == 'put-public':
-        print('-H{ACL_PUBLIC}', sign_url(url, verb='PUT', headers=[ACL_PUBLIC]))
+        print('-H{ACL_PUBLIC}', sign_url(url, method='PUT', headers=[ACL_PUBLIC]))
     else:
         sys.exit(f'unknown command {cmd}')
 

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -31,7 +31,8 @@ def get_key_filename(endpoint):
     return os.path.join(s3_key_dir, endpoint)
 
 
-def is_key_present(url):
+def is_key_present(url: urllib.parse.ParseResult) -> bool:
+    """Checks if an S3 key is available for the given url"""
     try:
         bucket, endpoint = split_bucket(url)
     except ValueError:
@@ -41,7 +42,8 @@ def is_key_present(url):
     return os.path.exists(get_key_filename(endpoint))
 
 
-def sign_url(url, verb='GET', headers=[], duration=12 * 60 * 60):
+def sign_url(url: urllib.parse.ParseResult, verb='GET', headers=[], duration=12 * 60 * 60) -> str:
+    """Returns a "pre-signed" url for the given method and headers"""
     bucket, endpoint = split_bucket(url)
     access, secret = open(get_key_filename(endpoint)).read().split()
 


### PR DESCRIPTION
Add support in lib/s3 for "version 4" request signing.  Provide a nice
curl wrapper, since image-upload and image-download are both using curl
to do the work.

Move image-download and image-upload to using the new mechanism.  This
gives us an extra nice advantage of having the server ensure the
checksum of the uploaded file for us.

Port some of the "cli" tools to use v4 signing, plus add one for
performing a "DELETE" request (which isn't possible under the v2
url signing).  We leave "PUT" on the old mechanism, to avoid having to
determine the checksum.

While we're at it, expand the possible filenames in the s3-keys
directories.  This will allow people to have a common key for everything
at linodeobjects.com, but will also allow per-bucket keys as well, both
of which are nice possibilities based on lessons learned through
experimentation since the first iteration of this work.

 * [x] image-refresh cirros
 * [x] image-refresh rhel-atomic