### PR TITLE
test: Really skip cockpituous test on testmap changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check whether there are changes that might affect the deployment
         id: changes
         run: |
-          changes=$(git diff --name-only origin/main..HEAD | grep -Ev '^(images|naughty|machine/machine_core|lib/testmap)/' || true)
+          changes=$(git diff --name-only origin/main..HEAD | grep -Ev '^(images|naughty|machine/machine_core|lib/testmap.py)/' || true)
           # print for debugging
           echo "changes:"
           echo "$changes"


### PR DESCRIPTION
Fixes commit 0ecfbfd100d, which had a wrong pattern -- `testmap/` is
never going to match.

---

This caused an unsightly test failure in https://github.com/cockpit-project/bots/pull/2543 yesterday.

Sorry  about that -- this time I *really* tested it.