### PR TITLE
naughty: Close 1784: fedora-34: reportd crashes in reportd_task_start

### DIFF
--- a/naughty/fedora-34/1784-reportd-crash-task_start
+++ b/naughty/fedora-34/1784-reportd-crash-task_start
@@ -1,5 +1,0 @@
-Stack trace of thread*
-#* reportd_task_start*
-*
-testlib.Error: FAIL: Test completed, but found unexpected journal messages:
-Process * (reportd) of user 0 dumped core.


### PR DESCRIPTION
Known issue which has not occurred in 22 days

fedora-34: reportd crashes in reportd_task_start

Fixes #1784