### PR TITLE
naughty: add pattern for libvirt failing to detach interface on RHEL-9

### DIFF
--- a/naughty/rhel-9/2153-libvirt-delete-interface
+++ b/naughty/rhel-9/2153-libvirt-delete-interface
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "test/check-machines-nics", line *, in testNICDelete
+    b.wait_not_present(".pf-c-modal-box")


### PR DESCRIPTION
This is supposed to fix the issue on https://logs.cockpit-project.org/logs/pull-224-20210628-162525-03f76900-rhel-9-0/log.html#60

I tried to verify with `./tests-policy -o --simple -v image:rhel-9-0 < /tmp/err` where `/tmp/err` contains the output from the failure in the link above, but it does not work. 