### PR TITLE
naughty: Add SELinux message for systemd unlinking /run/systemd/default-hostname

### DIFF
--- a/naughty/fedora-34/2141-selinux-unlink-default-hostname
+++ b/naughty/fedora-34/2141-selinux-unlink-default-hostname
@@ -1,0 +1,1 @@
+type=1400 audit(*): avc:  denied  { unlink } for  pid=1 comm="systemd" name="default-hostname" dev="tmpfs"


### PR DESCRIPTION
Known issue #2141
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1975811

----

Observed [here](https://logs.cockpit-project.org/logs/pull-15987-20210624-125257-823fc21a-fedora-34/log.html#101).