### PR TITLE
Moar prometheus stats

### DIFF
--- a/prometheus-stats
+++ b/prometheus-stats
@@ -73,7 +73,36 @@ queue_time_wait_seconds_bucket{{le="3600"}} {test_runs_wait_1h}
 queue_time_wait_seconds_bucket{{le="+Inf"}} {test_runs}
 queue_time_wait_seconds_sum {test_runs_queue_wait_sum}
 queue_time_wait_seconds_count {test_runs}
+"""
 
+    # Get total number of test runtime in the last 24 hours
+    test_run_seconds_sum = cursor.execute("""\
+            SELECT SUM(run_seconds)
+            FROM TestRuns
+            WHERE time > strftime('%s', 'now', '-24 hours')""").fetchone()[0]
+    if test_run_seconds_sum is None:
+        test_run_seconds_sum = 0
+
+    # How many tests ran for < 1 hour
+    test_run_seconds_1h = cursor.execute("""\
+            SELECT COUNT(*)
+            FROM TestRuns
+            WHERE time > strftime('%s', 'now', '-24 hours') AND run_seconds <= 3600""").fetchone()[0]
+
+    # How many tests ran for < 2 hour
+    test_run_seconds_2h = cursor.execute("""\
+            SELECT COUNT(*)
+            FROM TestRuns
+            WHERE time > strftime('%s', 'now', '-24 hours') AND run_seconds <= 7200""").fetchone()[0]
+
+    output += f"""
+# HELP test_run_seconds histogram of test execution time in the last 24 hours
+# TYPE test_run_seconds histogram
+test_run_seconds_bucket{{le="3600"}} {test_run_seconds_1h}
+test_run_seconds_bucket{{le="7200"}} {test_run_seconds_2h}
+test_run_seconds_bucket{{le="+Inf"}} {test_runs}
+test_run_seconds_sum {test_run_seconds_sum}
+test_run_seconds_count {test_runs}
 """
 
     # failures
@@ -93,7 +122,8 @@ queue_time_wait_seconds_count {test_runs}
             ORDER BY percent DESC
             LIMIT 50""").fetchall()
 
-    output += """# HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
+    output += """
+# HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
 # TYPE top_failures_pct gauge
 """
     for (project, test, fail_pct) in top_failures:

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -32,7 +32,7 @@ HOUR = 3600
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Generate statistics about failed tests')
+    parser = argparse.ArgumentParser(description='Generate infrastructure and test statistics')
     parser.add_argument("--db", default="test-results.db", help="Database name")
     parser.add_argument("--hours", default=12, type=int,
                         help="Number of hours to take statistics from. Default is %(default)s.")

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -21,7 +21,6 @@ import argparse
 import logging
 import sqlite3
 import sys
-import time
 import urllib.parse
 
 from lib import stores, s3
@@ -34,8 +33,6 @@ HOUR = 3600
 def main():
     parser = argparse.ArgumentParser(description='Generate infrastructure and test statistics')
     parser.add_argument("--db", default="test-results.db", help="Database name")
-    parser.add_argument("--hours", default=12, type=int,
-                        help="Number of hours to take statistics from. Default is %(default)s.")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     opts = parser.parse_args()
 
@@ -45,17 +42,15 @@ def main():
     db_conn = sqlite3.connect(opts.db)
     cursor = db_conn.cursor()
 
-    since = time.time() - opts.hours * HOUR
-
     # Output in prometheus format, see:
     # https://prometheus.io/docs/instrumenting/exposition_formats/
     output = ""
 
-    # Get total number of runs and wait time sum in last N hours
+    # Get total number of runs and wait time sum in last 24 hours
     (test_runs, test_runs_queue_wait_sum) = cursor.execute("""\
             SELECT COUNT(*), SUM(wait_seconds)
             FROM TestRuns
-            WHERE time > ? ;""", (since, )).fetchone()
+            WHERE time > strftime('%s', 'now', '-24 hours')""").fetchone()
     if test_runs_queue_wait_sum is None:
         test_runs_queue_wait_sum = 0
 
@@ -63,15 +58,15 @@ def main():
     test_runs_wait_5m = cursor.execute("""\
             SELECT COUNT(*)
             FROM TestRuns
-            WHERE time > ? AND wait_seconds <= 300; """, (since, )).fetchone()[0]
+            WHERE time > strftime('%s', 'now', '-24 hours') AND wait_seconds <= 300""").fetchone()[0]
 
     # Get how many test runs waited for at most 1 hour
     test_runs_wait_1h = cursor.execute("""\
             SELECT COUNT(*)
             FROM TestRuns
