### PR TITLE
naughty: Add pattern for SELinux hostnamectl denial

### DIFF
--- a/naughty/fedora-34/2291-selinux-hostnamectl
+++ b/naughty/fedora-34/2291-selinux-hostnamectl
@@ -1,0 +1,1 @@
+avc:  denied  { add_name } for  * comm="systemd-hostnam" name="*" scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0


### PR DESCRIPTION
Known issue #2291
Downstream report for RHEL 34: https://bugzilla.redhat.com/show_bug.cgi?id=1991444