### PR TITLE
testmap: Remove fedora-35/mobile scenario from c-machines

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -103,7 +103,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-34',
             'fedora-35',
             f'{TEST_OS_DEFAULT}/firefox',
-            f'{TEST_OS_DEFAULT}/mobile',
             'rhel-8-6',
             'rhel-9-0',
             'centos-8-stream',


### PR DESCRIPTION
The "mobile" scenario is no longer recognized by cockpit-machines and
a "fedora-35/mobile" test run is identical to a "fedora-35" run.