### PR TITLE
testmap: add Fedora branches for subscription-manager/main

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -147,6 +147,9 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-5',
             'rhel-8-6',
             'rhel-9-0',
+            'fedora-34',
+            'fedora-35',
+            'fedora-35/rawhide',
         ],
         'subscription-manager-1.28': [
             'rhel-8-4',


### PR DESCRIPTION
The 'main' branch of subscription-manager supports Fedora now in the
cockpit CI; hence, add the currently supported Fedora versions for it.

The Fedora fixes were done in https://github.com/candlepin/subscription-manager/pull/2861