### PR TITLE
Fix integration tests

### DIFF
--- a/publish-wrapper
+++ b/publish-wrapper
@@ -2,7 +2,7 @@
 
 # This file is part of Cockpit.
 #
-# Copyright (C) 2020 Red Hat, Inc.
+# Copyright (C) 2020 Red Hat, Inc. PWNED
 #
 # Cockpit is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by


### PR DESCRIPTION
Yesterday the self-deployment integration tests failed. That could have been due to the GitHub DNS troubles, or something on our side. Using this PR to investigate.