### PR TITLE
rename pr-tests to tests-status, adding features

### DIFF
--- a/pr-tests
+++ b/pr-tests
@@ -16,11 +16,11 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
 import argparse
+import ssl
 import sys
 import urllib.request
-import ssl
-import json
 
 from lib.stores import CA_PEM
 import task
@@ -66,21 +66,20 @@ def main():
     opts = parser.parse_args()
 
     api = task.github.GitHub(repo=opts.repo)
-    try:
-        statuses_url = api.get("pulls/" + str(opts.pr))["statuses_url"]
-    except TypeError:
-        sys.stderr.write("%s is not a pull request\n" % opts.pr)
-        return 1
 
-    with urllib.request.urlopen(statuses_url) as f:
-        statuses = json.load(f)
+    pull = api.get(f"pulls/{opts.pr}")
+    if not pull:
+        sys.exit(f"{opts.pr} is not a pull request.")
+    revision = pull['head']['sha']
+
+    statuses = api.statuses(revision)
 
     by_context = {}  # context → (state, url)
-    for status in statuses:
+    for context, status in statuses.items():
         # latest status wins
-        if status["context"] in by_context:
+        if context in by_context:
             continue
-        by_context[status["context"]] = (status["state"], status.get("target_url", ""))
+        by_context[context] = (status["state"], status.get("target_url", ""))
 
     by_state = {}  # state → [(context, url), ..]
     for context, (state, url) in by_context.items():
@@ -99,4 +98,4 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()

--- a/tests-status
+++ b/tests-status
@@ -19,6 +19,7 @@
 
 import argparse
 import ssl
+import subprocess
 import sys
 import urllib.request
 
@@ -57,20 +58,28 @@ def print_failure(context, url):
     print()
 
 
+def git(*args):
+    return subprocess.check_output(('git',) + args, encoding='utf-8').strip()
+
+
 def main():
     parser = argparse.ArgumentParser(description='Summarize test status of a PR')
     parser.add_argument('--repo', help="The repository of the PR", default=None)
     parser.add_argument('-v', '--verbose', action="store_true", default=False,
                         help="Print verbose information")
-    parser.add_argument("pr", type=int)
+    parser.add_argument("target", help='The pull request number to inspect, '
+                                       'or - for the upstream of the current branch')
     opts = parser.parse_args()
 
     api = task.github.GitHub(repo=opts.repo)
 
-    pull = api.get(f"pulls/{opts.pr}")
-    if not pull:
-        sys.exit(f"{opts.pr} is not a pull request.")
-    revision = pull['head']['sha']
+    if opts.target != '-':
+        pull = api.get(f"pulls/{opts.target}")
+        if not pull:
+            sys.exit(f"{opts.target} is not a pull request.")
+        revision = pull['head']['sha']
+    else:
+        revision = git('rev-parse', '@{upstream}')
 
     statuses = api.statuses(revision)
 

--- a/tests-status
+++ b/tests-status
@@ -62,6 +62,22 @@ def git(*args):
     return subprocess.check_output(('git',) + args, encoding='utf-8').strip()
 
 
+# returns a dict of state->[(context, url)]
+def sort_statuses(statuses):
+    by_context = {}  # context → (state, url)
+    for context, status in statuses.items():
+        # latest status wins
+        if context in by_context:
+            continue
+        by_context[context] = (status["state"], status.get("target_url", ""))
+
+    by_state = {}  # state → [(context, url), ..]
+    for context, (state, url) in by_context.items():
+        by_state.setdefault(state, []).append((context, url))
+
+    return by_state
+
+
 def main():
     parser = argparse.ArgumentParser(description='Summarize test status of a PR')
     parser.add_argument('--repo', help="The repository of the PR", default=None)
@@ -81,18 +97,7 @@ def main():
     else:
         revision = git('rev-parse', '@{upstream}')
 
-    statuses = api.statuses(revision)
-
-    by_context = {}  # context → (state, url)
-    for context, status in statuses.items():
-        # latest status wins
-        if context in by_context:
-            continue
-        by_context[context] = (status["state"], status.get("target_url", ""))
-
-    by_state = {}  # state → [(context, url), ..]
-    for context, (state, url) in by_context.items():
-        by_state.setdefault(state, []).append((context, url))
+    by_state = sort_statuses(api.statuses(revision))
 
     for state in by_state.keys():
         if state != "failure":

--- a/tests-status
+++ b/tests-status
@@ -21,6 +21,7 @@ import argparse
 import ssl
 import subprocess
 import sys
+import time
 import urllib.request
 
 from lib.stores import CA_PEM
@@ -80,6 +81,7 @@ def sort_statuses(statuses):
 
 def main():
     parser = argparse.ArgumentParser(description='Summarize test status of a PR')
+    parser.add_argument('--wait', action='store_true', help="Wait for all green, or one red", default=None)
     parser.add_argument('--repo', help="The repository of the PR", default=None)
     parser.add_argument('-v', '--verbose', action="store_true", default=False,
                         help="Print verbose information")
@@ -97,7 +99,15 @@ def main():
     else:
         revision = git('rev-parse', '@{upstream}')
 
-    by_state = sort_statuses(api.statuses(revision))
+    while True:
+        by_state = sort_statuses(api.statuses(revision))
+
+        if 'pending' not in by_state or 'failure' in by_state or not opts.wait:
+            break
+
+        print_summary(by_state, 'pending')
+        print('waiting...\n')
+        time.sleep(30)
 
     for state in by_state.keys():
         if state != "failure":


### PR DESCRIPTION
 - we now support the `-` syntax for "upstream of current branch", as per `tests-trigger`
 - add a new `--wait` option to block until one test is red or all tests are green