### PR TITLE
testlib: Stop testing rhel-8.5 by default

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -39,8 +39,6 @@ REPO_BRANCH_CONTEXT = {
             f'{TEST_OS_DEFAULT}/mobile',
             f'{TEST_OS_DEFAULT}/container-bastion',
             'fedora-coreos',
-            'rhel-8-5',
-            'rhel-8-5-distropkg',
             'rhel-8-6',
             'centos-8-stream',
             'rhel-9-0',
@@ -83,7 +81,6 @@ REPO_BRANCH_CONTEXT = {
     'cockpit-project/cockpit-podman': {
         'main': [
             'arch',
-            'rhel-8-5',
             'rhel-8-6',
             'rhel-9-0',
             'fedora-34',
@@ -107,7 +104,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-35',
             f'{TEST_OS_DEFAULT}/firefox',
             f'{TEST_OS_DEFAULT}/mobile',
-            'rhel-8-5',
             'rhel-8-6',
             'rhel-9-0',
             'centos-8-stream',
@@ -125,7 +121,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'rhel-8-5/osbuild-composer',
+            'rhel-8-6/osbuild-composer',
         ],
     },
     'osbuild/cockpit-composer': {
@@ -163,13 +159,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-5',
         ],
         '_manual': [
-            'rhel-8-4',
-            'rhel-8-5',
-            'rhel-8-6',
-            'rhel-9-0',
-            'fedora-34',
-            'fedora-35',
-            'fedora-35/rawhide',
         ],
     },
     'cockpit-project/cockpit-certificates': {
@@ -178,7 +167,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-35',
         ],
         '_manual': [
-            'rhel-8-5',
+            'rhel-8-6',
             'rhel-9-0',
             'centos-8-stream',
         ]


### PR DESCRIPTION
RHEL 8.5.1 has been released and 8.6 is closing in. I kept this context
in rhel-8-5 specific branches and for candlepin/subscription-manager as
they have different workflows. (There I also cleaned up _manual as all
of those context are defined in different branches)

Also introduced 8-6 variants for projects that had 8-5 only in _manual.