### PR TITLE
po-refresh: Drop changed() heuristics

### DIFF
--- a/po-refresh
+++ b/po-refresh
@@ -49,16 +49,6 @@ def run(context, verbose=False, **kwargs):
             sys.stderr.write("+ " + " ".join(args) + "\n")
         subprocess.check_call(args, cwd=cwd)
 
-    def changed(filename):
-        lines = output("git", "diff", "--", filename).split("\n")
-        msgstr = False
-        for line in lines:
-            if line.startswith("+msgstr ") and not line.endswith('""'):
-                if verbose:
-                    sys.stderr.write("{0}: {1}\n".format(filename, line[8:]))
-                msgstr = True
-        return msgstr
-
     # Make a tree with source and run "update-po" in it... outputs working directory
     line = output("bots/make-source", "update-po")
     work = os.path.abspath(line.strip())
@@ -158,16 +148,6 @@ def run(context, verbose=False, **kwargs):
                 current_linguas.append(locale[0])
                 current_linguas.sort()
             local_branch = add_and_commit_lang(name, locale[0], "Add")
-
-    # Here we have logic to only include files that actually
-    # changed translations, and reset all the remaining ones
-    files = output("git", "ls-files", "--modified", "po/")
-    for name in files.splitlines():
-        if name.endswith(".po"):
-            if changed(name):
-                execute("git", "add", "--", name)
-            else:
-                execute("git", "checkout", "--", name)
 
     branch = task.branch(context, "po: Update from Fedora Weblate", pathspec="po/",
                          branch=local_branch, **kwargs)


### PR DESCRIPTION
It is error prone: There are translation fixes/updates which happen in
continuation lines instead of the initial `msgstr` line, and they
currently get ignored.

It is also obsolete with weblate, as that only commits files which got
actual changes.