### PR TITLE
naughty: Add pattern for Fedora rawhide targetcli hang

### DIFF
--- a/naughty/fedora-35/2218-targetcli-hang
+++ b/naughty/fedora-35/2218-targetcli-hang
@@ -1,0 +1,2 @@
+RuntimeError: Timed out on*
+                  targetcli /backstores/ramdisk create


### PR DESCRIPTION
This only applies to packit tests.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1983545
Known issue #2218

---

Currently all c-machines packit tests [fail on rawhide](http://artifacts.dev.testing-farm.io/0615106d-12bd-410d-b272-04fe6a168d59/) because of this.