### PR TITLE
Image refresh for fedora-coreos

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-1c1d1022e253ab4e85f24e378a85710f3aae4dc999dd42b964fd548177d01e6e.qcow2
+fedora-coreos-293d7217c4cc24202deb059fb9bfa987dce238c82cc35ad7a4de074da38a50e0.qcow2

--- a/naughty/fedora-coreos/2031-selinux-systemd-hostnam
+++ b/naughty/fedora-coreos/2031-selinux-systemd-hostnam
@@ -1,0 +1,2 @@
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+audit*avc:  denied  { write } for * comm="systemd-hostnam" name="systemd" dev="tmpfs" *


### PR DESCRIPTION
Image refresh for fedora-coreos
 * [x] image-refresh fedora-coreos
 * [x] https://github.com/cockpit-project/cockpit/pull/15837
 * [x] add naughty for new SELinux systemd-hostnam violation