### PR TITLE
testmap: Add manual fedora-35 context

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -58,6 +58,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-testing/dnf-copr',
             'rhel-9-0-distropkg',
             'fedora-34/firefox-devel',
+            'fedora-35',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
So that we can trigger tests once we have a fedora-35 image.