### PR TITLE
naughty: Add pattern for cryptsetup resize on a LUKS

### DIFF
--- a/naughty/ubuntu-stable/1739-cryptsetup-systemd-umount-fs
+++ b/naughty/ubuntu-stable/1739-cryptsetup-systemd-umount-fs
@@ -1,0 +1,4 @@
+umount: /dev/mapper/luks-*: not mounted.
+*
+  File "*test/verify/check-storage-resize", line *, in testGrowShrinkEncryptedHelp
+    self.shrink_extfs(fs_dev, *)

--- a/naughty/ubuntu-stable/1739-cryptsetup-systemd-umount-fs-2
+++ b/naughty/ubuntu-stable/1739-cryptsetup-systemd-umount-fs-2
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-resize", line *, in testResizeLuks
+    self.checkResize("ext4", True,
+*
+  File "test/verify/storagelib.py", line *, in wait_mounted
+    self.content_tab_wait_in_info(row, col, "Mount point",


### PR DESCRIPTION
ubuntu-stable moved to 21.04 and this issue has been brought in.
As seen in https://github.com/cockpit-project/cockpit/pull/15772 or https://github.com/cockpit-project/cockpit/pull/15772