### PR TITLE
testmap: Allow "pixeldiffs" context for starterkit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -66,6 +66,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'fedora-34/firefox',
+            'pixeldiffs',
         ],
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
This is used for reviewing changes to pixel tests.  We want to "abuse"
our testing machinery to produce a nice web page.