### PR TITLE
naughty: Close 1095: user libvirtd crashes when session goes down

### DIFF
--- a/naughty/debian-testing/1095-libvirtd-crash-on-session-shutdown
+++ b/naughty/debian-testing/1095-libvirtd-crash-on-session-shutdown
@@ -1,4 +1,0 @@
-  File "test/common/testlib.py", line *, in tearDown
-    self.check_journal_messages()
-*
-Process * (libvirtd) of user 10* dumped core.


### PR DESCRIPTION
Known issue which has not occurred in 26 days

user libvirtd crashes when session goes down

Fixes #1095