### PR TITLE
naughty: Add pattern for podman segv on restore

### DIFF
--- a/naughty/fedora-35/2862-podman-restore-segv
+++ b/naughty/fedora-35/2862-podman-restore-segv
@@ -1,0 +1,2 @@
+testCheckpointRestoreCGroupsV2
+*b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in 'Running')


### PR DESCRIPTION
As seen in http://artifacts.dev.testing-farm.io/abe0bdc3-7096-4ea9-81d2-607d956f5e47/ for example

There is not much to go with than just this test failing on this one line :man_shrugging: 