### PR TITLE
images: Drop obsolete firewalld hack on ubuntu-stable

### DIFF
--- a/images/scripts/ubuntu-stable.install
+++ b/images/scripts/ubuntu-stable.install
@@ -3,6 +3,3 @@
 set -e
 
 /var/lib/testvm/debian.install "$@"
-
-# HACK: nftables backend does not currently work with libvirt: https://launchpad.net/bugs/1799095
-sed -i 's/FirewallBackend=nftables/FirewallBackend=iptables/' /etc/firewalld/firewalld.conf


### PR DESCRIPTION
The virsh network works fine with the default configuration now.