### PR TITLE
test-failure-policy: Never skip test with failed pixel test as known …

### DIFF
--- a/test-failure-policy
+++ b/test-failure-policy
@@ -128,6 +128,10 @@ def check_known_issue(api, trace, image):
         return None
 
     trace = normalize_traceback(trace)
+
+    if "Differences in pixel test" in trace:
+        return None
+
     number = None
     for naughty in os.listdir(image_naughty):
         (prefix, unused, name) = naughty.partition("-")


### PR DESCRIPTION
…issue

This leads to situations when we ignore pixel test failures in tests that
fail with known issues.

Example: https://logs.cockpit-project.org/logs/pull-893-20220125-124748-273163c6-fedora-35/log.html
(notice how it has 'changed pixels' but the test is still green)

One issue that could happen is when known issue would actively break pixel test. In such case we would have to add some check into the test itself to fail before the pixel test.