### PR TITLE
naughty: Close 1830: rhel 9: sssd-ifp.service fails to start

### DIFF
--- a/naughty/rhel-9/1830-sssd-ifp-crash
+++ b/naughty/rhel-9/1830-sssd-ifp-crash
@@ -1,1 +1,0 @@
-busctl get-property org.freedesktop.sssd.infopipe * returned non-zero exit status 1


### PR DESCRIPTION
Known issue which has not occurred in 21 days

rhel 9: sssd-ifp.service fails to start

Fixes #1830