### PR TITLE
naughty: Bring #2840 into normal form and make the "Job" line more flexible

### DIFF
--- a/naughty/rhel-9/2840-kdump-no-memory
+++ b/naughty/rhel-9/2840-kdump-no-memory
@@ -1,4 +1,6 @@
-testBasic (__main__.TestKdump)
 Job for kdump.service failed because the control process exited with error code.
 *
-*b.wait_in_text("#app", "Service is running")
+Traceback (most recent call last):*
+  File "test/verify/check-kdump", line *, in testBasic
+*
+    b.wait_in_text("#app", "Service is running")


### PR DESCRIPTION
With recent cockpit PRs, the output slightly changes, and there are
extra lines between `testBasic` and `Job ..failed`. Catch the affected
test as part of the traceback, like we do in other naughties, and make
the spacing flexible.

----

I validated this locally against both the [old log](https://logs.cockpit-project.org/logs/pull-16884-20220128-095734-b87b01b4-rhel-9-0/log.html) as well as the [new one](https://logs.cockpit-project.org/logs/pull-16823-20220128-084727-487dcffa-rhel-9-0/log.html#47-2) in https://github.com/cockpit-project/cockpit/pull/16823