### PR TITLE
testmap: update RHEL versions for subscription-manager branches

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -146,12 +146,20 @@ REPO_BRANCH_CONTEXT = {
     },
     'candlepin/subscription-manager': {
         'main': [
-            'rhel-8-4',
+            'rhel-8-5',
+            'rhel-8-6',
+            'rhel-9-0',
         ],
         'subscription-manager-1.28': [
             'rhel-8-4',
+            'rhel-8-5',
+            'rhel-8-6',
+        ],
+        'subscription-manager-1.28.21': [
+            'rhel-8-5',
         ],
         '_manual': [
+            'rhel-8-4',
             'rhel-8-5',
             'rhel-8-6',
             'rhel-9-0',


### PR DESCRIPTION
Improve the coverage of the active branches of subscription-manager
according to the RHEL versions they target, or that they are help
targetting:
- "main" targets RHEL 9, so add rhel-9-0; since commits from it are
  usually backported also to stable branches, add rhel-8-6 and rhel-8-5
  too; remove rhel-8-4, as it will be covered by other stable branches
- "subscription-manager-1.28" targets RHEL 8.x (currently 8.6), so
  add rhel-8-6; add rhel-8-5, as commits may be backported from other
  stable branches from this
- "subscription-manager-1.28.21" targets RHEL 8.5.x, so test rhel-8-5

Also add rhel-8-4 to "_manual", so it can still be manually triggered if
needed.