### PR TITLE
testmap: Validate service image refresh against subscription-manager

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -202,6 +202,7 @@ IMAGE_REFRESH_TRIGGERS = {
         "debian-stable@cockpit-project/cockpit",
         "rhel-8-4@cockpit-project/cockpit",
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",
+        "rhel-8-4@candlepin/subscription-manager",
     ]
 }
 


### PR DESCRIPTION
subscription-manager's tests run against candlepin and thus are affected
by behaviour changes.