### PR TITLE
naughty: Close 1236: kvdo module broken on CentOS 8

### DIFF
--- a/naughty/rhel-8/1236-no-kvdo
+++ b/naughty/rhel-8/1236-no-kvdo
@@ -1,1 +1,0 @@
-*vdo: ERROR - modprobe: FATAL: Module kvdo not found in directory /lib/modules/4.18.0


### PR DESCRIPTION
Known issue which has not occurred in 23 days

kvdo module broken on CentOS 8

Fixes #1236