### PR TITLE
tests-invoke: Add node and updated_at information to PR collision detection

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -49,7 +49,8 @@ def main():
 
         if pull:
             if pull["head"]["sha"] != opts.revision:
-                return f"Newer revision {pull['head']['sha']} available on GitHub for this pull request"
+                return (f"Newer revision {pull['head']['sha']} available on GitHub for this pull request;"
+                        f"node_id {pull['node_id']}, updated_at {pull['updated_at']}")
             if pull["state"] != "open":
                 return "Pull request isn't open"
 


### PR DESCRIPTION
This will check if the outdated API answers that we often get can be
mitigated by checking `updated_at`, and whether they always happen on
the same GitHub API node.

---

Still debugging [these](https://logs.cockpit-project.org/logs/pull-16429-20211007-120836-ae1353c3-fedora-34/log.html) [failures](https://logs.cockpit-project.org/logs/pull-16429-20211007-120832-ae1353c3-ubuntu-2004/log.html). I have an idea how to counteract: if `updated_at` goes backwards, we ignore it.