### PR TITLE
prometheus-stats: Export PR test retry status

### DIFF
--- a/prometheus-stats
+++ b/prometheus-stats
@@ -101,6 +101,29 @@ queue_time_wait_seconds_count {test_runs}
         if fail_pct > 10:
             output += f'top_failures_pct{{project="{project}",test="{test}"}} {fail_pct}\n'
 
+    # PR retries in the last 24 hours
+    pr_retries = cursor.execute("""
+            SELECT project, revision, MAX(retry)
+            FROM TestRuns
+            WHERE time > strftime('%s', 'now', '-24 hours')
+            GROUP BY project, revision""").fetchall()
+    retry_buckets = {}
+    for (project, revision, retries) in pr_retries:
+        retry_buckets[retries] = retry_buckets.setdefault(retries, 0) + 1
+    acc = 0
+
+    output += """
+# HELP pr_retries histogram of how many retries it took to get PRs from last 24h to green
+# TYPE pr_retries histogram
+"""
+    for retry_count in sorted(retry_buckets):
+        acc += retry_buckets[retry_count]
+        output += f'pr_retries_bucket{{le="{retry_count}"}} {acc}\n'
+    output += f'''pr_retries_bucket{{le="+Inf"}} {acc}
+pr_retries_sum {acc}
+pr_retries_count {acc}
+'''
+
     print(output)
 
     db_conn.close()


### PR DESCRIPTION
Export a histogram how many retries it took to get the last 24 hour's
merged pull requests to green. This does not contain any details, it is
meant to get a time series of our SLI/SLO.

----

From this:
```
sqlite> select project, revision, MAX(retry) FROM TestRuns WHERE time > strftime('%s', 'now', '-24 hours') GROUP BY project, revision;
cockpit-project/cockpit|6966dac6629c21dc4b6811b99747a8aa4557d6ee|1
cockpit-project/cockpit|87cf409c2fd7106cb0b74a72661c19ebc939cc53|1
cockpit-project/cockpit-machines|780a7257ff8ec422b44d496ee292ed510f542da9|0
cockpit-project/cockpit-machines/main|dc7ee5b5d5ff9e3178a0af80a0b89db4627f24ae|1
cockpit-project/cockpit-ostree|a83591e63a637a3e263fc55f9756c10c3ed48bb4|0
cockpit-project/cockpit-podman|02ebde7285de222db7a79f9071cfff9bb33f4db3|0
cockpit-project/cockpit-podman|62d1bba20266cf2c4d31e744433f26b1ba16ba4c|0
cockpit-project/cockpit/rhel-7.9|a83591e63a637a3e263fc55f9756c10c3ed48bb4|0
```
I get this:
```
# HELP pr_retries histogram of how many retries it took to get PRs from last 24h to green
# TYPE pr_retries histogram
pr_retries_bucket{le="0"} 5
pr_retries_bucket{le="1"} 8
pr_retries_bucket{le="+Inf"} 8
pr_retries_sum 8
pr_retries_count 8
```

_sum is of course rather bogus here, as it's a counter. I am not sure if I can just leave it out, but it doesn't really hurt.
