### PR TITLE
naughty: Close 1435: rhel-8.4/centos 8 stream have wrong version of kvdo module

### DIFF
--- a/naughty/rhel-8/1435-kmod-kvdo-version
+++ b/naughty/rhel-8/1435-kmod-kvdo-version
@@ -1,3 +1,0 @@
-*__main__.TestStorageVDO*
-*
-*vdo: ERROR - modprobe: FATAL: Module kvdo not found in directory /lib/modules/4.*.el8.*


### PR DESCRIPTION
Known issue which has not occurred in 24 days

rhel-8.4/centos 8 stream have wrong version of kvdo module

Fixes #1435