### PR TITLE
testmap: Add some fedora-35/* contexts to _manual

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -61,6 +61,9 @@ REPO_BRANCH_CONTEXT = {
             'fedora-testing/dnf-copr',
             'rhel-9-0-distropkg',
             'fedora-34/firefox-devel',
+            'fedora-35/mobile',
+            'fedora-35/firefox',
+            'fedora-35/devel',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
So that we can trigger them in the PR that switches the default to
fedora-35.