### PR TITLE
naughty: Close 1735: fedora-34: joining AD domain fails: Couldn't join realm: Enabling SSSD in nsswitch.conf and PAM failed

### DIFF
--- a/naughty/fedora-34/1735-realm-ad-authconfig
+++ b/naughty/fedora-34/1735-realm-ad-authconfig
@@ -1,5 +1,0 @@
-*Authenticated as user: Administrator@COCKPIT.LAN*
-*/usr/sbin/authconfig: No such file or directory*
-realm: Couldn't join realm: Enabling SSSD in nsswitch.conf and PAM failed.
-Traceback (most recent call last):*
-  File "test/verify/check-system-realms", line *

--- a/naughty/fedora-34/1735-realm-ad-authconfig-2
+++ b/naughty/fedora-34/1735-realm-ad-authconfig-2
@@ -1,4 +1,0 @@
-> log: Failed to join domain: cockpit.lan: Enabling SSSD in nsswitch.conf and PAM failed.*
-Traceback (most recent call last):*
-  File "test/verify/check-system-realms", line *, in testQualifiedUsers
-    b.wait_popdown("realms-op")

--- a/naughty/rhel-9/1735-realm-ad-authconfig
+++ b/naughty/rhel-9/1735-realm-ad-authconfig
@@ -1,5 +1,0 @@
-*Authenticated as user: Administrator@COCKPIT.LAN*
-*/usr/sbin/authconfig: No such file or directory*
-realm: Couldn't join realm: Enabling SSSD in nsswitch.conf and PAM failed.
-Traceback (most recent call last):*
-  File "test/verify/check-system-realms", line *

--- a/naughty/rhel-9/1735-realm-ad-authconfig-2
+++ b/naughty/rhel-9/1735-realm-ad-authconfig-2
@@ -1,4 +1,0 @@
-> log: Failed to join domain: cockpit.lan: Enabling SSSD in nsswitch.conf and PAM failed.*
-Traceback (most recent call last):*
-  File "test/verify/check-system-realms", line *, in testQualifiedUsers
-    b.wait_popdown("realms-op")


### PR DESCRIPTION
Known issue which has not occurred in 28 days

fedora-34: joining AD domain fails: Couldn't join realm: Enabling SSSD in nsswitch.conf and PAM failed

Fixes #1735