### PR TITLE
naughty: Close 1734: Fedora 34: kdump: kexec: failed to load kdump kernel

### DIFF
--- a/naughty/fedora-34/1734-kdump-memory
+++ b/naughty/fedora-34/1734-kdump-memory
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    b.wait_in_text("#app", "256 MiB")
-*
-testlib.Error: timeout

--- a/naughty/fedora-34/1734-kdump-service
+++ b/naughty/fedora-34/1734-kdump-service
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    b.wait_in_text("#app", "Service is running")
-*
-testlib.Error: timeout

--- a/naughty/rhel-9/1734-kdump-service
+++ b/naughty/rhel-9/1734-kdump-service
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    b.wait_in_text("#app", "Service is running")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 21 days

Fedora 34: kdump: kexec: failed to load kdump kernel

Fixes #1734