### PR TITLE
naughty: Close 2701: rhel-8-6:  org.redhat.RHSM1 sends EntitlementChanged notification too early

### DIFF
--- a/naughty/rhel-8/2701-rhsm-notifies-too-early
+++ b/naughty/rhel-8/2701-rhsm-notifies-too-early
@@ -1,2 +1,0 @@
-  File "check-packagekit", line *, in testNoUpdates
-    b.wait_visible("#status .pf-c-card__header button")

--- a/naughty/rhel-8/2701-rhsm-notifies-too-early-2
+++ b/naughty/rhel-8/2701-rhsm-notifies-too-early-2
@@ -1,2 +1,0 @@
-  File "check-packagekit", line *, in testAvailableUpdates
-    b.wait_not_present(".pf-c-empty-state")


### PR DESCRIPTION
Known issue which has not occurred in 21 days

rhel-8-6:  org.redhat.RHSM1 sends EntitlementChanged notification too early

Fixes #2701