### PR TITLE
naughty: Add pattern for tuned recommending nonexisting "atomic-guest" profile

### DIFF
--- a/naughty/rhel-9/2703-tuned-atomic-guest
+++ b/naughty/rhel-9/2703-tuned-atomic-guest
@@ -1,0 +1,5 @@
+  File "tests/test/verify/check-system-tuned", line *, in testBasic
+    b.wait_text('#tuned-status-button', recommended_profile)
+*
+testlib.Error: timeout
+wait_js_cond(ph_text_is("#tuned-status-button","atomic-guest")): timeout


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2030580
Known issue #2703

---

This will "fix" the recent failure of cockpit's centos-9-stream tests in packit. [example log](http://artifacts.dev.testing-farm.io/07c9b635-19fc-4802-90c7-1cf1985773bb/)