### PR TITLE
naughty: Fix pattern for #2248

### DIFF
--- a/naughty/ubuntu-2004/2248-resolved-segfault
+++ b/naughty/ubuntu-2004/2248-resolved-segfault
@@ -1,5 +1,5 @@
-Stack trace of thread 651:
-#0  * n/a (systemd-resolved + *)
+Stack trace of thread *
+#* n/a (systemd-resolved + *)
 * sd_event_dispatch (libsystemd-shared-*.so + *)
 *
 testlib.Error: FAIL: Test completed, but found unexpected journal messages:


### PR DESCRIPTION
The initial commit left a hardcoded thread number in it. Also, the stack
trace sometimes starts with `__GI_abort`, so so the first n/a frame is
not #0.

---

Noticed in [this failure](https://logs.cockpit-project.org/logs/pull-16172-20210729-124605-44c1dc7e-ubuntu-2004/log.html#47). Validated locally that the pattern now matches.