### PR TITLE
testmap: add manual Fedora branches for subscription-manager

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -163,6 +163,9 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-5',
             'rhel-8-6',
             'rhel-9-0',
+            'fedora-34',
+            'fedora-35',
+            'fedora-35/rawhide',
         ],
     },
     'skobyda/cockpit-certificates': {


### PR DESCRIPTION
The cockpit CI in subscription-manager/main is being fixed on to work
fine also on Fedora; hence, add the latest Fedora versions to the manual
test contexts for subscription-manager.

For the fixing attempts (which should work), see:
https://github.com/candlepin/subscription-manager/pull/2861