### PR TITLE
naughty: Close 2426: TestStorageMounting.testDuplicateMountPoints flake on ubuntu-2004: lvcreate is sometimes missing uevent

### DIFF
--- a/naughty/ubuntu-2004/2426-lvcreate-uevent
+++ b/naughty/ubuntu-2004/2426-lvcreate-uevent
@@ -1,5 +1,0 @@
-Traceback (most recent call last):*
-  File "test/verify/check-storage-mounting", line *, in testDuplicateMountPoints
-    self.content_row_wait_in_col(2, 2, "/dev/test/two")
-*
-testlib.Error: Condition did not become true.


### PR DESCRIPTION
Known issue which has not occurred in 23 days

TestStorageMounting.testDuplicateMountPoints flake on ubuntu-2004: lvcreate is sometimes missing uevent

Fixes #2426