### PR TITLE
images: Use only first link when looking for a bootstrap image

### DIFF
--- a/images/scripts/fedora-33.bootstrap
+++ b/images/scripts/fedora-33.bootstrap
@@ -20,7 +20,7 @@
 set -eux
 
 URL='https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/'
-IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"')"
+IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"' | head -n1)"
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"

--- a/images/scripts/fedora-34.bootstrap
+++ b/images/scripts/fedora-34.bootstrap
@@ -20,7 +20,7 @@
 set -eux
 
 URL='https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/'
-IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"')"
+IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"' | head -n1)"
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"


### PR DESCRIPTION
 * [x] image-refresh fedora-34

Some mirrors return directory listings that have two links for each
entry, like this:

```
   <tr class="even">
    <td class="indexcolicon">
     <a href="Fedora-Cloud-Base-34-1.2.x86_64.qcow2"><img src="/icons2/drive-harddisk.png" alt="[VM]"></a>
    </td>
    <td class="indexcolname">
     <a href="Fedora-Cloud-Base-34-1.2.x86_64.qcow2">Fedora-Cloud-Base-34-1.2.x86_64.qcow2</a>
    </td>
    <td class="indexcollastmod">2021-04-23 12:59  </td><td class="indexcolsize">249M</td>
   </tr>
```

Let's make sure there is only one word in the IMAGES variable in this case.