### PR TITLE
testmap: Drop Fedora-33 cockpit-composer test

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -129,6 +129,7 @@ REPO_BRANCH_CONTEXT = {
     'osbuild/cockpit-composer': {
         'main': [
             'fedora-34',
+            'fedora-34/firefox',
             'rhel-8-5',
             'rhel-9-0'
         ],
@@ -139,7 +140,6 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-35',
-            'fedora-34/firefox',
         ],
     },
     'candlepin/subscription-manager': {

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -128,8 +128,6 @@ REPO_BRANCH_CONTEXT = {
     },
     'osbuild/cockpit-composer': {
         'main': [
-            'fedora-33',
-            'fedora-33/firefox',
             'fedora-34',
             'rhel-8-5',
             'rhel-9-0'


### PR DESCRIPTION
Let's use this PR to drop Fedora-33 and add Fedora-34/firefox.