### PR TITLE
task: Move default AMQP server to AWS fallback

### DIFF
--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -43,7 +43,10 @@ BASELINE_PRIORITY = 5
 MAX_PRIORITY = 9
 # see https://github.com/cockpit-project/cockpituous/blob/master/tasks/cockpit-tasks-webhook.yaml
 DEFAULT_SECRETS_DIR = '/run/secrets/webhook'
-DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
+# main deployment on CentOS CI
+# DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
+# fallback deployment on AWS
+DEFAULT_AMQP_SERVER = 'ec2-54-210-157-13.compute-1.amazonaws.com:5671'
 
 arguments = {
     'rhel': {


### PR DESCRIPTION
CentOS CI has been down since yesterday, switch to our new fallback
deployment on AWS [1]

[1] https://github.com/cockpit-project/cockpituous/pull/419

----

Tested with
```
❱❱❱ ./inspect-queue  --secrets-dir ~/redhat/ci-secrets/webhook/
public queue:
{"command": "./publish-wrapper --repo cockpit-project/bots --test-name pull-2078-20210609-074241 --github-context fedora-33@osbuild/cockpit-composer --revision 4fbc4918b4f1e4bc86f5311990570ec29effa651 \"PRIORITY=0005 ./make-checkout --verbose --repo=osbuild/cockpit-composer master && cd make-checkout-workdir && TEST_OS=fedora-33 BASE_BRANCH=master COCKPIT_BOTS_REF=4fbc4918b4f1e4bc86f5311990570ec29effa651 ../tests-invoke --pull-number 2078 --revision 4fbc4918b4f1e4bc86f5311990570ec29effa651 --repo cockpit-project/bots\"", "type": "test", "sha": "4fbc4918b4f1e4bc86f5311990570ec29effa651", "ref": "master", "name": "pull-2078"}
[...]
```

With current master it tries to talk to CentOS CI, which fails with `ssl.SSLEOFError`.