### PR TITLE
machine: Put back expected message for #1970744 on fedora-33

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -216,6 +216,8 @@ class Machine(ssh_connection.SSHConnection):
         if self.image in ['fedora-33']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1965743
             allowed.append('audit:.*denied.*name="dma_heap".*')
+            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1970744
+            allowed.append('audit:.*denied.*path=".*dma_heap".*')
 
         if self.image in ['debian-testing', 'ubuntu-stable']:
             # HACK: https://bugs.debian.org/951477


### PR DESCRIPTION
Partially revert commit 54715bf085, this part did not yet get fixed in
Fedora 33.

----

[seen in the wild](https://logs.cockpit-project.org/logs/pull-16168-20210802-164116-7fc21784-fedora-33/log.html#134)