### PR TITLE
naughty: Close 1680: debian-testing: ifupdown scripts interfere with NetworkManager

### DIFF
--- a/naughty/debian-testing/1680-ifupdown-interferes-with-bonding
+++ b/naughty/debian-testing/1680-ifupdown-interferes-with-bonding
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-networkmanager-bond", line *, in testActive
-    b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", ip)


### PR DESCRIPTION
Known issue which has not occurred in 27 days

debian-testing: ifupdown scripts interfere with NetworkManager

Fixes #1680