-            WHERE time > ? AND wait_seconds <= 3600; """, (since, )).fetchone()[0]
+            WHERE time > strftime('%s', 'now', '-24 hours') AND wait_seconds <= 3600""").fetchone()[0]
 
-    output += f"""# HELP queue_time_wait_seconds histogram of queue wait times in the last {opts.hours} hours
+    output += f"""# HELP queue_time_wait_seconds histogram of queue wait times in the last 24 hours
 # TYPE queue_time_wait_seconds histogram
 queue_time_wait_seconds_bucket{{le="300"}} {test_runs_wait_5m}
 queue_time_wait_seconds_bucket{{le="3600"}} {test_runs_wait_1h}

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -102,13 +102,16 @@ queue_time_wait_seconds_count {test_runs}
 
     # PR retries in the last 24 hours
     pr_retries = cursor.execute("""
-            SELECT project, revision, MAX(retry)
+            SELECT project, revision, state, MAX(retry)
             FROM TestRuns
             WHERE time > strftime('%s', 'now', '-24 hours')
             GROUP BY project, revision""").fetchall()
     retry_buckets = {}
-    for (project, revision, retries) in pr_retries:
+    merged_failures = 0
+    for (project, revision, state, retries) in pr_retries:
         retry_buckets[retries] = retry_buckets.setdefault(retries, 0) + 1
+        if state != 'success':
+            merged_failures += 1
     acc = 0
 
     output += """
@@ -122,6 +125,12 @@ queue_time_wait_seconds_count {test_runs}
 pr_retries_sum {acc}
 pr_retries_count {acc}
 '''
+
+    output += f"""
+# HELP merged_failures How many PRs were merged with non-successful tests in the last 24h
+# TYPE merged_failures gauge
+merged_failures {merged_failures}
+"""
 
     # S3 space usage
     space_usage = {}


### PR DESCRIPTION
Implements two more things from our [SLIs](https://github.com/cockpit-project/cockpit/wiki/DevelopmentPrinciples#our-testsci-error-budget). Now only item 6 is missing, and I think we should just drop item 7.

```
❱❱❱ ./prometheus-stats
# HELP queue_time_wait_seconds histogram of queue wait times in the last 24 hours
# TYPE queue_time_wait_seconds histogram
queue_time_wait_seconds_bucket{le="300"} 19
queue_time_wait_seconds_bucket{le="3600"} 19
queue_time_wait_seconds_bucket{le="+Inf"} 19
queue_time_wait_seconds_sum 1028
queue_time_wait_seconds_count 19

# HELP test_run_seconds histogram of test execution time in the last 24 hours
# TYPE test_run_seconds histogram
test_run_seconds_bucket{le="3600"} 19
test_run_seconds_bucket{le="7200"} 19
test_run_seconds_bucket{le="+Inf"} 19
test_run_seconds_sum 23781
test_run_seconds_count 19

# HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
# TYPE top_failures_pct gauge
top_failures_pct{project="cockpit-project/cockpit/rhel-7.9",test="testIpa (check_realms.TestRealms)"} 40.0
top_failures_pct{project="osbuild/cockpit-composer",test="test/verify/check-image TestLargeImage.testOpenStack"} 23.076923076923077

# HELP pr_retries histogram of how many retries it took to get PRs from last 24h to green
# TYPE pr_retries histogram
pr_retries_bucket{le="0"} 2
pr_retries_bucket{le="1"} 4
pr_retries_bucket{le="5"} 5
pr_retries_bucket{le="+Inf"} 5
pr_retries_sum 5
pr_retries_count 5

# HELP merged_failures How many PRs were merged with non-successful tests in the last 24h
# TYPE merged_failures gauge
merged_failures 1

# HELP s3_usage_bytes How much disk space an S3 store is using
# TYPE s3_usage_bytes gauge
s3_usage_bytes{store="https://cockpit-images.eu-central-1.linodeobjects.com/"} 65802411520
s3_usage_bytes{store="https://cockpit-images.us-east-1.linodeobjects.com/"} 68112731648
```

I also tried with 48h, where we get a "non-perfect"  runtime:
```
test_run_seconds_bucket{le="3600"} 78
test_run_seconds_bucket{le="7200"} 83
test_run_seconds_bucket{le="+Inf"} 19
test_run_seconds_sum 162604
test_run_seconds_count 19
```
Corresponding to the [wheather report](https://logs-https-frontdoor.apps.ocp.ci.centos.org/tests.html)