### PR TITLE
naughty: Close 1691: RHEL 8.4/9.0 regression: Job for pmlogger.service failed because the service did not take the steps required by its unit configuration

### DIFF
--- a/naughty/rhel-9/1691-pmlogger-start-failure
+++ b/naughty/rhel-9/1691-pmlogger-start-failure
@@ -1,3 +1,0 @@
-Job for pmlogger.service failed because the service did not take the steps required by its unit configuration.*
-Traceback (most recent call last):*
-  File "test/verify/check-metrics", line *, in testBasic


### PR DESCRIPTION
Known issue which has not occurred in 21 days

RHEL 8.4/9.0 regression: Job for pmlogger.service failed because the service did not take the steps required by its unit configuration

Fixes #1691