### PR TITLE
images: Move debian-stable to Debian 11

### DIFF
--- a/images/debian-stable
+++ b/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-cd00fcebafefbf07c08f8377624decef50573dfa24bdf82e26b884c93b620ea3.qcow2
+debian-stable-66c0c24b4218f9035d62ff2f9c9e2e9e93556e82e774bc7555a8d2e5d98bc9c6.qcow2

--- a/images/scripts/debian-stable.bootstrap
+++ b/images/scripts/debian-stable.bootstrap
@@ -1,7 +1,7 @@
 #! /bin/sh -ex
 
-RELEASE=buster
-RELEASENUM=10
+RELEASE=bullseye
+RELEASENUM=11
 LATEST_DAILY=$(curl -s https://cloud.debian.org/images/cloud/$RELEASE/daily/ | sed -n '/<a href=/ { s/^.*href="//; s_/".*$__; p }'| sort -nu | tail -n1)
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "https://cloud.debian.org/images/cloud/$RELEASE/daily/$LATEST_DAILY/debian-${RELEASENUM}-genericcloud-amd64-daily-${LATEST_DAILY}.qcow2"

--- a/images/scripts/debian-stable.install
+++ b/images/scripts/debian-stable.install
@@ -4,8 +4,8 @@ set -e
 
 /var/lib/testvm/debian.install "$@"
 
-# HACK: https://bugs.debian.org/914694
-sed -i '/IndividualCalls/ s/=no/=yes/' /etc/firewalld/firewalld.conf
+# make libpwquality less aggressive, so that our "foobar" password works
+printf 'dictcheck = 0\nminlen = 6\n' >> /etc/security/pwquality.conf
 
 # Allow libvirtd coredumps
 echo '* soft core unlimited' >> /etc/security/limits.conf

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -51,6 +51,7 @@ sssd-dbus \
 
 TEST_PACKAGES="\
 acl \
+bind9-dnsutils \
 curl \
 firewalld \
 gdb \
@@ -83,12 +84,6 @@ until systemctl list-jobs | grep -q "No jobs"; do sleep 1; done
 RELEASE=$(grep -m1 ^deb /etc/apt/sources.list | awk '{print $3}')
 
 case "$RELEASE" in
-    buster)
-        # timesyncd got split out in Ubuntu 20.04 and Debian 11
-        TEST_PACKAGES="${TEST_PACKAGES/systemd-timesyncd /}"
-        # no podman package yet
-        TEST_PACKAGES="${TEST_PACKAGES/podman /}"
-        ;;
     bullseye)
         # freeipa got dropped from testing: https://tracker.debian.org/pkg/freeipa
         IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
@@ -145,11 +140,6 @@ APT='eatmydata apt-get -y -o Dpkg::Options::=--force-confold'
 
 # remove packages that we don't need
 for p in lxd snapd landscape-common accountsservice open-vm-tools ufw cloud-init; do $APT purge --auto-remove $p || true; done
-
-# HACK: debian-stable image got /usr/bin/qemu-img removed, even though qemu-utils package is installed
-if [ "$1" = "debian-stable" ]; then
-    $APT install --reinstall -y qemu-utils
-fi
 
 # python3-rtslib-fb postinst starts rtslib-fb-targetctl.service , but that may fail due to kernel being upgraded
 mkdir -p /run/systemd/system

--- a/naughty/debian-stable/1543-apparmor-denial-capnames-perfmon-and-bpf
+++ b/naughty/debian-stable/1543-apparmor-denial-capnames-perfmon-and-bpf
@@ -1,0 +1,1 @@
+*apparmor="DENIED" operation="capable" profile="libvirtd" * comm="rpc-worker" capability=39  capname="bpf"

--- a/naughty/debian-stable/1565-qemu-5.2-assert-BH_DELETED
+++ b/naughty/debian-stable/1565-qemu-5.2-assert-BH_DELETED
@@ -1,0 +1,3 @@
+*TestMachines*
+*
+Process * (qemu-system-x86) of user * dumped core.

--- a/naughty/debian-stable/1680-ifupdown-interferes-with-bonding
+++ b/naughty/debian-stable/1680-ifupdown-interferes-with-bonding
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-networkmanager-bond", line *, in testActive
+    b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", ip)

--- a/naughty/debian-stable/1733-udisks2-fails-to-format-vfat
+++ b/naughty/debian-stable/1733-udisks2-fails-to-format-vfat
@@ -1,0 +1,1 @@
+warning: Error synchronizing after formatting with type `vfat': Timed out waiting for object

--- a/naughty/debian-stable/2035-clevis-luks-bind-never-fails
+++ b/naughty/debian-stable/2035-clevis-luks-bind-never-fails
@@ -1,2 +1,0 @@
-  File "check-storage-luks", line *, in testClevisTang
-    b.wait_in_text("#dialog", "No key available with this passphrase.")

--- a/naughty/debian-stable/2220-libvirt-crashes-on-startup-2
+++ b/naughty/debian-stable/2220-libvirt-crashes-on-startup-2
@@ -1,0 +1,5 @@
+# testBasicWheelUserUnprivileged (__main__.TestMachinesLifecycle)
+*
+#0 * n/a (libvirt_driver_qemu.so + *)
+#1 * virStateShutdownPrepare (libvirt.so.0 + *)
+#2 * virNetDaemonRun (libvirt.so.0 + *)


### PR DESCRIPTION
Debian 11 "bullseye" got released on Aug 14th. Update bootstrap and sync
*.install hacks and naughties with debian-testing.

 * [x] image-refresh debian-stable
 * [ ] Adjust cockpit tests: https://github.com/cockpit-project/cockpit/pull/16262
 * [ ] Adjust cockpit-machines tests: https://github.com/cockpit-project/cockpit-machines/pull/333