### PR TITLE
fedora.install: make --quick quicker

### DIFF
--- a/images/scripts/lib/fedora.install
+++ b/images/scripts/lib/fedora.install
@@ -14,6 +14,7 @@ do_build=
 do_install=
 # we build RHEL 7.x in a CentOS mock, thus we can't parse os-release in the .spec
 mock_opts="--define='os_version_id $(. /etc/os-release; echo $VERSION_ID)'"
+quick=
 args=$(getopt -o "vqs:" -l "verbose,quick,skip:,build,install,rhel" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
@@ -23,6 +24,7 @@ while [ $# -gt 0 ]; do
 		;;
 	    -q|--quick)
                 mock_opts="$mock_opts --nocheck --define='selinux 0'"
+                quick=t
 		;;
             -s|--skip)
                 skip="$skip
@@ -101,21 +103,19 @@ fi
 
 if [ -n "$do_install" ]; then
     packages=$(find build-results -name "*.rpm" -not -name "*.src.rpm" | grep -vG "$skip")
-    rpm -U --force $packages
+    rpm -U --force ${quick:+--nodigest --nosignature} $packages
 
-    # check for files that are shipped by more than one RPM
-    DUPES=0
-    for f in $(rpm -ql $(rpm -qa '*cockpit*') | sort -u); do
-        [ -f "$f" ] || continue
-        # -debugsource overlap is legit
-        [ "${f#/usr/src/debug}" = "$f" ] || continue
-        pkgs=($(rpm -qf $f))
-        if [ ${#pkgs[@]} -ne 1 ]; then
-            echo "ERROR: $f is shipped by multiple packages: ${pkgs[@]}" >&2
-            ((DUPES=DUPESRC+1))
-        fi
-    done
-    [ "$DUPES" -eq 0 ] || exit "$DUPES"
+    if [ -z "${quick}" ]; then
+        # check for files that are shipped by more than one RPM
+        fail=
+        for f in $(find $(rpm -ql $(rpm -qa '*cockpit*') | sort | uniq -d) -maxdepth 0 -type f); do
+            # -debugsource overlap is legit
+            [ "${f#/usr/src/debug}" = "$f" ] || continue
+            echo "ERROR: $f is shipped by multiple packages: $(rpm -qf $f)" >&2
+            fail=1
+        done
+        [ -z "${fail}" ] || exit 1
+    fi
 
     if type firewall-cmd > /dev/null 2> /dev/null; then
         systemctl start firewalld


### PR DESCRIPTION
In case --quick is specified, give `--nodigest --nosignature` to the
`rpm` invocation (which speeds things up by almost a second) and skip
the "file installed by multiple packages" check.

Also, instead of implementing the duplicates and "is this a normal
file?" logic in a for loop in shell, use `uniq -d` and `find -type f`,
respectively.  This simplifies the test and makes it considerably faster
(as well as substantially less chatty).

I also entertained adding `nosync` to the image and setting it as an
LD_PRELOAD at the top of the script, but some quick experiments didn't
show it to make much of a difference, either way.