### PR TITLE
testmap: add new _manual triggers for cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -56,6 +56,8 @@ REPO_BRANCH_CONTEXT = {
             'fedora-testing',
             'fedora-testing/dnf-copr',
             'rhel-9-0-distropkg',
+            'fedora-34/devel',
+            'fedora-34/devel+firefox',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
... fedora-34/devel and fedora-34/devel+firefox.
    
Those are part of cockpit-project/cockpit#15959.
