### PR TITLE
naughty: copy 2158 to fedora-34 for podman

### DIFF
--- a/naughty/fedora-34/2158-podman-api-call-loses-data
+++ b/naughty/fedora-34/2158-podman-api-call-loses-data
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+*
+  File "test/check-application", line *, in testDownloadImage
+    dialog0.openDialog() \
+  File "test/check-application", line *, in expectDownloadSuccess
+    b.wait_visible('#containers-images td[data-label="Name"]:contains("{0}")'.format(self.imageName))


### PR DESCRIPTION
Known issue #2158

We see this fail on fedora-34 as well, as in

https://logs.cockpit-project.org/logs/pull-734-20210705-094516-d79ab0ac-fedora-34/log.html#5