### PR TITLE
naughty: Add pattern for missing uevents on lvcreate

### DIFF
--- a/naughty/ubuntu-2004/2426-lvcreate-uevent
+++ b/naughty/ubuntu-2004/2426-lvcreate-uevent
@@ -1,0 +1,5 @@
+Traceback (most recent call last):*
+  File "test/verify/check-storage-mounting", line *, in testDuplicateMountPoints
+    self.content_row_wait_in_col(2, 2, "/dev/test/two")
+*
+testlib.Error: Condition did not become true.


### PR DESCRIPTION
Not reported downstream, as this is fixed in current kernels/lvm2, and
too much effort (for too little gain) to track down.

Known issue #2426

----

The [weather report](https://logs-https-frontdoor.apps.ocp.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&test=test%2Fverify%2Fcheck-storage-mounting+TestStorageMounting.testDuplicateMountPoints) shows that this only happens on ubuntu-2004 (a *lot*!), the fedora-34 one was an unrelated cause.

[example](https://logs.cockpit-project.org/logs/pull-16367-20210920-075321-fc6655a0-ubuntu-2004/log.html#286) 