### PR TITLE
naughty: Adjust #2158 naughty pattern

### DIFF
--- a/naughty/fedora-34/2158-podman-api-call-loses-data
+++ b/naughty/fedora-34/2158-podman-api-call-loses-data
@@ -1,6 +1,6 @@
 Traceback (most recent call last):
 *
   File "test/check-application", line *, in testDownloadImage
-    dialog0.openDialog() \
+    dialog*.openDialog() \
   File "test/check-application", line *, in expectDownloadSuccess
     b.wait_visible('#containers-images td[data-label="Name"]:contains("{0}")'.format(self.imageName))

--- a/naughty/rhel-9/2158-podman-api-call-loses-data
+++ b/naughty/rhel-9/2158-podman-api-call-loses-data
@@ -1,6 +1,6 @@
 Traceback (most recent call last):
 *
   File "test/check-application", line *, in testDownloadImage
-    dialog0.openDialog() \
+    dialog*.openDialog() \
   File "test/check-application", line *, in expectDownloadSuccess
     b.wait_visible('#containers-images td[data-label="Name"]:contains("{0}")'.format(self.imageName))


### PR DESCRIPTION
The same issue can happen a little further down in the test (line 782)
where it calls `dialog.openDialog()`.

---

Observed in https://github.com/cockpit-project/cockpit-podman/pull/737 where [fedora-34](https://logs.cockpit-project.org/logs/pull-737-20210715-092023-8e328d38-fedora-34/log.html#5) and [rhel-9-0](https://logs.cockpit-project.org/logs/pull-737-20210715-092023-8e328d38-rhel-9-0/log.html#5) failed on this issue.