### PR TITLE
naughty: Close 838: Libvirtd dumps core on rhel-8.2

### DIFF
--- a/naughty/rhel-8/838-libvirtd-dumps-core
+++ b/naughty/rhel-8/838-libvirtd-dumps-core
@@ -1,2 +1,0 @@
-Process * (libvirtd) of user * dumped core.*
-*qemuStateStop*


### PR DESCRIPTION
Known issue which has not occurred in 27 days

Libvirtd dumps core on rhel-8.2

Fixes #838