### PR TITLE
lib: Update cockpit-11 e2e machine domain name

### DIFF
--- a/lib/stores
+++ b/lib/stores
@@ -1,4 +1,4 @@
 hybrid	https://cockpit-images.eu-central-1.linodeobjects.com/
 hybrid	https://cockpit-images.us-east-1.linodeobjects.com/
 public	https://images-frontdoor.apps.ocp.ci.centos.org/
-redhat	https://cockpit-11.e2e.bos.redhat.com:8493/
+redhat	https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com:8493/


### PR DESCRIPTION
This machine moved into a different DNS domain a few months ago, since
then the old name was not resolvable any more.