### PR TITLE
naughty: Close 2386: rhel-9-0: udisksd sometimes crashes during shutdown

### DIFF
--- a/naughty/rhel-9/2386-udisksd-crashes-during-shutdown
+++ b/naughty/rhel-9/2386-udisksd-crashes-during-shutdown
@@ -1,1 +1,0 @@
-Failed to connect to coredump service: Connection refused


### PR DESCRIPTION
Known issue which has not occurred in 28 days

rhel-9-0: udisksd sometimes crashes during shutdown

Fixes #2386