### PR TITLE
testmap: Test cockpit-podman on fedora-35

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -85,14 +85,13 @@ REPO_BRANCH_CONTEXT = {
             'rhel-9-0',
             'fedora-33',
             'fedora-34',
-            'fedora-34/rawhide',
+            'fedora-35',
+            'fedora-35/rawhide',
             'debian-testing',
             'ubuntu-stable',
         ],
         '_manual': [
             'centos-8-stream',
-            'fedora-35',
-            'fedora-35/rawhide',
         ],
     },
     'cockpit-project/cockpit-machines': {


### PR DESCRIPTION
And do the rawhide testing based on fedora-35 as well.