### PR TITLE
naughty: Copy alternative pattern for #1739 to other affected OSes

### DIFF
--- a/naughty/fedora-33/1739-cryptsetup-systemd-umount-fs-3
+++ b/naughty/fedora-33/1739-cryptsetup-systemd-umount-fs-3
@@ -1,0 +1,3 @@
+*self.checkResize*
+*
+AssertionError: * not greater than 300000

--- a/naughty/fedora-34/1739-cryptsetup-systemd-umount-fs-3
+++ b/naughty/fedora-34/1739-cryptsetup-systemd-umount-fs-3
@@ -1,0 +1,3 @@
+*self.checkResize*
+*
+AssertionError: * not greater than 300000

--- a/naughty/ubuntu-stable/1739-cryptsetup-systemd-umount-fs-3
+++ b/naughty/ubuntu-stable/1739-cryptsetup-systemd-umount-fs-3
@@ -1,0 +1,3 @@
+*self.checkResize*
+*
+AssertionError: * not greater than 300000


### PR DESCRIPTION
Commit 7902d6b356afd only added the alternative pattern to rhel-9, but
it demonstrably affects ubuntu-stable as well, and most likely Fedora
33/34.

----

[example](https://logs.cockpit-project.org/logs/pull-16124-20210722-044101-771379a1-ubuntu-stable/log.html#198-2)