### PR TITLE
tests-scan: Run firefox tests on internal machines

### DIFF
--- a/tests-scan
+++ b/tests-scan
@@ -121,7 +121,8 @@ def tests_human(priority, name, number, revision, ref, context, base, repo, bots
 
 
 def is_internal_context(context):
-    for pattern in ["rhel", "edge", "vmware", "openstack"]:
+    # HACK: CentOS CI doesn't like firefox, browser fails to start way too often
+    for pattern in ["rhel", "edge", "vmware", "openstack", "/firefox"]:
         if pattern in context:
             return True
     return False


### PR DESCRIPTION
In about half of cockpit test runs on CentOS CI, firefox fails to start
with messages like

    Sandbox: SandboxReporter: thread creation failed: Resource temporarily unavailable

and eventually `RuntimeError: timed out waiting for browser to start`.

This is a nuisance to debug, and breaks our tests too often. Run them on
our internal machines for the time being.

Examples (there's a *lot* of them):
 - https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-16168-20210730-133334-28a0649b-fedora-34-firefox/log.html#198-2
 -  https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-15968-20210702-121108-98c8fa4a-fedora-34-firefox/log.html