### PR TITLE
testmap: Run rhel-8-6-distropkg automatically

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -42,6 +42,7 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-5',
             'rhel-8-5-distropkg',
             'rhel-8-6',
+            'rhel-8-6-distropkg',
             'centos-8-stream',
             'rhel-9-0',
         ],

--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -235,7 +235,7 @@ class Machine(ssh_connection.SSHConnection):
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1979182
             allowed.append('audit.*denied.*{ getattr }.*comm="systemctl" name="/".*cockpit_ws_t.*')
 
-        if self.image in ['rhel-8-6', 'centos-8-stream']:
+        if self.image in ['rhel-8-6', 'rhel-8-6-distropkg', 'centos-8-stream']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2029873
             allowed.append('audit.*denied.*{ write }.*comm="rhsm-service" name="memfd:libffi".*')
             # same issue also fails later on with map/read/execute in permissive mode


### PR DESCRIPTION
Running tests in https://github.com/cockpit-project/cockpit/pull/16858