### PR TITLE
naughty: dnsmasq crash #2435 affects Fedora 35 as well

### DIFF
--- a/naughty/fedora-34/2435-dnsmasq-crash
+++ b/naughty/fedora-34/2435-dnsmasq-crash
@@ -1,0 +1,5 @@
+Process * (dnsmasq) of user * dumped core.
+*
+#* lookup_domain*
+#* check_dns_listeners*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:

--- a/naughty/fedora-35/2435-dnsmasq-crash
+++ b/naughty/fedora-35/2435-dnsmasq-crash
@@ -1,0 +1,5 @@
+Process * (dnsmasq) of user * dumped core.
+*
+#* lookup_domain*
+#* check_dns_listeners*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:


### PR DESCRIPTION
Also add it to Fedora 34, as Fedora CoreOS is based on that and
confirmed to be affected.

---

Observed [here](https://logs.cockpit-project.org/logs/pull-16517-20211026-120740-ff058897-fedora-35/log.html#71) from https://github.com/cockpit-project/cockpit/pull/16517