### PR TITLE
Drop environment checks from {tests,issue}-scan

### DIFF
--- a/issue-scan
+++ b/issue-scan
@@ -29,10 +29,6 @@ REDHAT_TASKS = [
     "redhat"
 ]
 
-KUBERNETES_TASKS = [
-    ".svc.cluster.local"
-]
-
 import argparse
 import pipes
 import sys
@@ -42,7 +38,6 @@ import logging
 sys.dont_write_bytecode = True
 logging.basicConfig(level=logging.INFO)
 
-from lib.stores import redhat_network
 from lib import testmap
 from task import github, distributed_queue, labels_of_pull
 
@@ -68,30 +63,11 @@ def main():
     if opts.amqp and no_amqp:
         parser.error("AMQP host:port specified but python-amqp not available")
 
-    # Figure if we're in a Kubernetes namespace. This file will always exist
-    try:
-        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
-            namespace = f.read().strip()
-    except IOError:
-        namespace = None
-
     for result in scan(opts.issues_data, opts.verbose, opts.repo):
         if opts.amqp:
             with distributed_queue.DistributedQueue(opts.amqp, queues=['rhel', 'public']) as q:
                 queue_task(q.channel, result)
             continue
-
-        elif not redhat_network() and contains_any(result, REDHAT_TASKS):
-            sys.stderr.write("issue-scan: skipping (outside redhat): {0}\n".format(result))
-            continue
-        elif contains_any(result, KUBERNETES_TASKS):
-            if not namespace:
-                sys.stderr.write("issue-scan: skipping (not in kubernetes): {0}\n".format(result))
-                continue
-            url = namespace + KUBERNETES_TASKS[0]
-            if url not in result:
-                sys.stderr.write("issue-scan: skipping (not same namespace): {0}\n".format(result))
-                continue
         sys.stdout.write(result + "\n")
 
     return 0

--- a/tests-scan
+++ b/tests-scan
@@ -27,7 +27,6 @@ import logging
 sys.dont_write_bytecode = True
 logging.basicConfig(level=logging.INFO)
 
-from lib.stores import redhat_network
 from task import github, labels_of_pull, distributed_queue
 from lib import testmap
 
@@ -131,9 +130,6 @@ def is_internal_context(context):
 # Prepare a test invocation command
 def tests_invoke(priority, name, number, revision, ref, context, base,
                  repo, bots_ref, github_context, options):
-    if not options.amqp and not redhat_network() and is_internal_context(context):
-        return ''
-
     try:
         priority = int(priority)
     except (ValueError, TypeError):


### PR DESCRIPTION
These only ever output to AMQP or to stdout, neither of which requires
any Red Hat internal resources. This distinction is only necessary in
run-queue.