### PR TITLE
tests-invoke: Avoid test failure due to GitHub API timeout during collision detection

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -40,7 +40,13 @@ def main():
     def detect_collisions(opts):
         api = github.GitHub(repo=opts.repo)
 
-        pull = api.get("pulls/{0}".format(opts.pull_number))
+        try:
+            pull = api.get("pulls/{0}".format(opts.pull_number))
+        except TimeoutError as e:
+            sys.stderr.write('Warning: collision detection failed, skipping: %s' % e)
+            # GitHub API is sometimes flaky, don't break test just because it sometimes does not respond
+            return None
+
         if pull:
             if pull["head"]["sha"] != opts.revision:
                 return "Newer revision available on GitHub for this pull request"


### PR DESCRIPTION
During times when the GitHub API is a bit flaky (like right now), a lot
of tests fail with "TimeoutError: [Errno 110] Connection timed out" in
detect_collisions(). This is awkward -- it's not that bad if two tests
run in parallel for a little longer when skipping a collision check or
two. So ignore connection timeouts for that particular check.

Note that when the GitHub API is permanently down, test invocation and
result reporting will fail anyway, so it's not completely hidden.


---

[example](https://logs.cockpit-project.org/logs/pull-16000-20210802-070918-81f4f244-centos-8-stream/log), I've retried PRs at least 5 times this morning already. /me draws a line into the sand