### PR TITLE
push-rewrite: stop trying to set no-test label

### DIFF
--- a/push-rewrite
+++ b/push-rewrite
@@ -45,15 +45,10 @@ def find_pr_with_sha(api, sha):
 def main():
     parser = argparse.ArgumentParser(description='Force push after a rewrite')
     parser.add_argument('--repo', help="The GitHub repository to work with", default=None)
-    parser.add_argument('remote', help='The remote to push to')
-    parser.add_argument('branch', nargs='?', help='The branch to push')
     opts = parser.parse_args()
 
-    if not opts.branch:
-        opts.branch = git("rev-parse", "--abbrev-ref", "HEAD")
-
-    local = git("rev-parse", opts.branch)
-    remote = git("rev-parse", opts.remote + "/" + opts.branch)
+    local = git('rev-parse', 'HEAD')
+    remote = git('rev-parse', 'HEAD@{push}')
 
     if local == remote:
         sys.exit('Nothing to push')
@@ -71,7 +66,7 @@ def main():
     if not tests_disabled:
         label(pull, {"labels": labels + ["no-test"]})
 
-    git("push", "--force-with-lease=" + opts.branch + ":" + remote, opts.remote, opts.branch + ":" + opts.branch)
+    git("push", "--force-with-lease")
 
     for n in range(100, 0, -1):
         try:

--- a/push-rewrite
+++ b/push-rewrite
@@ -17,7 +17,7 @@ import argparse
 import sys
 import time
 
-from task import github, label, labels_of_pull
+from task import github, labels_of_pull
 
 
 def execute(*args):
@@ -62,9 +62,10 @@ def main():
     pull = find_pr_with_sha(api, remote)
     labels = labels_of_pull(pull)
     tests_disabled = "no-test" in labels or "[no-test]" in pull["title"]
-    # add no-test label to prevent tests bring triggered
+    # needs no-test label to prevent tests bring triggered
+    # we cannot set the label for ourselves without `repo` permission
     if not tests_disabled:
-        label(pull, {"labels": labels + ["no-test"]})
+        sys.exit("Please set the 'no-test' label on the PR before trying this")
 
     git("push", "--force-with-lease")
 

--- a/push-rewrite
+++ b/push-rewrite
@@ -56,12 +56,10 @@ def main():
     remote = git("rev-parse", opts.remote + "/" + opts.branch)
 
     if local == remote:
-        sys.stderr.write("Nothing to push.\n")
-        return 0
+        sys.exit('Nothing to push')
 
     if git("diff", "--stat", local, remote) != "":
-        sys.stderr.write("You have local changes, aborting.\n")
-        return 1
+        sys.exit('You have local changes, aborting.')
 
     api = github.GitHub(repo=opts.repo)
     old_statuses = api.statuses(remote)
@@ -96,4 +94,4 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()


### PR DESCRIPTION
    push-rewrite checks to make sure that tests won't be automatically
    triggered before pushing the changes to the remote.  It does this by
    checking the title for "[no-test]" or seeing if the "no-test" label is
    set, and setting it if not.
    
    Unfortunately, the high level of access required to set labels on a PR
    (repo, or public_repo) is incompatible with our recent goals of scaling
    back the scopes we grant to our GitHub tokens.  Worse still: instead of
    a proper error message, we get a cryptic exception.
    
    Instead of attempting to change the label, let's just give a proper
    error message asking the user to set it for themselves.
