### PR TITLE
naughty: Close 2032: Fedora CoreOS: avc: denied { watch } for comm="agetty" path="/run/agetty.reload"

### DIFF
--- a/naughty/fedora-coreos/2032-selinux-agetty.reload
+++ b/naughty/fedora-coreos/2032-selinux-agetty.reload
@@ -1,1 +1,0 @@
-* type=1400 * avc:  denied  { watch } for * comm="agetty" path="/run/agetty.reload"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

Fedora CoreOS: avc: denied { watch } for comm="agetty" path="/run/agetty.reload"

Fixes #2032