### PR TITLE
naughty: Close 2031: fedora-coreos: avc: denied { write } for comm="systemd-hostnam" name="systemd" dev="tmpfs"

### DIFF
--- a/naughty/fedora-coreos/2031-selinux-systemd-hostnam
+++ b/naughty/fedora-coreos/2031-selinux-systemd-hostnam
@@ -1,2 +1,0 @@
-testlib.Error: FAIL: Test completed, but found unexpected journal messages:
-audit*avc:  denied  { write } for * comm="systemd-hostnam" name="systemd" dev="tmpfs" *


### PR DESCRIPTION
Known issue which has not occurred in 24 days

fedora-coreos: avc: denied { write } for comm="systemd-hostnam" name="systemd" dev="tmpfs"

Fixes #2031