### PR TITLE
naughty: Add pattern for Fedora CoreOS agetty.reload SELinux violation

### DIFF
--- a/naughty/fedora-coreos/2032-selinux-agetty.reload
+++ b/naughty/fedora-coreos/2032-selinux-agetty.reload
@@ -1,0 +1,1 @@
+* type=1400 * avc:  denied  { watch } for * comm="agetty" path="/run/agetty.reload"


### PR DESCRIPTION
Fixes failures like [this](https://logs.cockpit-project.org/logs/pull-15841-20210519-040829-bcbe6949-fedora-coreos/log.html)