### PR TITLE
naughty: Add pattern for unspecific systemd-resolved segfault

### DIFF
--- a/naughty/ubuntu-2004/2248-resolved-segfault
+++ b/naughty/ubuntu-2004/2248-resolved-segfault
@@ -1,0 +1,6 @@
+Stack trace of thread 651:
+#0  * n/a (systemd-resolved + *)
+* sd_event_dispatch (libsystemd-shared-*.so + *)
+*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process * (systemd-resolve) of user * dumped core.


### PR DESCRIPTION
This happens unrelated to any particular test, and seems to not happen
any more with current upstream and Ubuntu versions. As the stack trace
has no useful information, and none of our tests directly interact with
resolved, let's just ignore these.

Known issue #2248

----

[example](https://logs.cockpit-project.org/logs/pull-16151-20210727-043808-47a25c67-ubuntu-2004/log.html#47)