### PR TITLE
Revert "naughty: Close 1785: fedora-34: reportd crashes in g_bus_unown_name()"

### DIFF
--- a/naughty/fedora-34/1785-reportd-crash-g_bus_unown_name
+++ b/naughty/fedora-34/1785-reportd-crash-g_bus_unown_name
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-system-journal", line *, in testAbrtReport
+    b.wait_visible(".pf-c-modal-box__body input[type='%s']" % (purpose))
+*
+testlib.Error: timeout


### PR DESCRIPTION
This reverts commit b7a2bfe9e5ce49c771ab89823cfc6e02580fa9ae.

Reportd still crashes.  With a different backtrace and in different
scenarios but let's just treat all these crashes the same.