### PR TITLE
naughty: Close 1927: qemu 6.0.0rc2 regression: attaching network interface crashes with segfault

### DIFF
--- a/naughty/fedora-35/1927-qemu-net-attach-crash
+++ b/naughty/fedora-35/1927-qemu-net-attach-crash
@@ -1,8 +1,0 @@
-  File "tests/test/check-machines-nics", line *, in testNICAdd
-    self.NICAddDialog(
-  File "tests/test/check-machines-nics", line *, in execute
-    self.create()
-  File "tests/test/check-machines-nics", line *, in create
-    self.browser.wait_not_present("#vm-subVmTest1-add-iface-dialog")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 22 days

qemu 6.0.0rc2 regression: attaching network interface crashes with segfault

Fixes #1927