### PR TITLE
images: Specify address for freeipa container and enable pcp plugin

### DIFF
--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -180,15 +180,23 @@ chmod 755 /root/run-candlepin
 # grafana setup
 #
 #############################
+# HACK: Due to unsigned grafana-pcp plugin we have to use development mode
+# See https://github.com/performancecopilot/grafana-pcp/issues/94
+cat <<EOF > /root/grafana.ini
+app_mode = development
+EOF
+chmod 644 /root/grafana.ini
 
 # determine latest release of PCP plugin
 url_base=https://github.com/performancecopilot/grafana-pcp/releases
 latest_ver=$(basename $(curl -Ls -o /dev/null -w '%{url_effective}' ${url_base}/latest))
 
 podman run -d --rm --name grafana -p 3000:3000 \
+    -v /root/grafana.ini:/opt/bitnami/grafana/conf/grafana.ini:z \
     -v grafana-data-plugins:/opt/bitnami/grafana/data/plugins \
     -e GF_SECURITY_ADMIN_PASSWORD=foobar \
     -e GF_INSTALL_PLUGINS="redis-datasource,performancecopilot-pcp-app=https://github.com/performancecopilot/grafana-pcp/releases/download/${latest_ver}/performancecopilot-pcp-app-${latest_ver#v}.zip" \
+    -e GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS="performancecopilot-pcp-app,redis-datasource" \
     quay.io/bitnami/grafana
 
 # wait until set up completed
@@ -198,8 +206,10 @@ podman stop grafana
 cat <<EOF > /root/run-grafana
 #!/bin/sh
 podman run -d --rm --name grafana -p 3000:3000 \
+    -v /root/grafana.ini:/opt/bitnami/grafana/conf/grafana.ini:z \
     -v grafana-data-plugins:/opt/bitnami/grafana/data/plugins \
     -e GF_SECURITY_ADMIN_PASSWORD=foobar \
+    -e GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS="performancecopilot-pcp-app,redis-datasource" \
     quay.io/bitnami/grafana
 EOF
 chmod 755 /root/run-grafana

--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -26,7 +26,7 @@ mkdir /var/lib/ipa-data
 cat <<EOF > /root/run-freeipa
 podman run -d --rm --name freeipa -ti -h f0.cockpit.lan \
     -e IPA_SERVER_IP=$SERVER_IP \
-    -p 53:53/udp -p 53:53 -p 80:80 -p 443:443 -p 389:389 -p 636:636 -p 88:88 -p 464:464 -p 88:88/udp -p 464:464/udp -p 123:123/udp \
+    -p $SERVER_IP:53:53/udp -p $SERVER_IP:53:53 -p 80:80 -p 443:443 -p 389:389 -p 636:636 -p 88:88 -p 464:464 -p 88:88/udp -p 464:464/udp -p 123:123/udp \
     -v /var/lib/ipa-data:/data:Z \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
     quay.io/freeipa/freeipa-server:centos-8-stream \
@@ -84,8 +84,8 @@ podman run -d -it --rm --name samba \
     -e "DOMAINPASS=foobarFoo123" \
     -e "DNSFORWARDER=172.27.0.3" \
     -e "HOSTIP=$SERVER_IP" \
-    -p 53:53 \
-    -p 53:53/udp \
+    -p $SERVER_IP:53:53 \
+    -p $SERVER_IP:53:53/udp \
     -p 88:88 \
     -p 88:88/udp \
     -p 135:135 \

--- a/images/services
+++ b/images/services
@@ -1,1 +1,1 @@
-services-c317297cfabe53fd35328d6c9d53aa00e51b99fb696f4950e5f7e320db66fcc6.qcow2
+services-dcacbbf6ac4a192991e6f4d24d95832235a0eaa4bbe67ba313f4a9be74f19b74.qcow2


### PR DESCRIPTION
Port 53 is takes by systemd-resolve on adress 127.0.0.53. From `man podman run`:
```
If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
```
which then failed with:
```
Error: cannot listen on the UDP port: listen udp4 :53: bind: address already in use
```

 * [x] image-refresh services