### PR TITLE
machine: disable PKCS11Provider to avoid errors

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -39,7 +39,7 @@ def write_all(fd, data):
 
 class SSHConnection(object):
     ssh_default_opts = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
-                        "-o", "IdentitiesOnly=yes", "-o", "BatchMode=yes"]
+                        "-o", "IdentitiesOnly=yes", "-o", "BatchMode=yes", "-o", "PKCS11Provider=none"]
 
     def __init__(self, user, address, ssh_port, identity_file, verbose=False):
         self.verbose = verbose


### PR DESCRIPTION
Due to our use of BatchMode=yes and the fact that I use PKCS11 for my
SSH key, I see a bunch of superfluous logging output from ssh every time
I start a VM:

    $ bots/vm-run -q fedora-35
    pin required
    C_FindObjectsInit failed: 179
    C_FindObjectsFinal failed: 179
    C_FindObjectsInit failed: 179
    C_FindObjectsFinal failed: 179

    SSH ACCESS
      $ ssh -p 2201 -i bots/machine/identity root@127.0.0.2

    COCKPIT
      http://127.0.0.2:9091

    [ ^C to terminate ]

That's caused by https://bugzilla.mindrot.org/show_bug.cgi?id=3359.

Let's increase the LogLevel by one notch to FATAL to avoid these
messages (which are issued at the "ERROR" level).