### PR TITLE
naughty: Close 1893: RHEL 9: podman: configured runtime does not support checkpoint/restore

### DIFF
--- a/naughty/rhel-9/1893-podman-checkpoint-restore
+++ b/naughty/rhel-9/1893-podman-checkpoint-restore
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-*
-  File "test/check-application", line *, in _testCheckpointRestore
-    b.wait(lambda: b.text('#containers-containers tr:contains(swamped-crate) td:nth-of-type(6)') in NOT_RUNNING)
-*
-testlib.Error: timed out waiting for predicate to become true


### PR DESCRIPTION
Known issue which has not occurred in 24 days

RHEL 9: podman: configured runtime does not support checkpoint/restore

Fixes #1893