### PR TITLE
testmap: rename subscription-manager/master to main

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -152,7 +152,7 @@ REPO_BRANCH_CONTEXT = {
         ],
     },
     'candlepin/subscription-manager': {
-        'master': [
+        'main': [
             'rhel-8-4',
         ],
         'subscription-manager-1.28': [


### PR DESCRIPTION
The 'master' branch of subscription-manager was renamed to 'main'
yesterday; hence update its reference.