### PR TITLE
WIP: 2-ci-srv-03: [no-test] scripts: tweak Fedora image finding logic

### DIFF
--- a/images/scripts/fedora-33.bootstrap
+++ b/images/scripts/fedora-33.bootstrap
@@ -17,8 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-URL=https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/
-IMAGE=$(curl -L -s "$URL" | sed -n '/<a href=.*Fedora-Cloud-Base-33.*qcow2"/ { s/^.*href="//; s_".*$__; p }')
+set -eux
+
+URL='https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/'
+IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"')"
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"

--- a/images/scripts/fedora-34.bootstrap
+++ b/images/scripts/fedora-34.bootstrap
@@ -17,10 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA.
 
-set -ex
+set -eux
 
-URL=https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/
-IMAGE=$(curl -L -s "$URL" | sed -n '/<a href=.*Fedora-Cloud-Base-34.*qcow2"/ { s/^.*href="//; s_".*$__; p }')
+URL='https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/'
+IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"')"
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"


### PR DESCRIPTION
 - set the usual `-eux` on the script.  We had a check for an empty
   image written as `[ -n "${IMAGE}" ]` and that was failing because of
   no `-e`.  The other two are also nice.

 - simplify the detection logic so it's a bit easier to understand:
   anything that looks like a filename in quotes will do.

 * [x] image-refresh fedora-34
 * [ ] image-refresh fedora-33
 * [ ] image-refresh fedora-testing