### PR TITLE
github-upload-action-secrets: download right pubkey

### DIFF
--- a/github-upload-action-secrets
+++ b/github-upload-action-secrets
@@ -82,8 +82,6 @@ def main():
         # organization
         resource = '/orgs/' + opts.receiver
 
-    pubkey = api.get(resource + "/actions/secrets/public-key")
-
     if opts.env:
         # create env if not present already
         env_path = f"{resource}/environments/{urllib.parse.quote(opts.env)}"
@@ -95,6 +93,8 @@ def main():
             api.put(env_path, {})
     else:
         secrets_path = f"{resource}/actions/secrets"
+
+    pubkey = api.get(f"{secrets_path}/public-key")
 
     for secret_name in os.listdir(opts.secrets_dir):
         path = os.path.join(opts.secrets_dir, secret_name)


### PR DESCRIPTION
We need to download the public-key specific to the endpoint where we'll
be uploading our secrets.  Before, there was only one endpoint (the
project) but now it might be an environment.

Download the public-key from the right place, based on the already-set
`secrets_path`.