### PR TITLE
testmap: automatically start the anaconda webui tests

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -176,9 +176,9 @@ REPO_BRANCH_CONTEXT = {
     },
     'rhinstaller/anaconda': {
         'master': [
+            'fedora-35/rawhide',
         ],
         '_manual': [
-            'fedora-35/rawhide',
         ]
     },
 }


### PR DESCRIPTION
They are now stable enough.

:warning: !!! Please wait for https://github.com/rhinstaller/anaconda/pull/3790 to get merged and also I need to communicate it. Will undraft it later today !!!