### PR TITLE
image-customize: Add SRPM build/install with --build

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -96,8 +96,6 @@ class BuildAction(ActionBase):
         vm_source = os.path.join("/var/tmp", sourcename)
         machine_instance.upload([source], vm_source, relative_dir=".")
 
-        machine_instance.execute("rm -rf /var/tmp/build; mkdir -p /var/tmp/build")
-
         # this will fail if neither is available -- exception is clear enough, this is a developer tool
         out = machine_instance.execute("(which pbuilder || which mock || which pacman) 2>/dev/null")
         if 'pbuilder' in out:
@@ -115,6 +113,8 @@ class BuildAction(ActionBase):
         # build source packge
         machine.execute(f"""
             set -eu
+            rm -rf /var/tmp/build
+            mkdir -p /var/tmp/build
             tar -C /var/tmp/build -xf '{vm_source}'
             cd "$(ls -d /var/tmp/build/*)"
             # find and copy debian packaging directory
@@ -141,14 +141,13 @@ class BuildAction(ActionBase):
             mock_opts += ' --nocheck'
 
         # build source package
-        machine.execute(f'rpmbuild --define "_srcrpmdir /var/tmp/build" -ts "{vm_source}"')
+        machine.execute(f'''su builder -c 'rpmbuild --define "_topdir /var/tmp/build" -ts "{vm_source}"' ''')
 
         # build binary RPMs from srpm; disable all repositorys as mock insists on
         # calling `dnf builddep`, which insists on a cache; our test VMs don't have a cache,
         # as the mock is offline and pre-installed
-        machine.execute('chown -R builder:builder /var/tmp/build')
-        machine.execute("su builder -c 'cd /var/tmp/build; mock --no-clean --no-cleanup-after --disablerepo=* "
-                        f"--offline --resultdir . {mock_opts} --rebuild *.src.rpm'",
+        machine.execute("su builder -c 'mock --no-clean --no-cleanup-after --disablerepo=* "
+                        f"--offline --resultdir /var/tmp/build {mock_opts} --rebuild /var/tmp/build/SRPMS/*.src.rpm'",
                         timeout=1800)
 
         # install RPMs
@@ -158,8 +157,10 @@ class BuildAction(ActionBase):
     def build_arch(machine, vm_source):
         # unpack source tree's arch packaging directory (PKGBUILD refers to some files)
         # and set PKGBUILD variables
-        machine.execute(f"""
+        machine.write("/var/tmp/mkbuild.sh", f"""#!/bin/sh
             set -eu
+            rm -rf /var/tmp/build
+            mkdir -p /var/tmp/build
             tar -C /var/tmp/build -xf '{vm_source}'
             cd /var/tmp/build/
             unpackdir="$(ls)"
@@ -167,10 +168,10 @@ class BuildAction(ActionBase):
             cp "$archdir"/* .
             # tarball must be in same directory as PKGBUILD
             cp '{vm_source}' /var/tmp/build/
-            """)
+            """, perm="755")
+        machine.execute("su builder /var/tmp/mkbuild.sh")
 
         # build binaries
-        machine.execute("chown -R builder:builder /var/tmp/build")
         machine.execute("cd /var/tmp/build; su builder -c extra-x86_64-build", timeout=1800)
 
         # install packages

--- a/image-customize
+++ b/image-customize
@@ -87,12 +87,13 @@ class InstallAction(ActionBase):
 
 
 class BuildAction(ActionBase):
-    '''Build and install distribution package(s) from dist tarball'''
+    '''Build and install distribution package(s) from dist tarball or source RPM'''
 
     @staticmethod
     def execute(machine_instance, source):
         # upload the tarball or srpm
         sourcename = os.path.basename(source)
+
         vm_source = os.path.join("/var/tmp", sourcename)
         machine_instance.upload([source], vm_source, relative_dir=".")
 
@@ -140,14 +141,18 @@ class BuildAction(ActionBase):
         if opt_quick:
             mock_opts += ' --nocheck'
 
-        # build source package
-        machine.execute(f'''su builder -c 'rpmbuild --define "_topdir /var/tmp/build" -ts "{vm_source}"' ''')
+        # build source package, unless this is running against an srpm already
+        if vm_source.endswith(".src.rpm"):
+            srpm = vm_source
+        else:
+            machine.execute(f'''su builder -c 'rpmbuild --define "_topdir /var/tmp/build" -ts "{vm_source}"' ''')
+            srpm = "/var/tmp/build/SRPMS/*.src.rpm"
 
         # build binary RPMs from srpm; disable all repositorys as mock insists on
         # calling `dnf builddep`, which insists on a cache; our test VMs don't have a cache,
         # as the mock is offline and pre-installed
         machine.execute("su builder -c 'mock --no-clean --no-cleanup-after --disablerepo=* "
-                        f"--offline --resultdir /var/tmp/build {mock_opts} --rebuild /var/tmp/build/SRPMS/*.src.rpm'",
+                        f"--offline --resultdir /var/tmp/build {mock_opts} --rebuild {srpm}'",
                         timeout=1800)
 
         # install RPMs
@@ -218,8 +223,8 @@ def main():
     # actions (at least one must be given, executed in order)
     parser.add_argument('-i', '--install', action=InstallAction, metavar="PACKAGE", dest='actions', default=[],
                         help='Install package')
-    parser.add_argument('-b', '--build', action=BuildAction, metavar="DIST-TAR", dest='actions', default=[],
-                        help='Build and install distribution package(s) from dist tarball')
+    parser.add_argument('-b', '--build', action=BuildAction, metavar="TAR-OR-SRPM", dest='actions', default=[],
+                        help='Build and install distribution package(s) from dist tarball or source RPM')
     parser.add_argument('-r', '--run-command', action=RunCommandAction, dest='actions',
                         help='Run command inside virtual machine')
     parser.add_argument('-s', '--script', action=ScriptAction, dest='actions',

--- a/image-customize
+++ b/image-customize
@@ -18,7 +18,6 @@
 
 import argparse
 import os
-import re
 import sys
 import subprocess
 
@@ -95,11 +94,6 @@ class BuildAction(ActionBase):
         # upload the tarball or srpm
         sourcename = os.path.basename(source)
         vm_source = os.path.join("/var/tmp", sourcename)
-        # looks like cockpit-foo-123.10.gdbde381.tar.xz
-        m = re.fullmatch(r'.+-([^-]+)\.tar(\..*)?', sourcename)
-        if not m:
-            raise ValueError(f"cannot parse version number from {sourcename}")
-        version = m.group(1)
         machine_instance.upload([source], vm_source, relative_dir=".")
 
         machine_instance.execute("rm -rf /var/tmp/build; mkdir -p /var/tmp/build")
@@ -107,15 +101,15 @@ class BuildAction(ActionBase):
         # this will fail if neither is available -- exception is clear enough, this is a developer tool
         out = machine_instance.execute("(which pbuilder || which mock || which pacman) 2>/dev/null")
         if 'pbuilder' in out:
-            BuildAction.build_deb(machine_instance, vm_source, version)
+            BuildAction.build_deb(machine_instance, vm_source)
         elif 'mock' in out:
-            BuildAction.build_rpm(machine_instance, vm_source, version)
+            BuildAction.build_rpm(machine_instance, vm_source)
         elif 'pacman' in out:
-            BuildAction.build_arch(machine_instance, vm_source, version)
+            BuildAction.build_arch(machine_instance, vm_source)
         else:
             raise NotImplementedError(f"unknown build platform: {out}")
 
-    def build_deb(machine, vm_source, version):
+    def build_deb(machine, vm_source):
         build_opts = 'nocheck' if opt_quick else ''
 
         # build source packge
@@ -127,9 +121,9 @@ class BuildAction(ActionBase):
             cp -r "$(dirname $(find -path '*/debian/control'))" .
             # create orig.tar link for building dsc
             source=$(awk '/^Source: / {{ print $2 }}' debian/control)
-            ln -s '{vm_source}' ../${{source}}_{version}.orig.tar.xz
-            # fill in the version number
-            sed -i '1 s/([^)-]*/({version}/' debian/changelog
+            version=$(dpkg-parsechangelog -SVersion)
+            # cut off Debian revision
+            ln -s '{vm_source}' ../${{source}}_${{version%-*}}.orig.tar.xz
 
             DEB_BUILD_OPTIONS='{build_opts}' dpkg-buildpackage -S -us -uc -nc""")
 
