### PR TITLE
machine: Allow ebtables crash on Ubuntu 20.04 as well

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -226,7 +226,7 @@ class Machine(ssh_connection.SSHConnection):
             allowed.append('audit:.*denied.*{ setpcap }.*comm="firewalld".*')
             allowed.append('audit:.*denied.*{ setcap }.*comm="firewalld".*')
 
-        if self.image in ['debian-testing', 'ubuntu-stable']:
+        if self.image in ['debian-testing', 'ubuntu-stable', 'ubuntu-2004']:
             # HACK: https://bugs.debian.org/951477
             allowed.append(r'Process .* \(ip6?tables\) of user 0 dumped core.*')
             allowed.append(r'Process .* \(iptables-restor\) of user 0 dumped core.*')

--- a/naughty/ubuntu-2004/2248-resolved-segfault
+++ b/naughty/ubuntu-2004/2248-resolved-segfault
@@ -1,6 +1,5 @@
 Stack trace of thread *
 #* n/a (systemd-resolved + *)
-* sd_event_dispatch (libsystemd-shared-*.so + *)
 *
 testlib.Error: FAIL: Test completed, but found unexpected journal messages:
 Process * (systemd-resolve) of user * dumped core.


### PR DESCRIPTION
Seen in https://logs.cockpit-project.org/logs/pull-16393-20210924-055006-c0468b60-ubuntu-2004/log.html#234