### PR TITLE
task: Drop scanning of /orgs/cockpit-project/teams

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -57,8 +57,6 @@ NOT_TESTED_DIRECT = "Not yet tested (direct trigger)"
 
 ISSUE_TITLE_IMAGE_REFRESH = "Image refresh for {0}"
 
-TEAM_CONTRIBUTORS = "Contributors"
-
 
 class Logger(object):
     def __init__(self, directory):
@@ -381,21 +379,14 @@ class GitHub(object):
         users = {"github-actions[bot]", "candlepin", "cockpit-project", "osbuild"}
 
         # individual persons from https://github.com/orgs/cockpit-project/teams/contributors/members
-        teamId = self.teamIdFromName(TEAM_CONTRIBUTORS)
         page = 1
         count = 100
         while count == 100:
-            data = self.get("/teams/{0}/members?page={1}&per_page={2}".format(teamId, page, count)) or []
+            data = self.get(f"/orgs/cockpit-project/teams/contributors/members?page={page}&per_page={count}") or []
             users.update(user.get("login") for user in data)
             count = len(data)
             page += 1
         return users
-
-    def teamIdFromName(self, name):
-        for team in self.get("/orgs/cockpit-project/teams") or []:
-            if team.get("name") == name:
-                return team["id"]
-        raise KeyError("Team {0} not found".format(name))
 
     def is_user_allowed(self, user):
         return user in self.allowlist()

--- a/task/test-github
+++ b/task/test-github
@@ -86,12 +86,7 @@ def mockServer():
                     self.replyData("", status=304)
                 else:
                     self.replyJson({"user": "blah"}, headers={"Last-Modified": "Thu, 05 Jul 2012 15:31:30 GMT"})
-            elif parsed.path == "/orgs/cockpit-project/teams":
-                self.replyJson([
-                    {"name": github.TEAM_CONTRIBUTORS, "id": 1},
-                    {"name": "Other team", "id": 2}
-                ])
-            elif parsed.path == "/teams/1/members":
+            elif parsed.path == "/orgs/cockpit-project/teams/contributors/members":
                 self.replyJson([
                     {"login": "one"},
                     {"login": "two"},
@@ -185,11 +180,6 @@ class TestGitHub(unittest.TestCase):
                                          "cockpit-project", "osbuild"]))
         self.assertNotIn("four", allowlist)
         self.assertNotIn("", allowlist)
-
-    def testTeamIdFromName(self):
-        self.assertEqual(self.api.teamIdFromName(github.TEAM_CONTRIBUTORS), 1)
-        self.assertEqual(self.api.teamIdFromName("Other team"), 2)
-        self.assertRaises(KeyError, self.api.teamIdFromName, "team that doesn't exist")
 
     def testLastIssueDelete(self):
         self.assertEqual(len(self.api.issues()), 2)


### PR DESCRIPTION
It is not necessary to map a team name to an ID; one can directly look
up a team by name:
https://docs.github.com/en/rest/reference/teams#get-a-team-by-name

Do that and drop the teamIdFromName() helper.

-----

Tested with `./tests-trigger` and  making sure that it can still correctly determine team membership (with `read:org` permission, that does not change). 