### PR TITLE
Fix prometheus-stats

### DIFF
--- a/prometheus-stats
+++ b/prometheus-stats
@@ -52,6 +52,8 @@ def main():
             SELECT COUNT(*), SUM(wait_seconds)
             FROM TestRuns
             WHERE time > ? ;""", (since, )).fetchone()
+    if test_runs_queue_wait_sum is None:
+        test_runs_queue_wait_sum = 0
 
     # Get how many test runs waited for more than 5 minutes
     test_runs_wait_5m = cursor.execute("""\

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -66,7 +66,7 @@ def main():
             WHERE time > ? AND wait_seconds > 3600; """, (since, )).fetchone()[0]
 
     output += """# HELP queue_time_wait_seconds histogram of queue wait times in the last %i hours
-# TYPE queue_time_wait_seconds histogram\n"
+# TYPE queue_time_wait_seconds histogram
 queue_time_wait_seconds_bucket{le="300"} %i
 queue_time_wait_seconds_bucket{le="3600"} %i
 queue_time_wait_seconds_bucket{le="+Inf"} %i


### PR DESCRIPTION
I was wondering why our stats [did not get imported](http://prometheus.osci.redhat.com/graph?g0.range_input=1h&g0.expr=%7Bjob%3D~%22cockpit%22%7D&g0.tab=0), and noticed a stray `"` in https://images-frontdoor.apps.ocp.ci.centos.org/prometheus .

This hopefully fixes it.