### PR TITLE
Revert "naughty: Close 2703: "tuned-adm recommend" reports non-existing "atomic-guest""

### DIFF
--- a/naughty/rhel-9/2703-tuned-atomic-guest
+++ b/naughty/rhel-9/2703-tuned-atomic-guest
@@ -1,0 +1,5 @@
+  File "tests/test/verify/check-system-tuned", line *, in testBasic
+    b.wait_text('#tuned-status-button', recommended_profile)
+*
+testlib.Error: timeout
+wait_js_cond(ph_text_is("#tuned-status-button","atomic-guest")): timeout


### PR DESCRIPTION
This still happens in CentOS 9 Stream, like in http://artifacts.dev.testing-farm.io/c64adb27-6c06-41df-b790-b06c2e497c62/.