### PR TITLE
naughty: Copy pattern for add_name denial to rhel-9-0 and f-coreos

### DIFF
--- a/naughty/fedora-coreos/2291-selinux-hostnamectl
+++ b/naughty/fedora-coreos/2291-selinux-hostnamectl
@@ -1,0 +1,1 @@
+avc:  denied  { add_name } for  * comm="systemd-hostnam" name="*" scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0

--- a/naughty/rhel-9/2291-selinux-hostnamectl
+++ b/naughty/rhel-9/2291-selinux-hostnamectl
@@ -1,0 +1,1 @@
+avc:  denied  { add_name } for  * comm="systemd-hostnam" name="*" scontext=system_u:system_r:systemd_hostnamed_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=dir permissive=0


### PR DESCRIPTION
Examples: [fedora-coreos](https://logs.cockpit-project.org/logs/pull-16213-20210811-153533-2fd39fb1-fedora-coreos/log.html#279) and [rhel-9](https://logs.cockpit-project.org/logs/pull-16213-20210811-153533-2fd39fb1-rhel-9-0/log.html#279-2)