### PR TITLE
naughty: Add pattern for recurring reportd crash

### DIFF
--- a/naughty/fedora-35/1784-reportd-crash-task_start
+++ b/naughty/fedora-35/1784-reportd-crash-task_start
@@ -1,0 +1,5 @@
+Stack trace of thread*
+#* reportd_task_start*
+*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process * (reportd) of user 0 dumped core.


### PR DESCRIPTION
We used to have this pattern, then we stopped seeing it but it seems it
is still happening.