### PR TITLE
naughty: Add pattern for SELinux systemd-tty-askpass watch_read violation

### DIFF
--- a/naughty/fedora-34/2359-selinux-tty-askpass-watch_reads
+++ b/naughty/fedora-34/2359-selinux-tty-askpass-watch_reads
@@ -1,0 +1,1 @@
+avc:  denied  { watch watch_reads } for * comm="systemd-tty-ask" path="/dev/tty1"


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1999526
Known issue #2359

---

[example](https://logs.cockpit-project.org/logs/pull-16280-20210831-071636-4c080105-fedora-34-firefox/log.html#182)