### PR TITLE
task: Fix is_user_allowed() for low-privileged tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ the [GitHub CLI](https://cli.github.com/) configuration in
 
     https://github.com/settings/tokens
 
-When generating a new personal access token, the scope only needs to
-encompass `public_repo` (or `repo` if you're accessing a private repo).
+When generating a new personal access token, the scope should only contain
+`repo:status` and `read:org`.  Note in particular, that `repo` and
+`public_repo` scopes each grant full push access, and should not be used.
 
 If you'd like to download Red Hat-only internal images from S3, you'll
 need to create a key file in `~/.config/cockpit-dev/s3-keys/[domain]`.

--- a/task/github.py
+++ b/task/github.py
@@ -88,10 +88,16 @@ class GitHubError(RuntimeError):
         self.reason = response.get('reason')
 
     def __str__(self):
-        return ('Error accessing {0}\n'
-                '  Status: {1}\n'
-                '  Reason: {2}\n'
-                '  Response: {3}'.format(self.url, self.status, self.reason, self.data))
+        result = (f'Error accessing {self.url}\n'
+                  f'  Status: {self.status}\n'
+                  f'  Reason: {self.reason}\n'
+                  f'  Response: {self.data}')
+
+        if self.status == 401:
+            result += ('\n\nPlease ensure that your github-token is configured '
+                       'with the appropriate permissions.  See bots/README.md')
+
+        return result
 
 
 def get_repo():
@@ -392,12 +398,6 @@ class GitHub(object):
         raise KeyError("Team {0} not found".format(name))
 
     def is_user_allowed(self, user):
-        # Firstly check if user has push access
-        data = self.get("/repos/{0}/collaborators/{1}/permission".format(self.repo, user)) or {}
-        if data.get("permission") in ["admin", "write"]:
-            return True
-
-        # User does not have push access, lets check if in `Contributors` group
         return user in self.allowlist()
 
 


### PR DESCRIPTION
If the token does not have `public_repo` permissions, reading the
project collaborators will fail. This caused a `GitHubError` crash
and prevented the intended fallback to self.allowlist(). Turn that
exception into a warning instead.