### PR TITLE
RHEL: make insights-client non-verbose

### DIFF
--- a/images/scripts/rhel-7-9.setup
+++ b/images/scripts/rhel-7-9.setup
@@ -195,6 +195,7 @@ fi
 # last_stable.egg makes that work as expected, too.
 
 if [ -x /usr/bin/insights-client ]; then
+    rpm -q insights-client
     insights-client --version
     insights-client --status --verbose || true
     if [ -f /var/lib/insights/newest.egg ]; then

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -219,7 +219,7 @@ fi
 
 if [ -x /usr/bin/insights-client ]; then
     insights-client --version
-    insights-client --status --verbose || true
+    insights-client --status || true
     if [ -f /var/lib/insights/newest.egg ]; then
         cp /var/lib/insights/newest.egg /var/lib/insights/last_stable.egg
         cp /var/lib/insights/newest.egg.asc /var/lib/insights/last_stable.egg.asc

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -218,6 +218,7 @@ fi
 # last_stable.egg makes that work as expected, too.
 
 if [ -x /usr/bin/insights-client ]; then
+    rpm -q insights-client
     insights-client --version
     insights-client --status || true
     if [ -f /var/lib/insights/newest.egg ]; then


### PR DESCRIPTION
Apparently, newer versions of the insights-client in RHEL 9 log the HTTP traffic, which includes binary data (the egg file). Since we are not really interested in it, and that the log file is available locally anyway, simply make the `--status` run as non-verbose.

Also, print the RPM version of the `insights-client` package, to help debugging problems.

Fixes #2563

 - [ ] image-refresh rhel-9-0