### PR TITLE
testmap: There must be default branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -184,6 +184,8 @@ REPO_BRANCH_CONTEXT = {
         ]
     },
     'M4rtinK/anaconda': {
+        'master': [
+        ],
         'master-cockpit_web_ui_prototype': [
             'fedora-35/rawhide',
         ]


### PR DESCRIPTION
Otherwise tests fail with `ValueError: repo M4rtinK/anaconda does not contain main or master branch`

As seen in https://github.com/cockpit-project/bots/issues/2804