### PR TITLE
machine_core: Handle EAGAIN from os.write() [select version 2]

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -30,6 +30,13 @@ from . import exceptions
 from . import timeout as timeoutlib
 
 
+def write_all(fd, data):
+    while len(data) > 0:
+        select.select([], [fd], [])
+        written = os.write(fd, data)
+        data = data[written:]
+
+
 class SSHConnection(object):
     ssh_default_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "BatchMode=yes"]
 
@@ -328,7 +335,7 @@ class SSHConnection(object):
                             proc.stdout.close()
                         else:
                             if self.verbose:
-                                os.write(sys.__stdout__.fileno(), data)
+                                write_all(sys.__stdout__.fileno(), data)
                             output += data.decode('utf-8', 'replace')
                     elif fd == stderr_fd:
                         data = os.read(fd, 1024)
@@ -336,7 +343,7 @@ class SSHConnection(object):
                             rset.remove(stderr_fd)
                             proc.stderr.close()
                         elif not quiet or self.verbose:
-                            os.write(sys.__stderr__.fileno(), data)
+                            write_all(sys.__stderr__.fileno(), data)
                 for fd in ret[1]:
                     if fd == stdin_fd:
                         if input:


### PR DESCRIPTION
Writing larger blocks to the sink often causes `EAGAIN`. Handle that by
using select() for waiting for write-ability (thanks Allison).
Also handle partial writes (thanks Marius for the idea).