### PR TITLE
naughty: Relax pattern for systemd-tty-askpass watch_reads

### DIFF
--- a/naughty/fedora-34/2359-selinux-tty-askpass-watch_reads
+++ b/naughty/fedora-34/2359-selinux-tty-askpass-watch_reads
@@ -1,1 +1,1 @@
-avc:  denied  { watch watch_reads } for * comm="systemd-tty-ask" path="/dev/tty1"
+avc:  denied  { watch watch_reads } for * comm="systemd-tty-ask"

--- a/naughty/fedora-35/2359-selinux-tty-askpass-watch_reads
+++ b/naughty/fedora-35/2359-selinux-tty-askpass-watch_reads
@@ -1,1 +1,1 @@
-avc:  denied  { watch watch_reads } for * comm="systemd-tty-ask" path="/dev/tty1"
+avc:  denied  { watch watch_reads } for * comm="systemd-tty-ask"


### PR DESCRIPTION
It also happens for path="/dev/ttyS0" and possibly others.

[example](https://logs.cockpit-project.org/logs/pull-16281-20210831-184227-dbe34f3f-fedora-34-firefox/log.html#151)