@@ -139,7 +133,7 @@ class BuildAction(ActionBase):
         # install packages
         machine.execute("dpkg -i /var/tmp/build/*.deb")
 
-    def build_rpm(machine, vm_source, version):
+    def build_rpm(machine, vm_source):
         mock_opts = ''
         if opt_verbose:
             mock_opts += ' --verbose'
@@ -161,7 +155,7 @@ class BuildAction(ActionBase):
         machine.execute('packages=$(find /var/tmp/build -name "*.rpm" -not -name "*.src.rpm"); '
                         f'rpm -U --force --verbose {"--nodigest --nosignature" if opt_quick else ""} $packages')
 
-    def build_arch(machine, vm_source, version):
+    def build_arch(machine, vm_source):
         # unpack source tree's arch packaging directory (PKGBUILD refers to some files)
         # and set PKGBUILD variables
         machine.execute(f"""
@@ -171,7 +165,6 @@ class BuildAction(ActionBase):
             unpackdir="$(ls)"
             archdir=$(dirname $(find -path '*/arch/PKGBUILD'))
             cp "$archdir"/* .
-            sed -i 's/VERSION/{version}/; s/SOURCE/{os.path.basename(vm_source)}/' PKGBUILD
             # tarball must be in same directory as PKGBUILD
             cp '{vm_source}' /var/tmp/build/
             """)


### PR DESCRIPTION
This is necessary at least for testing Cockpit on RHEL 8, where it currently
needs to do some special hacks to produce two source rpms with half of the
binary packages. This cannot be represented with a tarball build.

It might also be generally useful for some general development.

----

Tested locally with building cockpit's srpm into rhel-9-0 image.