### PR TITLE
Add pattern for libvirt crashing on debian-testing

### DIFF
--- a/naughty/debian-testing/2220-libvirt-crashes-on-startup
+++ b/naughty/debian-testing/2220-libvirt-crashes-on-startup
@@ -1,0 +1,5 @@
+# testBasicWheelUserUnprivileged (__main__.TestMachinesLifecycle)
+*
+#0 * n/a (libvirt_driver_qemu.so + *)
+#1 * virStateShutdownPrepare (libvirt.so.0 + *)
+#2 * virNetDaemonRun (libvirt.so.0 + *)


### PR DESCRIPTION
Known issue #2220
Downstream report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=991278