### PR TITLE
naughty: #2141 also happens on Fedora CoreOS

### DIFF
--- a/naughty/fedora-coreos/2141-selinux-unlink-default-hostname
+++ b/naughty/fedora-coreos/2141-selinux-unlink-default-hostname
@@ -1,0 +1,1 @@
+type=1400 audit(*): avc:  denied  { unlink } for  pid=1 comm="systemd" name="default-hostname" dev="tmpfs"


### PR DESCRIPTION
[example](https://logs.cockpit-project.org/logs/pull-16033-20210701-153132-839e602e-fedora-coreos/log.html#266), seen in https://github.com/cockpit-project/cockpit/pull/16033