### PR TITLE
Add sshpass to TEST_PACKAGES for machines migration tests

### DIFF
--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -61,6 +61,7 @@ mdadm \
 nfs-server \
 podman \
 qemu-kvm \
+sshpass \
 socat \
 systemd-coredump \
 systemd-timesyncd \

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -156,6 +156,7 @@ ltrace \
 nmap-ncat \
 python3-tracer \
 qemu-kvm \
+sshpass \
 socat \
 strace \
 tang \


### PR DESCRIPTION
I use sshpass to set up key authentication between machines for migration tests for cockpit-machines https://github.com/cockpit-project/cockpit-machines/pull/15

 * [ ] FAIL: image-refresh centos-8-stream
 * [ ] FAIL: image-refresh rhel-8-5
 * [ ] FAIL: image-refresh rhel-9-0
 * [x] image-refresh ubuntu-2004
 * [x] image-refresh ubuntu-stable
 * [x] image-refresh debian-stable
 * [x] image-refresh debian-testing