### PR TITLE
naughty: Close 1688: fedora-34: SELinux is preventing abrt-dump-journ from 'watch' accesses on the directory /run/log/journal

### DIFF
--- a/naughty/fedora-34/1688-selinux-abrt
+++ b/naughty/fedora-34/1688-selinux-abrt
@@ -1,1 +1,0 @@
-* type=1400 audit(*): avc:  denied  { watch } * comm="abrt-dump-journ" path="/run/log/journal"


### PR DESCRIPTION
Known issue which has not occurred in 28 days

fedora-34: SELinux is preventing abrt-dump-journ from 'watch' accesses on the directory /run/log/journal

Fixes #1688