### PR TITLE
naughty: Close 2218: targetcli create hangs forever

### DIFF
--- a/naughty/fedora-35/2218-targetcli-hang
+++ b/naughty/fedora-35/2218-targetcli-hang
@@ -1,2 +1,0 @@
-RuntimeError: Timed out on*
-                  targetcli /backstores/ramdisk create


### PR DESCRIPTION
Known issue which has not occurred in 28 days

targetcli create hangs forever

Fixes #2218