### PR TITLE
sync-quay: Drop obsolete selenium containers

### DIFF
--- a/sync-quay
+++ b/sync-quay
@@ -7,6 +7,3 @@ function sync() {
 }
 
 sync nowsci samba-domain
-sync selenium hub:3
-sync selenium node-chrome-debug:3
-sync selenium node-firefox-debug:3


### PR DESCRIPTION
We don't need these any more since commit 29e7d3b51e10.