### PR TITLE
testmap: Add some fedora-35/* contexts to _manual of c-machines

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -117,6 +117,8 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'fedora-testing',
+            'fedora-35/firefox',
+            'fedora-35/mobile',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
To be able to test them before switching the default.