### PR TITLE
lib: Fix tests_for_{image,po_refresh}() for "main" branches

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -266,6 +266,15 @@ def projects():
     return REPO_BRANCH_CONTEXT.keys()
 
 
+def get_default_branch(repo):
+    branches = REPO_BRANCH_CONTEXT[repo]
+    if 'main' in branches:
+        return 'main'
+    if 'master' in branches:
+        return 'master'
+    raise ValueError(f"repo {repo} does not contain main or master branch")
+
+
 def tests_for_project(project):
     """Return branch -> contexts map."""
     res = REPO_BRANCH_CONTEXT.get(project, {})
@@ -288,7 +297,7 @@ def tests_for_image(image):
             for context in contexts:
                 if context.split('/')[0].replace('-distropkg', '') == image:
                     c = context + '@' + repo
-                    if branch != "master":
+                    if branch != get_default_branch(repo):
                         c += "/" + branch
                     tests.add(c)
 
@@ -304,7 +313,7 @@ def tests_for_image(image):
 def tests_for_po_refresh(project):
     if project == "cockpit-project/cockpit":
         return [TEST_OS_DEFAULT]
-    return REPO_BRANCH_CONTEXT.get(project, {}).get("master", [])
+    return REPO_BRANCH_CONTEXT.get(project, {}).get(get_default_branch(project), [])
 
 
 def known_context(context):


### PR DESCRIPTION
The former fixes image refreshes to not have
"@cockpit-project/cockpit-machines/main" contexts. This fixes the
duplication in our test results database, where c-machines tests
appear with both a /main branch suffix and without.

This also fixes c-machines PO refreshes to not get any tests triggered.

----

Tested locally with these hacks:
```diff
-- po-refresh
+++ po-refresh
@@ -33,6 +33,11 @@ from lib import testmap
 
 def run(context, verbose=False, **kwargs):
     cwd = BASE_DIR
+    api = github.GitHub()
+    triggers = testmap.tests_for_po_refresh(api.repo)
+    print(triggers)
+    return
+
 
     def output(*args):
         if verbose:
@@ -172,8 +177,6 @@ def run(context, verbose=False, **kwargs):
     branch = task.branch(context, "po: Update from Fedora Weblate", pathspec="po/",
                          branch=local_branch, **kwargs)
 
-    api = github.GitHub()
-
     if local_branch and not branch:  # We only introduced/dropped language but otherwise no updates
         if kwargs["issue"]:
             clean = "https://github.com/{0}".format(api.repo)
--- tests-trigger
+++ tests-trigger
@@ -40,6 +40,8 @@ def trigger_pull(api, opts):
     else:
         contexts = set(statuses.keys())
         all = True
+    print(contexts)
+    return
 
     ret = 0
     for context in contexts:

```

```
╭─ martin@abakus:~/upstream/cockpit-machines [main] ────────────────────╮
❱❱❱ bots/po-refresh 
['debian-stable', 'debian-testing', 'ubuntu-2004', 'ubuntu-stable', 'fedora-33', 'fedora-34', 'fedora-33/firefox', 'rhel-8-5', 'rhel-9-0', 'centos-8-stream']
# ^^ this was empty before

╭─ martin@abakus:~/upstream/cockpit-podman [test-cleanups] ────────────────────╮
❱❱❱ bots/po-refresh
['rhel-8-4', 'fedora-33', 'fedora-34', 'fedora-34/rawhide', 'debian-testing', 'ubuntu-stable']

❱❱❱ ./tests-trigger 1868 image:rhel-8-5
{'rhel-8-5@cockpit-project/cockpit', 'rhel-8-5@cockpit-project/cockpit-machines', 'rhel-8-5-distropkg@cockpit-project/cockpit'}
# ^^^ was /main before
```