### PR TITLE
naughty: Add two Fedora 34 reportd crashes

### DIFF
--- a/naughty/fedora-34/1784-reportd-crash-task_start
+++ b/naughty/fedora-34/1784-reportd-crash-task_start
@@ -1,0 +1,5 @@
+Stack trace of thread*
+#* reportd_task_start*
+*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process * (reportd) of user 0 dumped core.

--- a/naughty/fedora-34/1785-reportd-crash-g_bus_unown_name
+++ b/naughty/fedora-34/1785-reportd-crash-g_bus_unown_name
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-system-journal", line *, in testAbrtReport
+    b.wait_visible(".pf-c-modal-box__body input[type='%s']" % (purpose))
+*
+testlib.Error: timeout


### PR DESCRIPTION
The cause is the same, it just differes when reportd crashes and whether
it makes the test fail or it just sees the journal message.

Re-introduces: #1786

Known issues: #1784 and #1785
Downstream reports: https://bugzilla.redhat.com/show_bug.cgi?id=1938086

This is our [top flakes and the only unexpected message](https://images-frontdoor.apps.ocp.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit)