### PR TITLE
github-upload-action-secrets: Upload to environment

### DIFF
--- a/github-upload-action-secrets
+++ b/github-upload-action-secrets
@@ -32,6 +32,7 @@
 import argparse
 import os
 import sys
+import urllib.parse
 from base64 import b64encode
 
 from nacl import encoding, public
@@ -51,16 +52,28 @@ def encrypt(public_key: str, secret_value: str) -> str:
 def main():
     api = task.github.GitHub()
 
-    # get organization of the current repo
-    org = api.get('/repos/' + api.repo)["organization"]["login"]
-
     parser = argparse.ArgumentParser(description='Upload encrypted action secrets to GitHub')
-    parser.add_argument('-r', '--receiver', default=org, metavar="[ORGNAME | OWNER/REPO]",
-                        help="The organization or repository which will receive the secrets; default: %(default)s")
+    parser.add_argument('-r', '--receiver', metavar="[ORGNAME | OWNER/REPO]",
+                        help="The organization or repository which will receive the secrets; "
+                        "default: organization (if available and --env is not given) or repo of current checkout")
+    parser.add_argument('-e', '--env', metavar="ENVNAME",
+                        help="Upload secrets to given project environment (--receiver must be a project)")
+    parser.add_argument('-d', '--dry-run', action="store_true", default=False,
+                        help="Only show which secrets would get uploaded where")
     parser.add_argument('-v', '--verbose', action="store_true", default=False,
                         help="Print verbose information")
     parser.add_argument("secrets_dir", help="directory with one file per secret")
     opts = parser.parse_args()
+
+    if not opts.receiver:
+        if not opts.env:
+            # get organization of the current repo, if available
+            try:
+                opts.receiver = api.get('/repos/' + api.repo)["organization"]["login"]
+            except KeyError:
+                opts.receiver = api.repo
+        else:
+            opts.receiver = api.repo
 
     if '/' in opts.receiver:
         # repository
@@ -71,14 +84,29 @@ def main():
 
     pubkey = api.get(resource + "/actions/secrets/public-key")
 
+    if opts.env:
+        # create env if not present already
+        env_path = f"{resource}/environments/{urllib.parse.quote(opts.env)}"
+        secrets_path = f"{env_path}/secrets"
+        if api.get(env_path):
+            print(f"Environment {opts.env} already exists")
+        else:
+            print(f"Creating non-existing environment {opts.env}")
+            api.put(env_path, {})
+    else:
+        secrets_path = f"{resource}/actions/secrets"
+
     for secret_name in os.listdir(opts.secrets_dir):
         path = os.path.join(opts.secrets_dir, secret_name)
-        if opts.verbose:
-            print("Encrypting and uploading", path, "to", opts.receiver)
+        if opts.dry_run or opts.verbose:
+            print(opts.dry_run and "Would upload" or "Uploading", path, "to", opts.receiver,
+                  opts.env and f"environment {opts.env}" or "")
+        if opts.dry_run:
+            continue
         with open(path) as f:
             enc = encrypt(pubkey["key"], f.read().strip())
         payload = {"key_id": pubkey["key_id"], "encrypted_value": enc, "visibility": "all"}
-        api.put(resource + "/actions/secrets/" + secret_name, payload)
+        api.put(f"{secrets_path}/{secret_name}", payload)
 
     return 0
 


### PR DESCRIPTION
Add a new `--env` option to upload the given secrets to a project
environment, instead of the organization or global project secrets. This
is useful for partitioning secrets and thus limiting their potential
exposure/leakage.

There is no such thing as organization environments, they are always
per-project (as of today). Thus change the default value of `--receiver`
to depend on whether or not `--env` is given. Also fix the case where
there is no repo organization (as in personal forks), just use the repo
itself as a fallback.

Also add a `--dry-run` option to see exactly what happens without
actually writing to the API.

-----

Starting with a blank https://github.com/cockpit-project/cockpit-podman/settings/environments , I tested this with uploading our release secrets to a new environment:
```
❱❱❱ bots/github-upload-action-secrets -e release -v ~/redhat/ci-secrets/github-env-release/
Creating non-existing environment release
Uploading /home/martin/redhat/ci-secrets/github-env-release/SSH_KNOWN_HOSTS to cockpit-project/cockpit-podman environment release
Uploading /home/martin/redhat/ci-secrets/github-env-release/COPR_TOKEN to cockpit-project/cockpit-podman environment release
Uploading /home/martin/redhat/ci-secrets/github-env-release/FEDPKG_SSH_PRIVATE to cockpit-project/cockpit-podman environment release
Uploading /home/martin/redhat/ci-secrets/github-env-release/FEDPKG_SSH_PUBLIC to cockpit-project/cockpit-podman environment release
Uploading /home/martin/redhat/ci-secrets/github-env-release/COCKPIT_FEDORA_PASSWORD to cockpit-project/cockpit-podman environment release
```
I can run it again, then it says

    Environment release already exists

instead, and everything still works. I now see the "release" environment with the appropriate secrets on https://github.com/cockpit-project/cockpit-podman/settings/environments.

I also checked that uploading to the org still works (oops, I had a typo there in the first push):
```
❱❱❱ bots/github-upload-action-secrets -v ~/redhat/ci-secrets/github-org/
Uploading /home/martin/redhat/ci-secrets/github-org/QUAY_TOKEN to cockpit-project 
Uploading /home/martin/redhat/ci-secrets/github-org/SINK_SSHRELAY_PRIVATE to cockpit-project 
Uploading /home/martin/redhat/ci-secrets/github-org/COCKPITUOUS_GHCR_TOKEN to cockpit-project 
Uploading /home/martin/redhat/ci-secrets/github-org/COCKPITUOUS_TOKEN to cockpit-project 
Uploading /home/martin/redhat/ci-secrets/github-org/QUAY_BOTUSER to cockpit-project 
```
(This requires temporarily adding `admin:org` to token privs).