### PR TITLE
images: print insights-client version before calling insigths

### DIFF
--- a/images/scripts/rhel-7-9.setup
+++ b/images/scripts/rhel-7-9.setup
@@ -195,13 +195,13 @@ fi
 # last_stable.egg makes that work as expected, too.
 
 if [ -x /usr/bin/insights-client ]; then
+    insights-client --version
     insights-client --status --verbose || true
     if [ -f /var/lib/insights/newest.egg ]; then
         cp /var/lib/insights/newest.egg /var/lib/insights/last_stable.egg
         cp /var/lib/insights/newest.egg.asc /var/lib/insights/last_stable.egg.asc
         rm -f /etc/insights-client/rpm.egg /etc/insights-client/rpm.egg.asc
     fi
-    insights-client --version
 fi
 
 # Pre-install cockpit packages from base, to check for API breakages

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -218,13 +218,13 @@ fi
 # last_stable.egg makes that work as expected, too.
 
 if [ -x /usr/bin/insights-client ]; then
+    insights-client --version
     insights-client --status --verbose || true
     if [ -f /var/lib/insights/newest.egg ]; then
         cp /var/lib/insights/newest.egg /var/lib/insights/last_stable.egg
         cp /var/lib/insights/newest.egg.asc /var/lib/insights/last_stable.egg.asc
         rm -f /etc/insights-client/rpm.egg /etc/insights-client/rpm.egg.asc
     fi
-    insights-client --version
 fi
 
 # Pre-install cockpit packages from base, to check for API breakages


### PR DESCRIPTION
The insights debug logs does not reveal the insights version and it
fails no version information is printed.

 * [x] image-refresh rhel-7-9
 - [ ] image-refresh rhel-9-0