### PR TITLE
machine: add machine.libexecdir

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -85,6 +85,11 @@ class Machine(ssh_connection.SSHConnection):
         else:
             self.label = "{}@{}:{}".format(self.ssh_user, self.ssh_address, self.ssh_port)
 
+        if "debian" in self.image or "ubuntu" in self.image:
+            self.libexecdir = "/usr/lib/cockpit"
+        else:
+            self.libexecdir = "/usr/libexec"
+
         # The Linux kernel boot_id
         self.boot_id = None
 


### PR DESCRIPTION
This points to /usr/lib/cockpit on Debian and /usr/libexec elsewhere.