### PR TITLE
testmap: Update triggered test for cockpit po refresh

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -319,5 +319,5 @@ def tests_for_image(image):
 
 def tests_for_po_refresh(project):
     if project == "cockpit-project/cockpit":
-        return [TEST_OS_DEFAULT]
+        return ["fedora-coreos"]
     return REPO_BRANCH_CONTEXT.get(project, {}).get(get_default_branch(project), [])


### PR DESCRIPTION
We recently changed our GitHub branch protection to set "fedora-coreos"
as required test.

---

I saw this in https://github.com/cockpit-project/cockpit/pull/16906 this morning, where fedora-35 was auto-triggered, but fcos was required/missing.