### PR TITLE
prometheus-stats: Fix inverted bucketing

### DIFF
--- a/prometheus-stats
+++ b/prometheus-stats
@@ -55,17 +55,17 @@ def main():
     if test_runs_queue_wait_sum is None:
         test_runs_queue_wait_sum = 0
 
-    # Get how many test runs waited for more than 5 minutes
+    # How many test runs waited for at most 5 minutes
     test_runs_wait_5m = cursor.execute("""\
             SELECT COUNT(*)
             FROM TestRuns
-            WHERE time > ? AND wait_seconds > 300; """, (since, )).fetchone()[0]
+            WHERE time > ? AND wait_seconds <= 300; """, (since, )).fetchone()[0]
 
-    # Get how many test runs waited for more than 1 hour
+    # Get how many test runs waited for at most 1 hour
     test_runs_wait_1h = cursor.execute("""\
             SELECT COUNT(*)
             FROM TestRuns
-            WHERE time > ? AND wait_seconds > 3600; """, (since, )).fetchone()[0]
+            WHERE time > ? AND wait_seconds <= 3600; """, (since, )).fetchone()[0]
 
     output += """# HELP queue_time_wait_seconds histogram of queue wait times in the last %i hours
 # TYPE queue_time_wait_seconds histogram


### PR DESCRIPTION
The `{le="t"}` bucket is supposed to contain the counts for "less or
equal" t, not "bigger than".

----

Now it looks like this. Everythign in order (all tests < 5 mins) in the last 12 hours:
```
./prometheus-stats --hours 12 --db test-results.db 
# HELP queue_time_wait_seconds histogram of queue wait times in the last 12 hours
# TYPE queue_time_wait_seconds histogram
queue_time_wait_seconds_bucket{le="300"} 10
queue_time_wait_seconds_bucket{le="3600"} 10
queue_time_wait_seconds_bucket{le="+Inf"} 10
queue_time_wait_seconds_sum 185
queue_time_wait_seconds_count 10
```

A week ago we had a few which ran between > 5 mins and 1 h:
```
 ./prometheus-stats --hours 168 --db test-results.db 
# HELP queue_time_wait_seconds histogram of queue wait times in the last 168 hours
# TYPE queue_time_wait_seconds histogram
queue_time_wait_seconds_bucket{le="300"} 321
queue_time_wait_seconds_bucket{le="3600"} 328
queue_time_wait_seconds_bucket{le="+Inf"} 328
queue_time_wait_seconds_sum 20825
queue_time_wait_seconds_count 328
```