### PR TITLE
naughty: Add pattern for realmd IPA uninstall crash

### DIFF
--- a/naughty/ubuntu-2004/2485-ipa-leave-crash
+++ b/naughty/ubuntu-2004/2485-ipa-leave-crash
@@ -1,0 +1,7 @@
+warning: Failed to leave domain: Running ipa-client-install failed
+*
+Traceback (most recent call last):
+  File "test/verify/check-system-realms", line *, in testQualifiedUsers
+    b.wait_not_present("#realms-leave-dialog")
+*
+testlib.Error: timeout

--- a/naughty/ubuntu-stable/2485-ipa-leave-crash
+++ b/naughty/ubuntu-stable/2485-ipa-leave-crash
@@ -1,0 +1,7 @@
+warning: Failed to leave domain: Running ipa-client-install failed
+*
+Traceback (most recent call last):
+  File "test/verify/check-system-realms", line *, in testQualifiedUsers
+    b.wait_not_present("#realms-leave-dialog")
+*
+testlib.Error: timeout


### PR DESCRIPTION
This crash has been around for a long time, but hidden by some missing
error handling in cockpit's realmd UI.
https://github.com/cockpit-project/cockpit/pull/16429 fixes that and now
spots the crash.

Downstream report: https://launchpad.net/bugs/1946244
Known issue #2485