### PR TITLE
naughty: Add pattern for QEMU 6.0.0rc2 network attachment crash

### DIFF
--- a/naughty/fedora-35/1927-qemu-net-attach-crash
+++ b/naughty/fedora-35/1927-qemu-net-attach-crash
@@ -1,0 +1,8 @@
+  File "tests/test/check-machines-nics", line *, in testNICAdd
+    self.NICAddDialog(
+  File "tests/test/check-machines-nics", line *, in execute
+    self.create()
+  File "tests/test/check-machines-nics", line *, in create
+    self.browser.wait_not_present("#vm-subVmTest1-add-iface-dialog")
+*
+testlib.Error: timeout


### PR DESCRIPTION
This currently only happens in Fedora rawhide (35) during
cockpit-machines tests. See
https://github.com/cockpit-project/cockpit-machines/pull/110

https://bugzilla.redhat.com/show_bug.cgi?id=1949786
Known issue #1927

----

This is difficult to test in our CI, as we don't have fedora-35 images. I reproduced the crash in `tmt run`, locally applied this bots change in the test instance, and it's correctly recognized:
```
$ TEST_OS=fedora-35 test/common/run-tests TestMachinesNICs.testNICAdd --machine localhost:22 --browser localhost:9090 
[...]
# Result testNICAdd (__main__.TestMachinesNICs) failed
# 1 TEST FAILED [80s on testcloud]
ok 1 /var/tmp/tmt/run-001/plans/all/discover/default/tests/test/check-machines-nics TestMachinesNICs.testNICAdd [ND@0] # SKIP Known issue #1927
```