### PR TITLE
naughty: Close 1711: subscription-manager-cockpit is broken on rhel-8-4 images: [Errno 20] Not a directory: '/etc/pki/product'

### DIFF
--- a/naughty/rhel-8/1711-sub-man-missing-product
+++ b/naughty/rhel-8/1711-sub-man-missing-product
@@ -1,3 +1,0 @@
-warning: [Errno 20] Not a directory: '/etc/pki/product'*
-Traceback (most recent call last):*
-  File "integration-tests/check-subscriptions", *


### PR DESCRIPTION
Known issue which has not occurred in 28 days

subscription-manager-cockpit is broken on rhel-8-4 images: [Errno 20] Not a directory: '/etc/pki/product'

Fixes #1711