### PR TITLE
test-failure-policy: Never skip test with failed pixel tests

### DIFF
--- a/test-failure-policy
+++ b/test-failure-policy
@@ -129,7 +129,8 @@ def check_known_issue(api, trace, image):
 
     trace = normalize_traceback(trace)
 
-    if "Differences in pixel test" in trace:
+    pixel_patterns = ["Differences in pixel test", "New pixel test reference", "Unused reference image"]
+    if [pattern for pattern in pixel_patterns if pattern in trace]:
         return None
 
     number = None


### PR DESCRIPTION
Similar to https://github.com/cockpit-project/bots/commit/7052a2672
but also consider cases when new pixels were added or if some pixel test
is not used anymore.
    
This should help with maintenance that we don't break pixel tests while
test has naughty. Of course, if the test fails before any pixel test is
done we will need to adjust the pixel tests once the issue goes away.


Seen in https://logs.cockpit-project.org/logs/pull-896-20220128-144258-e3620ee6-fedora-35/log.html