### PR TITLE
lib: Drop CentOS CI image store

### DIFF
--- a/lib/stores
+++ b/lib/stores
@@ -1,4 +1,3 @@
 hybrid	https://cockpit-images.eu-central-1.linodeobjects.com/
 hybrid	https://cockpit-images.us-east-1.linodeobjects.com/
-public	https://images-frontdoor.apps.ocp.ci.centos.org/
 redhat	https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com:8493/


### PR DESCRIPTION
Linode stores have proven to be very reliable, and we still have
redundancy on cockpit-11. Let's tear down the image server on CentOS CI
to reduce usage of our custom cert/key and upload token, and save some
bandwidth/time on image refreshes (which upload to all stores).