### PR TITLE
testmap: Remove "pixeldiffs" context again

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -66,7 +66,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'fedora-34/firefox',
-            'pixeldiffs',
         ],
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
We are not going to use it, uff.