### PR TITLE
testmap: Drop rhel-8-4 and add fedora-35

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -68,6 +68,7 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream',
         ],
         '_manual': [
+            'fedora-35',
             'fedora-34/firefox',
         ],
     },
@@ -80,7 +81,6 @@ REPO_BRANCH_CONTEXT = {
     },
     'cockpit-project/cockpit-podman': {
         'main': [
-            'rhel-8-4',
             'rhel-8-5',
             'rhel-9-0',
             'fedora-33',
@@ -122,7 +122,6 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'fedora-34/lorax',
             'fedora-34/osbuild-composer',
-            'rhel-8-4/lorax',
             'rhel-8-5/osbuild-composer',
             'rhel-9-0/osbuild-composer',
             'rhel-7-9',
@@ -143,13 +142,10 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-5',
             'rhel-9-0'
         ],
-        'rhel-8': [
-            'rhel-8-4',
-            'rhel-8-4/firefox',
-        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-34',
+            'fedora-35',
         ],
     },
     'candlepin/subscription-manager': {
@@ -169,10 +165,10 @@ REPO_BRANCH_CONTEXT = {
             'fedora-34',
         ],
         '_manual': [
-            'rhel-8-4',
             'rhel-8-5',
             'rhel-9-0',
             'centos-8-stream',
+            'fedora-35',
         ]
     },
 }


### PR DESCRIPTION
- Declare manual fedora-35 tests for projects that didn't have any
- Stop testing on rhel-8-4
- cockpit-composer won't be rebasing `rhel-8` brnach anymore, so it is
  "rhel-8-4"

Next I'll try to move f-35 into `main`.