### PR TITLE
naughty: copy fedora-coreos iptables naughty to fedora-35

### DIFF
--- a/naughty/fedora-35/2787-selinux-ioctl-iptables-containers
+++ b/naughty/fedora-35/2787-selinux-ioctl-iptables-containers
@@ -1,0 +1,1 @@
+avc:  denied  { ioctl } for * comm="iptables" path="/var/lib/containers/storage/*" dev="overlay" * scontext=unconfined_u:system_r:iptables_t:* tcontext=system_u:object_r:container_file_t:s0:*


### PR DESCRIPTION
This can fail in any container scenario, and cockpit runs the
container-bastion on fedora-35.

See https://logs.cockpit-project.org/logs/pull-16871-20220127-104105-88bebe63-fedora-35-container-bastion/log.html