### PR TITLE
tests-invoke: Ignore outdated PR status replies

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -37,7 +37,12 @@ def main():
     parser.add_argument('--revision', help="Revision of the PR head", required=True)
     opts = parser.parse_args()
 
+    # keep track of the most recent pull.updated_at attribute
+    last_updated_at = "0"
+
     def detect_collisions(opts):
+        nonlocal last_updated_at
+
         api = github.GitHub(repo=opts.repo)
 
         try:
@@ -49,8 +54,17 @@ def main():
 
         if pull:
             if pull["head"]["sha"] != opts.revision:
+                # Ignore GitHub API servers with outdated information
+                if pull["updated_at"] < last_updated_at:
+                    sys.stderr.write(f"tests-invoke: Ignoring pull_request response for updated_at {pull['updated_at']}"
+                                     f"; it is older than the previous {last_updated_at}\n")
+                    return None
+
                 return (f"Newer revision {pull['head']['sha']} available on GitHub for this pull request;"
                         f"node_id {pull['node_id']}, updated_at {pull['updated_at']}")
+
+            last_updated_at = pull["updated_at"]
+
             if pull["state"] != "open":
                 return "Pull request isn't open"
 


### PR DESCRIPTION
These days there is some broken GitHub API server which returns vastly
outdated pull request data. This breaks PRs with force-pushes, as the
outdated SHA triggers the collision detection.

To avoid that, keep track of the response's .updated_at attribute, and
ignore responses which go backwards in time.

Revert the extra debugging from commit 847f436.

-----

I tested this locally by creating a .cockpit-ci/run with `sleep 20`, this diff:

```diff
diff --git tests-invoke tests-invoke
index fe7bcae..40f108c 100755
--- tests-invoke
+++ tests-invoke
@@ -53,6 +52,10 @@ def main():
             return None
 
         if pull:
+            sys.stderr.write(f"tests-invoke DEBUG: updated_at {pull['updated_at']}, last_updated_at "
+                             f"{last_updated_at}, pull.head.SHA {pull['head']['sha']}, "
+                             f"opts.revision {opts.revision}\n")
+
             if pull["head"]["sha"] != opts.revision:
                 # Ignore GitHub API servers with outdated information
                 if pull["updated_at"] < last_updated_at:
@@ -65,9 +68,6 @@ def main():
 
             last_updated_at = pull["updated_at"]
 
-            if pull["state"] != "open":
-                return "Pull request isn't open"
-
         return None
 
     try:
@@ -87,7 +87,7 @@ def main():
                 p.terminate()
                 p.wait(timeout=60)
             else:
-                time.sleep(60)
+                time.sleep(5)
         return_code = p.returncode
         sys.stderr.write("Test run finished, return code: {0}\n".format(return_code))
         return return_code

```

and running

    ./tests-invoke --pull-number 2494  --revision 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1

```
tests-invoke DEBUG: updated_at 2021-10-08T04:40:43Z, last_updated_at 0, pull.head.SHA 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1, opts.revision 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1
tests-invoke DEBUG: updated_at 2021-10-08T04:40:43Z, last_updated_at 2021-10-08T04:40:43Z, pull.head.SHA 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1, opts.revision 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1
tests-invoke DEBUG: updated_at 2021-10-08T04:40:43Z, last_updated_at 2021-10-08T04:40:43Z, pull.head.SHA 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1, opts.revision 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1
tests-invoke DEBUG: updated_at 2021-10-08T04:40:43Z, last_updated_at 2021-10-08T04:40:43Z, pull.head.SHA 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1, opts.revision 3f79061c5122843f679ea0b2b7ce0b2b9b0bc3e1
Test run finished, return code: 0
```

This did not catch an outdated API server, but at least shows that I didn't completely break the logic. I lightly tested the "outdated" case by setting a newer timestamp to the initialization and giving a wrong SHA on the command line -- this then ignored the responses and ran the test.