### PR TITLE
testmap: Add manual fedora-35/pixels context for cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -60,6 +60,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-testing/dnf-copr',
             'rhel-9-0-distropkg',
             f'{TEST_OS_DEFAULT}/firefox-devel',
+            f'{TEST_OS_DEFAULT}/pixels',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
To allow testing the upcoming TEST_PIXELS stuff.