### PR TITLE
test: Really really skip cockpituous test on testmap changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check whether there are changes that might affect the deployment
         id: changes
         run: |
-          changes=$(git diff --name-only origin/main..HEAD | grep -Ev '^(images|naughty|machine/machine_core|lib/testmap.py)/' || true)
+          changes=$(git diff --name-only origin/main..HEAD | grep -Ev '^(images/|naughty/|machine/machine_core/|lib/testmap.py)' || true)
           # print for debugging
           echo "changes:"
           echo "$changes"


### PR DESCRIPTION
Commit e3c5f32bef tried to fix this but we still were running tests on
testmap changes. The issue is that there was trailing `/` for each of
the locations, but testmap.py is not a directory.