### PR TITLE
naughty: Close 1785: fedora-34: reportd crashes

### DIFF
--- a/naughty/fedora-34/1785-reportd-crash-g_bus_unown_name
+++ b/naughty/fedora-34/1785-reportd-crash-g_bus_unown_name
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-system-journal", line *, in testAbrtReport
-    b.wait_visible(".pf-c-modal-box__body input[type='%s']" % (purpose))
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 24 days

fedora-34: reportd crashes

Fixes #1785