### PR TITLE
naughty: Close 798: Libvirtd dumps core when stopped too quickly

### DIFF
--- a/naughty/fedora-33/798-libvirtd-coredump
+++ b/naughty/fedora-33/798-libvirtd-coredump
@@ -1,4 +1,0 @@
-*testLibvirt*
-*
-Process * (libvirtd) of user 0 dumped core.*
-*virObjectUnref*

--- a/naughty/rhel-8/798-libvirtd-coredump
+++ b/naughty/rhel-8/798-libvirtd-coredump
@@ -1,4 +1,0 @@
-*testLibvirt*
-*
-Process * (libvirtd) of user 0 dumped core.*
-*virObjectUnref*


### PR DESCRIPTION
Known issue which has not occurred in 24 days

Libvirtd dumps core when stopped too quickly

Fixes #798