### PR TITLE
naughty: polkit crash affects Fedora 35 and Ubuntu stable as well

### DIFF
--- a/naughty/fedora-35/2567-polkit-crash-system_bus_name_get_creds_sync
+++ b/naughty/fedora-35/2567-polkit-crash-system_bus_name_get_creds_sync
@@ -1,0 +1,3 @@
+Process * (polkitd) of user * dumped core.*
+#* polkit_system_bus_name_get_creds_sync*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages

--- a/naughty/ubuntu-stable/2567-polkit-crash-system_bus_name_get_creds_sync
+++ b/naughty/ubuntu-stable/2567-polkit-crash-system_bus_name_get_creds_sync
@@ -1,0 +1,3 @@
+Process * (polkitd) of user * dumped core.*
+#* polkit_system_bus_name_get_user_sync*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages


### PR DESCRIPTION
[failure on F35](https://logs.cockpit-project.org/logs/pull-16538-20211102-093808-427b29b1-fedora-35/log.html#291-2), [failure on ubuntu-stable](https://logs.cockpit-project.org/logs/pull-16538-20211102-104209-427b29b1-ubuntu-stable/log.html#291-2)