### PR TITLE
testmap: Add new cockpit rhel-9.0 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -53,6 +53,9 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream',
             'fedora-34/container-bastion',
         ],
+        'rhel-9.0': [
+            'rhel-9-0',
+        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-testing',


### PR DESCRIPTION
Only test on rhel-9-0 image. We don't build any containers from this
branch.