### PR TITLE
testmap: Drop centos-8-stream from cockpit/rhel-8.5 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -52,7 +52,6 @@ REPO_BRANCH_CONTEXT = {
         'rhel-8.5': [
             'rhel-8-5',
             'rhel-8-5-distropkg',
-            'centos-8-stream',
             f'{TEST_OS_DEFAULT}/container-bastion',
         ],
         # These can be triggered manually with bots/tests-trigger


### PR DESCRIPTION
CentOS 8 Stream moved to RHEL 8.6 nightly, and expected test failures
start to fail. These tests are not relevant for this branch any more.

----

Will address one failure in PR #2729