### PR TITLE
Revert: task: Move default AMQP server to AWS fallback

### DIFF
--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -44,9 +44,9 @@ MAX_PRIORITY = 9
 # see https://github.com/cockpit-project/cockpituous/blob/master/tasks/cockpit-tasks-webhook.yaml
 DEFAULT_SECRETS_DIR = '/run/secrets/webhook'
 # main deployment on CentOS CI
-# DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
+DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
 # fallback deployment on AWS
-DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
+# DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
 
 arguments = {
     'rhel': {


### PR DESCRIPTION
CentOS CI is back online, and the webhook works much more reliably
there.

This reverts commit 836457afd43b1971, but keeps the fallback commented
out for the future.