### PR TITLE
images: Upgrade debian-testing image to actual testing

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-8a68ea4ce9b50f5d2f5c17af781dcdf98c215d839882eb78bad5bb4c559333d3.qcow2
+debian-testing-117dd598b6a46fcf07152a06e81f832f6eec58c56dcba7de7b8dcb04c17e4986.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -32,6 +32,7 @@ python3-dbus \
 qemu-block-extra \
 realmd \
 selinux-basics \
+sscg \
 thin-provisioning-tools \
 unattended-upgrades \
 tuned \
@@ -94,6 +95,8 @@ case "$RELEASE" in
     bullseye)
         # freeipa got dropped from testing: https://tracker.debian.org/pkg/freeipa
         IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
+        # no sscg yet
+        COCKPIT_DEPS="${COCKPIT_DEPS/sscg /}"
         ;;
     testing)
         # freeipa got dropped from testing: https://tracker.debian.org/pkg/freeipa
@@ -102,6 +105,12 @@ case "$RELEASE" in
     focal)
         # no podman package yet
         TEST_PACKAGES="${TEST_PACKAGES/podman /}"
+        # no sscg yet
+        COCKPIT_DEPS="${COCKPIT_DEPS/sscg /}"
+        ;;
+    hirsute)
+        # no sscg yet
+        COCKPIT_DEPS="${COCKPIT_DEPS/sscg /}"
         ;;
 esac
 

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -83,8 +83,19 @@ until systemctl list-jobs | grep -q "No jobs"; do sleep 1; done
 
 RELEASE=$(grep -m1 ^deb /etc/apt/sources.list | awk '{print $3}')
 
+# debian-testing image gets bootstrapped from debian stable; upgrade
+if [ "$1" = "debian-testing" ]; then
+    rm --verbose -f /etc/apt/sources.list.d/*
+    echo 'deb http://deb.debian.org/debian testing main' > /etc/apt/sources.list
+    RELEASE=testing
+fi
+
 case "$RELEASE" in
     bullseye)
+        # freeipa got dropped from testing: https://tracker.debian.org/pkg/freeipa
+        IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
+        ;;
+    testing)
         # freeipa got dropped from testing: https://tracker.debian.org/pkg/freeipa
         IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
         ;;

--- a/naughty/debian-testing/1565-qemu-5.2-assert-BH_DELETED
+++ b/naughty/debian-testing/1565-qemu-5.2-assert-BH_DELETED
@@ -1,3 +1,0 @@
-*TestMachines*
-*
-Process * (qemu-system-x86) of user * dumped core.

--- a/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs
+++ b/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs
@@ -1,0 +1,4 @@
+umount: /dev/mapper/luks-*: not mounted.
+*
+  File "*test/verify/check-storage-resize", line *, in testGrowShrinkEncryptedHelp
+    self.shrink_extfs(fs_dev, *)

--- a/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs-2
+++ b/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs-2
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-resize", line *, in testResizeLuks
+    self.checkResize("ext4", True,
+*
+  File "test/verify/storagelib.py", line *, in wait_mounted
+    self.content_tab_wait_in_info(row, col, "Mount point",

--- a/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs-3
+++ b/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs-3
@@ -1,0 +1,3 @@
+*self.checkResize*
+*
+AssertionError: * not greater than 300000

--- a/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs-4
+++ b/naughty/debian-testing/1739-cryptsetup-systemd-umount-fs-4
@@ -1,0 +1,3 @@
+  File "test/verify/check-storage-resize", line *, in testGrowShrinkEncryptedHelp
+    self.assertGreater(size, 250000)
+AssertionError: * not greater than 250000

--- a/naughty/debian-testing/2220-libvirt-crashes-on-startup
+++ b/naughty/debian-testing/2220-libvirt-crashes-on-startup
@@ -1,4 +1,0 @@
-# testBasicWheelUserUnprivileged (__main__.TestMachinesLifecycle)
-*
-  File "test/check-machines-lifecycle", line *, in _testBasic
-    b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")

--- a/naughty/debian-testing/2220-libvirt-crashes-on-startup-2
+++ b/naughty/debian-testing/2220-libvirt-crashes-on-startup-2
@@ -1,5 +1,0 @@
-# testBasicWheelUserUnprivileged (__main__.TestMachinesLifecycle)
-*
-#0 * n/a (libvirt_driver_qemu.so + *)
-#1 * virStateShutdownPrepare (libvirt.so.0 + *)
-#2 * virNetDaemonRun (libvirt.so.0 + *)

--- a/naughty/debian-testing/2519-libvirt-veth-nodedev
+++ b/naughty/debian-testing/2519-libvirt-veth-nodedev
@@ -1,0 +1,4 @@
+  File "test/check-machines-create", line *, in fill
+    b.select_from_dropdown("#network-select", self.location)
+*
+wait_js_cond(ph_is_present("#network-select option[value='type=direct,source=eth42']")): Uncaught (in promise) Error: condition did not become true

--- a/naughty/debian-testing/70-pxe-boot-logs-serial-console-libvirt
+++ b/naughty/debian-testing/70-pxe-boot-logs-serial-console-libvirt
@@ -1,1 +1,0 @@
-subprocess.CalledProcessError: Command 'sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'' returned non-zero exit status 1.


### PR DESCRIPTION
There are no cloud images for bookworm yet (the future release which is
currently testing), so the debian-testing image is still being
bootstrapped from bullseye (current stable). Update the image to actual
testing again.

 * [x] image-refresh debian-testing