### PR TITLE
fedora.install: be less picky about make-srpms output

### DIFF
--- a/images/scripts/lib/fedora.install
+++ b/images/scripts/lib/fedora.install
@@ -72,8 +72,8 @@ if [ -n "$do_build" ]; then
     sed -i.bak '/self.builddep_command =/ s_self.command_"/bin/true"_' /usr/lib/python*/*-packages/mockbuild/package_manager.py
 
     rm -rf build-results
-    srpm=$(/var/lib/testvm/make-srpm "$tar")
-    LC_ALL=C.UTF-8 su builder -c "/usr/bin/mock --offline --no-clean --no-cleanup-after --resultdir build-results $mock_opts --rebuild $srpm"
+    srpm=($(/var/lib/testvm/make-srpm "$tar"))
+    LC_ALL=C.UTF-8 su builder -c "/usr/bin/mock --offline --no-clean --no-cleanup-after --resultdir build-results $mock_opts --rebuild ${srpm[*]}"
 
     cat <<EOF >/tmp/rpmlint
 #! /bin/bash


### PR DESCRIPTION
fedora.install calls make-srpm and takes its output and pastes it
directly (as a single string) into a shell script fragment which it then
evaluates with `sh -c`.  If the output happened to be newline-separated,
then each new line will run as a separate command.

Capture the output as what it's meant to be: as a list of filenames.
Store that in an array, and expand the array inside the shell fragment.