### PR TITLE
naughty: Close 2230: systemd[1]: Assertion 'a <= b' failed at src/libsystemd/sd-event/sd-event.c:2903, function sleep_between(). Aborting

### DIFF
--- a/naughty/fedora-34/2230-systemd-assert-sleep_between
+++ b/naughty/fedora-34/2230-systemd-assert-sleep_between
@@ -1,6 +1,0 @@
-Process * (systemd) of user 0 dumped core.
-*
-* sleep_between (libsystemd-shared*
-*
-testlib.Error: FAIL: Test completed, but found unexpected journal messages:
-Due to PID 1 having crashed coredump collection will now be turned off.

--- a/naughty/fedora-coreos/2230-systemd-assert-sleep_between
+++ b/naughty/fedora-coreos/2230-systemd-assert-sleep_between
@@ -1,4 +1,0 @@
-Process * (systemd) of user * dumped core.
-*
-* sleep_between (libsystemd-shared*
-*


### PR DESCRIPTION
Known issue which has not occurred in 24 days

systemd[1]: Assertion 'a <= b' failed at src/libsystemd/sd-event/sd-event.c:2903, function sleep_between(). Aborting

Fixes #2230