### PR TITLE
machine: Extend rhbz#2029873 patterns

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -238,6 +238,8 @@ class Machine(ssh_connection.SSHConnection):
         if self.image in ['rhel-8-6', 'centos-8-stream']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2029873
             allowed.append('audit.*denied.*{ write }.*comm="rhsm-service" name="memfd:libffi".*')
+            # same issue also fails later on with map/read/execute in permissive mode
+            allowed.append('audit.*denied.*comm="rhsm-service" .* dev="tmpfs".*permissive=1.*')
 
         if self.image in ['rhel-9-0']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1989641


### PR DESCRIPTION
The same rhsm/SELinux issue also causes follow-up denials in permissive
mode:

    audit: type=1400 audit(1639419114.745:11): avc:  denied  { map } for  pid=2311 comm="rhsm-service" path=2F6D656D66643A6C6962666669202864656C6574656429 dev="tmpfs" ino=40599 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1
    audit: type=1400 audit(1639419114.745:12): avc:  denied  { read execute } for  pid=2311 comm="rhsm-service" path=2F6D656D66643A6C6962666669202864656C6574656429 dev="tmpfs" ino=40599 scontext=system_u:system_r:rhsmcertd_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1

These are already covered by the existing bug. Add the patterns.

----

Fixes [this flake](https://logs.cockpit-project.org/logs/pull-16723-20211213-173633-6d5453f9-rhel-8-6/log.html#125).