### PR TITLE
naughty: Close 1492: Fedora CoreOS regression: avc: denied { read } for name="stub-resolv.conf"

### DIFF
--- a/naughty/fedora-coreos/1492-selinux-stub-resolv.conf
+++ b/naughty/fedora-coreos/1492-selinux-stub-resolv.conf
@@ -1,1 +1,0 @@
-* avc:  denied  { read } for * name="stub-resolv.conf"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

Fedora CoreOS regression: avc: denied { read } for name="stub-resolv.conf"

Fixes #1492