### PR TITLE
tests-invoke: Show newer revision SHA on collisions

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -49,7 +49,7 @@ def main():
 
         if pull:
             if pull["head"]["sha"] != opts.revision:
-                return "Newer revision available on GitHub for this pull request"
+                return f"Newer revision {pull['head']['sha']} available on GitHub for this pull request"
             if pull["state"] != "open":
                 return "Pull request isn't open"
 


### PR DESCRIPTION
This has started to act up and cause a lot of test abortions due to
alleged new revisions. Let's see what it is actually finding.

This is probably some GitHub error/inconsistency somewhere.

-----

In https://github.com/cockpit-project/cockpit/pull/16429 and also c-podman and others we are getting an awful amount of "test failure 241" errors, such as https://logs.cockpit-project.org/logs/pull-16429-20211007-110414-ae1353c3-fedora-34/log.html

This is our collision detection acting up, this is the first step of debugging.