### PR TITLE
naughty: Close 2158: podman image list api calls called directly after an event loses events  

### DIFF
--- a/naughty/fedora-34/2158-podman-api-call-loses-data
+++ b/naughty/fedora-34/2158-podman-api-call-loses-data
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-*
-  File "test/check-application", line *, in testDownloadImage
-    dialog*.openDialog() \
-  File "test/check-application", line *, in expectDownloadSuccess
-    b.wait_visible('#containers-images td[data-label="Name"]:contains("{0}")'.format(self.imageName))

--- a/naughty/rhel-9/2158-podman-api-call-loses-data
+++ b/naughty/rhel-9/2158-podman-api-call-loses-data
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-*
-  File "test/check-application", line *, in testDownloadImage
-    dialog*.openDialog() \
-  File "test/check-application", line *, in expectDownloadSuccess
-    b.wait_visible('#containers-images td[data-label="Name"]:contains("{0}")'.format(self.imageName))

--- a/naughty/rhel-9/2158-podman-api-call-loses-data-2
+++ b/naughty/rhel-9/2158-podman-api-call-loses-data-2
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-*
-  File "test/check-application", line *, in testDownloadImage
-    dialog*.openDialog() \
-  File "test/check-application", line *, in expectDownloadSuccess
-    checkImage(b, "localhost:5000/{0}:{1}".format(self.imageName, self.imageTag or "latest"), "system" if self.user == "system" else "admin")


### PR DESCRIPTION
Known issue which has not occurred in 23 days

podman image list api calls called directly after an event loses events  

Fixes #2158