### PR TITLE
workflows: Ignore changes to machine_core for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
           git config user.email github-actions@github.com
           git rebase origin/master
 
-      - name: Check whether anything besides images/ or naughty/ changed
+      - name: Check whether anything besides images/, machine_core/, or naughty/ changed
         id: changes
         run: |
-          changes=$(git diff --name-only origin/master..HEAD | grep -Ev '^(images|naughty)/' || true)
+          changes=$(git diff --name-only origin/master..HEAD | grep -Ev '^(images|naughty|machine/machine_core)/' || true)
           # print for debugging
           echo "changes:"
           echo "$changes"


### PR DESCRIPTION
These will now happen very often due to the allowed_messages(). There is
no need to run the deployment test on these.

---

The integration test [fails very often](https://github.com/cockpit-project/bots/actions/runs/927575743) , in particular if there is more than one running test. I'll look at this, but there are still several much bigger fires burning right now.