### PR TITLE
prometheus-stats: Export unstable tests

### DIFF
--- a/prometheus-stats
+++ b/prometheus-stats
@@ -67,14 +67,14 @@ def main():
             FROM TestRuns
             WHERE time > ? AND wait_seconds <= 3600; """, (since, )).fetchone()[0]
 
-    output += """# HELP queue_time_wait_seconds histogram of queue wait times in the last %i hours
+    output += f"""# HELP queue_time_wait_seconds histogram of queue wait times in the last {opts.hours} hours
 # TYPE queue_time_wait_seconds histogram
-queue_time_wait_seconds_bucket{le="300"} %i
-queue_time_wait_seconds_bucket{le="3600"} %i
-queue_time_wait_seconds_bucket{le="+Inf"} %i
-queue_time_wait_seconds_sum %i
-queue_time_wait_seconds_count %i
-""" % (opts.hours, test_runs_wait_5m, test_runs_wait_1h, test_runs, test_runs_queue_wait_sum, test_runs)
+queue_time_wait_seconds_bucket{{le="300"}} {test_runs_wait_5m}
+queue_time_wait_seconds_bucket{{le="3600"}} {test_runs_wait_1h}
+queue_time_wait_seconds_bucket{{le="+Inf"}} {test_runs}
+queue_time_wait_seconds_sum {test_runs_queue_wait_sum}
+queue_time_wait_seconds_count {test_runs}
+"""
 
     print(output)
 

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -74,7 +74,32 @@ queue_time_wait_seconds_bucket{{le="3600"}} {test_runs_wait_1h}
 queue_time_wait_seconds_bucket{{le="+Inf"}} {test_runs}
 queue_time_wait_seconds_sum {test_runs_queue_wait_sum}
 queue_time_wait_seconds_count {test_runs}
+
 """
+
+    # failures
+    top_failures = cursor.execute("""
+            SELECT TestRuns.project, t1.testname, (t2.failed * 100.0) / COUNT(run) AS percent
+            FROM Tests AS t1
+            JOIN TestRuns ON t1.run = TestRuns.id
+            JOIN (
+                SELECT testname, COUNT(run) as failed
+                FROM Tests
+                JOIN TestRuns ON Tests.run = TestRuns.id
+                WHERE TestRuns.time > strftime('%s', 'now', '-7 days') AND Tests.failed = 1
+                GROUP BY testname
+            ) AS t2 ON t1.testname = t2.testname
+            WHERE TestRuns.time > strftime('%s', 'now', '-7 days') AND t2.failed > 1
+            GROUP BY t1.testname
+            ORDER BY percent DESC
+            LIMIT 50""").fetchall()
+
+    output += """# HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
+# TYPE top_failures_pct gauge
+"""
+    for (project, test, fail_pct) in top_failures:
+        if fail_pct > 10:
+            output += f'top_failures_pct{{project="{project}",test="{test}"}} {fail_pct}\n'
 
     print(output)
 


### PR DESCRIPTION
Add a new top_failures_pct{project,test} metric for the topmost tests
that fail more than 10% of the time. These represent SLO violations, and
we want to expose them on Grafana.

This is still a bit experimental -- in particular, this does not yet
expose example URLs for further investigation.

---

```
❱❱❱ ./prometheus-stats --db test-results.db 
# HELP queue_time_wait_seconds histogram of queue wait times in the last 12 hours
# TYPE queue_time_wait_seconds histogram
queue_time_wait_seconds_bucket{le="300"} 2
queue_time_wait_seconds_bucket{le="3600"} 2
queue_time_wait_seconds_bucket{le="+Inf"} 2
queue_time_wait_seconds_sum 30
queue_time_wait_seconds_count 2

# HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
# TYPE top_failures_pct gauge
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testRegister (check_subscriptions.TestSubscriptions)"} 47.36842105263158
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testSubAndInAndFail (check_subscriptions.TestSubscriptions)"} 35.294117647058826
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testNotSupported (check_realms.TestRealms)"} 35.294117647058826
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testNegotiate (check_realms.TestKerberos)"} 35.294117647058826
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testMissingPackages (check_subscriptions.TestSubscriptionsPackages)"} 35.294117647058826
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testIpaUnqualifiedUsers (check_realms.TestRealms)"} 35.294117647058826
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testIpa (check_realms.TestRealms)"} 35.294117647058826
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testInsights (check_subscriptions.TestSubscriptions)"} 35.294117647058826
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testNoUpdates (check_packagekit.TestUpdatesSubscriptions)"} 20.0
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testAvailableUpdates (check_packagekit.TestUpdatesSubscriptions)"} 20.0
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testPackageKitCrash (check_packagekit.TestUpdates)"} 13.333333333333334
```
This coincides well with the [weather report](https://images-frontdoor.apps.ocp.ci.centos.org/tests.html?days=7).