### PR TITLE
naughty: Close 69: debian-stable: UDisks2 fails to create snapshots of thin volumes

### DIFF
--- a/naughty/debian-stable/69-udisks2-fails-with-thin-snapshots
+++ b/naughty/debian-stable/69-udisks2-fails-with-thin-snapshots
@@ -1,1 +1,0 @@
-Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/naughty/debian-stable/69-udisks2-fails-with-thin-snapshots-2
+++ b/naughty/debian-stable/69-udisks2-fails-with-thin-snapshots-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-lvm2", line *, in testSnapshots
-    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/naughty/debian-testing/69-udisks2-fails-with-thin-snapshots
+++ b/naughty/debian-testing/69-udisks2-fails-with-thin-snapshots
@@ -1,1 +1,0 @@
-Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/naughty/debian-testing/69-udisks2-fails-with-thin-snapshots-2
+++ b/naughty/debian-testing/69-udisks2-fails-with-thin-snapshots-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-lvm2", line *, in testSnapshots
-    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/naughty/rhel-7/69-udisks2-fails-with-thin-snapshots
+++ b/naughty/rhel-7/69-udisks2-fails-with-thin-snapshots
@@ -1,1 +1,0 @@
-Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/naughty/rhel-7/69-udisks2-fails-with-thin-snapshots-2
+++ b/naughty/rhel-7/69-udisks2-fails-with-thin-snapshots-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-lvm2", line *, in testSnapshots
-    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/naughty/rhel-8/69-udisks2-fails-with-thin-snapshots
+++ b/naughty/rhel-8/69-udisks2-fails-with-thin-snapshots
@@ -1,1 +1,0 @@
-Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/naughty/rhel-8/69-udisks2-fails-with-thin-snapshots-2
+++ b/naughty/rhel-8/69-udisks2-fails-with-thin-snapshots-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-lvm2", line *, in testSnapshots
-    self.content_row_wait_in_col(3, 2, "mysnapshot")


### PR DESCRIPTION
Known issue which has not occurred in 27 days

debian-stable: UDisks2 fails to create snapshots of thin volumes

Fixes #69