### PR TITLE
machine: Don't send invalid DHCP hostname with colons

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -96,7 +96,7 @@ TEST_DOMAIN_XML = """
     {ethernet}
     <qemu:arg value='-netdev'/>
     <qemu:arg value='user,id=base0,restrict={restrict},net=172.27.0.0/24,""" \
-"""dnssearch=loopback,hostname={name},{forwards}'/>
+"""dnssearch=loopback,hostname={hostname},{forwards}'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='virtio-net-pci,netdev=base0,bus=pci.0,addr=0x0e'/>
   </qemu:commandline>
@@ -346,7 +346,7 @@ class VirtMachine(Machine):
             sys.stderr.write("WARNING: Machine will run about 10-20 times slower\n")
 
         keys.update(self.networking)
-        keys["name"] = "{image}-{control}".format(**keys)
+        keys["hostname"] = keys["image"] + '-' + keys["control"].replace(':', '-').replace('.', '-')
         test_domain_desc = TEST_DOMAIN_XML.format(**keys)
 
         # add the virtual machine

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -95,7 +95,8 @@ TEST_DOMAIN_XML = """
   <qemu:commandline>
     {ethernet}
     <qemu:arg value='-netdev'/>
-    <qemu:arg value='user,id=base0,restrict={restrict},net=172.27.0.0/24,hostname={name},{forwards}'/>
+    <qemu:arg value='user,id=base0,restrict={restrict},net=172.27.0.0/24,""" \
+"""dnssearch=loopback,hostname={name},{forwards}'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='virtio-net-pci,netdev=base0,bus=pci.0,addr=0x0e'/>
   </qemu:commandline>


### PR DESCRIPTION
`control` is "127.0.0.1:<port>". Using that as DHCP-announced host name
is invalid, as `:` must not appear  in a hostname, they caused
NetworkManager/hostnamed to groan:

    policy: set-hostname: current hostname was changed outside NetworkManager: 'localhost'
    policy: set-hostname: set hostname to 'rhel-8-4-127.0.0.2\0582201' (from DHCPv4)
    hostname: couldn't set the system hostname to 'rhel-8-4-127.0.0.2\0582201' using hostnamed:
      GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: Invalid hostname 'rhel-8-4-127.0.0.2\0582201'

Replace the colon with a dash. Also rename the "name" key to "hostname"
to make it more obvious what this is for.

Fixes #1908

 - [x] https://github.com/cockpit-project/cockpit/pull/16043