### PR TITLE
naughty: Close 1745: fedora-34: udev causes drives' properties Model, Id, Vendor some encoding issues

### DIFF
--- a/naughty/fedora-34/1745-udev-drive-names-encode
+++ b/naughty/fedora-34/1745-udev-drive-names-encode
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-mdraid", line *, in *
-    self.wait_states({"QEMU QEMU HARDDISK (DISK1)": "In sync",
-*
-testlib.Error: timeout

--- a/naughty/fedora-34/1745-udev-drive-names-encode-2
+++ b/naughty/fedora-34/1745-udev-drive-names-encode-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-mdraid", line *, in testRaid
-    b.wait_in_text("#drives", "DISK1")
-*
-testlib.Error: timeout

--- a/naughty/fedora-34/1745-udev-drive-names-encode-3
+++ b/naughty/fedora-34/1745-udev-drive-names-encode-3
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-lvm2", line *, in testUnpartitionedSpace
-    self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create volume group'),
-*
-testlib.Error: timed out waiting for predicate to become true

--- a/naughty/fedora-34/1745-udev-drive-names-encode-4
+++ b/naughty/fedora-34/1745-udev-drive-names-encode-4
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/test/verify/check-storage-iscsi", line *, in testISCSI
-    b.wait_in_text('#drives', "LIO-ORG test")
-*
-testlib.Error: timeout

--- a/naughty/rhel-9/1745-udev-drive-names-encode
+++ b/naughty/rhel-9/1745-udev-drive-names-encode
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-mdraid", line *, in *
-    self.wait_states({"QEMU QEMU HARDDISK (DISK1)": "In sync",
-*
-testlib.Error: timeout

--- a/naughty/rhel-9/1745-udev-drive-names-encode-2
+++ b/naughty/rhel-9/1745-udev-drive-names-encode-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-mdraid", line *, in testRaid
-    b.wait_in_text("#drives", "DISK1")
-*
-testlib.Error: timeout

--- a/naughty/rhel-9/1745-udev-drive-names-encode-3
+++ b/naughty/rhel-9/1745-udev-drive-names-encode-3
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-lvm2", line *, in testUnpartitionedSpace
-    self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create volume group'),
-*
-testlib.Error: timed out waiting for predicate to become true

--- a/naughty/rhel-9/1745-udev-drive-names-encode-4
+++ b/naughty/rhel-9/1745-udev-drive-names-encode-4
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "/test/verify/check-storage-iscsi", line *, in testISCSI
-    b.wait_in_text('#drives', "LIO-ORG test")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 25 days

fedora-34: udev causes drives' properties Model, Id, Vendor some encoding issues

Fixes #1745