### PR TITLE
Set IdentitiesOnly for ssh connections

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -38,7 +38,8 @@ def write_all(fd, data):
 
 
 class SSHConnection(object):
-    ssh_default_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "BatchMode=yes"]
+    ssh_default_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+                        "-o", "IdentitiesOnly=yes", "-o", "BatchMode=yes"]
 
     def __init__(self, user, address, ssh_port, identity_file, verbose=False):
         self.verbose = verbose


### PR DESCRIPTION
With IdentitiesOnly option enabled, ssh only tries the configured
IdentitiesFile for authentication. This is useful for when ssh offers to
many different identities causing an authentication failure.