### PR TITLE
testmap: Add some fedora-35/rawhide context to _manual of anaconda project

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -182,6 +182,11 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream',
         ]
     },
+    'M4rtinK/anaconda': {
+        '_manual': [
+            'fedora-35/rawhide',
+        ]
+    },
 }
 
 # The OSTree variants can't build their own packages, so we build in


### PR DESCRIPTION
The repository used belongs to @M4rtinK and is just a staging
development repo which will be soon replaced.