### PR TITLE
naughty: Close 70: Can't get PXE boot logs from libvirt guest on a serial console

### DIFF
--- a/naughty/debian-stable/70-pxe-boot-logs-serial-console-libvirt
+++ b/naughty/debian-stable/70-pxe-boot-logs-serial-console-libvirt
@@ -1,1 +1,0 @@
-subprocess.CalledProcessError: Command 'sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'' returned non-zero exit status 1.

--- a/naughty/rhel-9/70-pxe-boot-logs-serial-console-libvirt
+++ b/naughty/rhel-9/70-pxe-boot-logs-serial-console-libvirt
@@ -1,1 +1,0 @@
-subprocess.CalledProcessError: Command 'sed 's,\x1B\[[0-9;]*[a-zA-Z],,g' /tmp/serial.txt | grep 'Rebooting in 60'' returned non-zero exit status 1.


### PR DESCRIPTION
Known issue which has not occurred in 23 days

Can't get PXE boot logs from libvirt guest on a serial console

Fixes #70