### PR TITLE
naughty: Add pattern for polkit crash in polkit_system_bus_name_get_creds_sync()

### DIFF
--- a/naughty/debian-testing/2567-polkit-crash-system_bus_name_get_creds_sync
+++ b/naughty/debian-testing/2567-polkit-crash-system_bus_name_get_creds_sync
@@ -1,0 +1,3 @@
+Process * (polkitd) of user * dumped core.*
+#* polkit_system_bus_name_get_user_sync*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages

--- a/naughty/fedora-34/2567-polkit-crash-system_bus_name_get_creds_sync
+++ b/naughty/fedora-34/2567-polkit-crash-system_bus_name_get_creds_sync
@@ -1,0 +1,3 @@
+Process * (polkitd) of user * dumped core.*
+#* polkit_system_bus_name_get_creds_sync*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages

--- a/naughty/rhel-9/2567-polkit-crash-system_bus_name_get_creds_sync
+++ b/naughty/rhel-9/2567-polkit-crash-system_bus_name_get_creds_sync
@@ -1,0 +1,3 @@
+Process * (polkitd) of user * dumped core.*
+#* polkit_system_bus_name_get_creds_sync*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1962466
Known issue #2567

---

This started to happen in https://github.com/cockpit-project/cockpit/pull/16516 due to timing changes.

[example log](https://logs.cockpit-project.org/logs/pull-16516-20211028-061209-eae2ebf8-fedora-34-mobile/log.html#290-2)