### PR TITLE
naughty: Improve patterns for #1739

### DIFF
--- a/naughty/fedora-33/1739-cryptsetup-systemd-umount-fs
+++ b/naughty/fedora-33/1739-cryptsetup-systemd-umount-fs
@@ -1,4 +1,4 @@
 umount: /dev/mapper/luks-*: not mounted.
 *
   File "*test/verify/check-storage-resize", line *, in testGrowShrinkEncryptedHelp
-    self.shrink_extfs(fs_dev, "200M")
+    self.shrink_extfs(fs_dev, *)

--- a/naughty/fedora-33/1739-cryptsetup-systemd-umount-fs-2
+++ b/naughty/fedora-33/1739-cryptsetup-systemd-umount-fs-2
@@ -1,5 +1,5 @@
 Traceback (most recent call last):
-  File "test/verify/check-storage-resize", line 136, in testResizeLuks
+  File "test/verify/check-storage-resize", line *, in testResizeLuks
     self.checkResize("ext4", True,
-*
-testlib.Error: timeout
+  File "test/verify/check-storage-resize", line *, in checkResize
+    b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")

--- a/naughty/fedora-34/1739-cryptsetup-systemd-umount-fs
+++ b/naughty/fedora-34/1739-cryptsetup-systemd-umount-fs
@@ -1,4 +1,4 @@
 umount: /dev/mapper/luks-*: not mounted.
 *
   File "*test/verify/check-storage-resize", line *, in testGrowShrinkEncryptedHelp
-    self.shrink_extfs(fs_dev, "200M")
+    self.shrink_extfs(fs_dev, *)

--- a/naughty/fedora-34/1739-cryptsetup-systemd-umount-fs-2
+++ b/naughty/fedora-34/1739-cryptsetup-systemd-umount-fs-2
@@ -1,5 +1,5 @@
 Traceback (most recent call last):
-  File "test/verify/check-storage-resize", line 136, in testResizeLuks
+  File "test/verify/check-storage-resize", line *, in testResizeLuks
     self.checkResize("ext4", True,
-*
-testlib.Error: timeout
+  File "test/verify/check-storage-resize", line *, in checkResize
+    b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")

--- a/naughty/rhel-9/1739-cryptsetup-systemd-umount-fs
+++ b/naughty/rhel-9/1739-cryptsetup-systemd-umount-fs
@@ -1,4 +1,4 @@
 umount: /dev/mapper/luks-*: not mounted.
 *
   File "*test/verify/check-storage-resize", line *, in testGrowShrinkEncryptedHelp
-    self.shrink_extfs(fs_dev, "200M")
+    self.shrink_extfs(fs_dev, *)

--- a/naughty/rhel-9/1739-cryptsetup-systemd-umount-fs-2
+++ b/naughty/rhel-9/1739-cryptsetup-systemd-umount-fs-2
@@ -1,5 +1,5 @@
 Traceback (most recent call last):
-  File "test/verify/check-storage-resize", line 136, in testResizeLuks
+  File "test/verify/check-storage-resize", line *, in testResizeLuks
     self.checkResize("ext4", True,
-*
-testlib.Error: timeout
+  File "test/verify/check-storage-resize", line *, in checkResize
+    b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")


### PR DESCRIPTION
- Narrow it down to only match when the filesystem is unexpectedly not
  mounted.
- Match both call sites of shrink_extfs
- Don't insist on "testlib.Error: timeout" as Firefox produces some
  weird RuntimeError here (which is probably a bug in itself).