### PR TITLE
task: Use $GITHUB_REF as PR base branch if available

### DIFF
--- a/task/__init__.py
+++ b/task/__init__.py
@@ -373,9 +373,13 @@ def pull(branch, body=None, issue=None, base=None, labels=['bot'], run_tests=Tru
     if "pull" in kwargs:
         return kwargs["pull"]
 
+    # $GITHUB_REF is set when running from workflows
+    if not base:
+        base = os.path.basename(os.getenv("GITHUB_REF", default_branch()))
+
     data = {
         "head": branch,
-        "base": default_branch() if base is None else base,
+        "base": base,
         "maintainer_can_modify": True
     }
     if issue:


### PR DESCRIPTION
This is set by GitHub action runs for "push", "schedule",
"workflow_dispatch", and similar non-PR events [1]. Similarly how our
release workflows already use `$GITHUB_REF` to determine which branch to
act on, use this variable as a fallback in `task.pull()` when not giving
an explicit `base` branch.

This fixes bots like po-refresh or npm-update when running them on
stable branches. Previously, their generated PRs were targetting main.

[1] https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables

----

https://github.com/cockpit-project/cockpit/pull/16313 is an example PR which was generated by current bots from me triggering "po-refresh" manually on the rhel-9.0 branch. Admittedly I did not test this locally, as it's quite involved to set up everything. After this lands, I'll do another rhel-8.5 translation update (which we need to do anyway), and test this in real life. I'll also trigger a run on main to be sure it still works there as well.