### PR TITLE
naughty: Close 2259: API: libpod/containers/<id>/stats for unprivileged mode unexpectedly succeeds and has wrong CPU and network numbers

### DIFF
--- a/naughty/rhel-8/2259-podman-invalid-user-stats
+++ b/naughty/rhel-8/2259-podman-invalid-user-stats
@@ -1,6 +1,0 @@
-  File "test/check-application", line *, in testLifecycleOperationsUser
-    self._testLifecycleOperations(False)
-  File "test/check-application", line *, in _testLifecycleOperations
-    self.assertEqual(cpu, "n/a")
-*
-AssertionError: '0.00%' != 'n/a'

--- a/naughty/ubuntu-stable/2259-podman-invalid-user-stats
+++ b/naughty/ubuntu-stable/2259-podman-invalid-user-stats
@@ -1,6 +1,0 @@
-  File "test/check-application", line *, in testLifecycleOperationsUser
-    self._testLifecycleOperations(False)
-  File "test/check-application", line *, in _testLifecycleOperations
-    self.assertEqual(cpu, "n/a")
-*
-AssertionError: '0.00%' != 'n/a'


### PR DESCRIPTION
Known issue which has not occurred in 24 days

API: libpod/containers/<id>/stats for unprivileged mode unexpectedly succeeds and has wrong CPU and network numbers

Fixes #2259