### PR TITLE
task: add ~/.config/cockpit-dev/allowed-users

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -392,6 +392,15 @@ class GitHub(object):
         raise KeyError("Team {0} not found".format(name))
 
     def is_user_allowed(self, user):
+        # First, check the local userlist, if it exists:
+
+        try:
+            with open(xdg_config_home('cockpit-dev', 'allowed-users'), "r") as f:
+                if user in f.read().split():
+                    return True
+        except FileNotFoundError:
+            pass
+
         # Firstly check if user has push access
         data = self.get("/repos/{0}/collaborators/{1}/permission".format(self.repo, user)) or {}
         if data.get("permission") in ["admin", "write"]:


### PR DESCRIPTION
Add a local file which can be used as an alternative to querying
permitted users for test runs from GitHub (which requires a fairly
powerful token).

Putting your own GitHub login in your allowed-users file, for example,
will allow you to use tests-scan or tests-trigger on your own pull
requests, with a token that has only the repo:status scope.

The permitted users must be separated by whitespace, eg. one per line.