### PR TITLE
testmap: test rhel-8-4 for subscription-manager/1.28

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -155,6 +155,9 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'rhel-8-4',
         ],
+        'subscription-manager-1.28': [
+            'rhel-8-4',
+        ],
         '_manual': [
             'rhel-8-5',
             'rhel-9-0',


### PR DESCRIPTION
Test the subscription-manager-1.28 branch of subscription-manager using
rhel-8-4, as that branch is the current for RHEL 8.4.

 - [x] Land https://github.com/candlepin/subscription-manager/pull/2582