### PR TITLE
naughty: Close 2066: rhel-9-0: can't start VM with virtiofs filesystem

### DIFF
--- a/naughty/rhel-9/2066-libvirt-virtiofs-failure
+++ b/naughty/rhel-9/2066-libvirt-virtiofs-failure
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/check-machines-filesystems", line *, in testBasic
-    b.wait_visible("#vm-subVmTest1-filesystems-add[aria-disabled=true]")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 23 days

rhel-9-0: can't start VM with virtiofs filesystem

Fixes #2066