### PR TITLE
test: Skip cockpituous test on testmap changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
           git config user.email github-actions@github.com
           git rebase origin/main
 
-      - name: Check whether anything besides images/, machine_core/, or naughty/ changed
+      - name: Check whether there are changes that might affect the deployment
         id: changes
         run: |
-          changes=$(git diff --name-only origin/main..HEAD | grep -Ev '^(images|naughty|machine/machine_core)/' || true)
+          changes=$(git diff --name-only origin/main..HEAD | grep -Ev '^(images|naughty|machine/machine_core|lib/testmap)/' || true)
           # print for debugging
           echo "changes:"
           echo "$changes"


### PR DESCRIPTION
These are often sent from developer forks (where the cockpituous test
does not work), don't affect the deployment, and are self-validating.

----

Seen in e.g. PR #2498 which always get that unsightly cockpituous test failure.