### PR TITLE
workflows: Only run tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: test
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   bots:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Running them on both push and pull_request runs the integration test
twice in parallel, which collides on the "unit-tests" status -- only one
of these two is going to actually run the test and win the race, the
other will fail.

cockpituous does the same [1], and it works reliably there.

[1] https://github.com/cockpit-project/cockpituous/blob/main/.github/workflows/tests.yml