### PR TITLE
Revert "testmap: Move cockpit-composer/rhel-9-0 to manual"

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -129,6 +129,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-34',
             'fedora-34/firefox',
             'rhel-8-6',
+            'rhel-9-0'
         ],
         'rhel-8-5': [
             'rhel-8-5',
@@ -138,7 +139,6 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'fedora-35',
             'fedora-35/firefox',
-            'rhel-9-0',
         ],
     },
     'candlepin/subscription-manager': {


### PR DESCRIPTION
This reverts commit e2592e7fce002d7c4b63170f4f47aaec840e914e.

Cockpit-composer now passes rhel-9 tests.

See https://github.com/osbuild/cockpit-composer/pull/1394