### PR TITLE
naughty: Close 1956: tuned breaks podman networking in Ubuntu 21.04

### DIFF
--- a/naughty/ubuntu-stable/1956-podman-port-exposure
+++ b/naughty/ubuntu-stable/1956-podman-port-exposure
@@ -1,5 +1,0 @@
-  File "test/check-application", line *, in testDownloadImage
-*
-    self.execute(True, "podman tag quay.io/libpod/busybox localhost:5000/my-busybox && podman push localhost:5000/my-busybox")
-*
-RuntimeError: Timed out


### PR DESCRIPTION
Known issue which has not occurred in 25 days

tuned breaks podman networking in Ubuntu 21.04

Fixes #1956