### PR TITLE
naughty: Close 1372: In debian-stable images libvirt crashes when freeing up resources in TestMachines tests

### DIFF
--- a/naughty/debian-stable/1372-libvirt-crashes-on-test-teardown
+++ b/naughty/debian-stable/1372-libvirt-crashes-on-test-teardown
@@ -1,6 +1,0 @@
-*TestMachines*
-*
-Process * (libvirtd) of user * dumped core.*
-#1  * virQEMUDriverGetConfig (libvirt_driver_qemu.so)
-*
-#3  * virStateStop (libvirt.so.0)


### PR DESCRIPTION
Known issue which has not occurred in 22 days

In debian-stable images libvirt crashes when freeing up resources in TestMachines tests

Fixes #1372