### PR TITLE
machine_core: Handle EAGAIN from os.write() [sleep version]

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -30,6 +30,16 @@ from . import exceptions
 from . import timeout as timeoutlib
 
 
+def write_all(fd, data):
+    while len(data) > 0:
+        try:
+            written = os.write(fd, data)
+            data = data[written:]
+        except BlockingIOError:
+            time.sleep(0.1)
+            pass
+
+
 class SSHConnection(object):
     ssh_default_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "BatchMode=yes"]
 
@@ -328,7 +338,7 @@ class SSHConnection(object):
                             proc.stdout.close()
                         else:
                             if self.verbose:
-                                os.write(sys.__stdout__.fileno(), data)
+                                write_all(sys.__stdout__.fileno(), data)
                             output += data.decode('utf-8', 'replace')
                     elif fd == stderr_fd:
                         data = os.read(fd, 1024)
@@ -336,11 +346,14 @@ class SSHConnection(object):
                             rset.remove(stderr_fd)
                             proc.stderr.close()
                         elif not quiet or self.verbose:
-                            os.write(sys.__stderr__.fileno(), data)
+                            write_all(sys.__stderr__.fileno(), data)
                 for fd in ret[1]:
                     if fd == stdin_fd:
                         if input:
-                            num = os.write(fd, input.encode('utf-8'))
+                            try:
+                                num = os.write(fd, input.encode('utf-8'))
+                            except BlockingIOError:
+                                continue
                             input = input[num:]
                         if not input:
                             wset.remove(stdin_fd)


### PR DESCRIPTION
Writing larger blocks to the sink often causes `EAGAIN`. Handle that and
retry, instead of crashing. Also handle partial writes (thanks Marius
for the idea).

----

Recently this started happening a *lot*, e.g. [here](https://logs.cockpit-project.org/logs/pull-15924-20210611-103243-42e6e0c6-fedora-coreos/log.html) or [here](https://logs.cockpit-project.org/logs/pull-15933-20210611-101052-86488262-fedora-33-container-bastion/log.html)