### PR TITLE
machines: add back a graphics adaptor

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -80,6 +80,14 @@ TEST_DOMAIN_XML = """
       <serial>ROOT</serial>
     </disk>
     <controller type='scsi' model='virtio-scsi' index='0' id='hot'/>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <alias name='video0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <graphics type='vnc' autoport='yes' listen='127.0.0.1'>
+      <listen type='address' address='127.0.0.1'/>
+    </graphics>
     <console type='pty'>
       <target type='serial' port='0'/>
     </console>


### PR DESCRIPTION
We ripped this code out when removing our windows image, back in
b4ac348460bc63088a9588b7b87fae24de0b6e3a.  It turns out that this is
needed for `vm-run -G` to work (which still exists).  It's also useful
for debugging in some cases.

I considered enabling this conditionally, but it comes with very little
cost, so let's just turn it on by default.

It should now be possible, on any running VM to find the vm via `virsh
list` and connect to it, by ID number, with `virt-viewer`.  That already
came in useful for debugging issues while adding the new Arch Linux
image.