### PR TITLE
publish-wrapper: Stop sending API tokens through the sink protocol

### DIFF
--- a/publish-wrapper
+++ b/publish-wrapper
@@ -84,7 +84,6 @@ class PullTask():
 
         status = {
             "github": {
-                "token": self.api.token,
                 "requests": [
                     # Set status to pending
                     {
@@ -109,7 +108,6 @@ class PullTask():
             "revision": opts.revision,
             "onaborted": {
                 "github": {
-                    "token": self.api.token,
                     "requests": [
                         # Set status to error
                         {


### PR DESCRIPTION
The sink already has ~/.config/github-token, and falls back to that if
the request does not include it [1]. As in our practical purposes that
is the same token, drop it.

This avoids sending the token through the wire protocol all the time,
where it is very prone to getting leaked through error logging.

[1] https://github.com/cockpit-project/cockpituous/blob/5221fac7e/sink/sink#L149

-----

@allisonkarlitskaya and I analyzed the [recent leak](https://logs.cockpit-project.org/logs/pull-16055-20210707-085430-83f62fca-fedora-34/log.html) (don't worry, the token is invalid now) and are fairly convinced that this is the root cause.

I admittedly didn't test this so far. Due to the current crisis, I propose a more cowboy-ish approach: Let's roll this out, in the worst case our statuses for PRs won't work. Then I'd rather analyse it then when/where it goes wrong.

 - [x] https://github.com/cockpit-project/cockpituous/pull/429
 - [x] PR #2187 to fix tests