### PR TITLE
machine_core: Fix VirtMachine.add_disk() on Fedora 35

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -532,7 +532,7 @@ class VirtMachine(Machine):
         if path:
             (unused, image) = tempfile.mkstemp(suffix='.qcow2', prefix=os.path.basename(path), dir=self.run_dir)
             subprocess.check_call(["qemu-img", "create", "-q", "-f", "qcow2",
-                                   "-o", "backing_file=" + os.path.realpath(path), image])
+                                   "-o", f"backing_file={os.path.realpath(path)},backing_fmt=qcow2", image])
 
         else:
             assert size is not None


### PR DESCRIPTION
Similar to commit 0603b382dd7e1, specify the backing format for creating
a qcow2 overlay in VirtMachine.add_disk(), so that this continues to
work in a Fedora 35 environment. That update
(https://github.com/cockpit-project/cockpituous/pull/442) broke
cockpit's rhel-7.9 branch.

---

[failure log](https://logs.cockpit-project.org/logs/pull-2524-20211018-125249-e88e4c12-rhel-7-9-cockpit-project-cockpit-rhel-7.9/log.html) from unrelated https://github.com/cockpit-project/bots/pull/2524