### PR TITLE
workflows: don't try cockpituous tests on non-origin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,10 @@ jobs:
               ':!lib/testmap.py' \
           >&2 || echo "::set-output name=changed::true"
 
+      - name: Ensure branch was proposed from origin
+        if: steps.changes.outputs.changed
+        run: test "${{ github.event.pull_request.head.repo.url }}" = "${{ github.event.pull_request.base.repo.url }}"
+
       - name: Clone cockpituous repository
         if: steps.changes.outputs.changed
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,12 @@ jobs:
       - name: Check whether there are changes that might affect the deployment
         id: changes
         run: |
-          changes=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD | grep -Ev '^(images/|naughty/|machine/machine_core/|lib/testmap.py)' || true)
-          # print for debugging
-          echo "changes:"
-          echo "$changes"
-          [ -z "$changes" ] || echo "::set-output name=changed::true"
+          git log --exit-code --stat HEAD --not origin/${{ github.event.pull_request.base.ref }} -- \
+              ':!images' \
+              ':!naughty' \
+              ':!machine/machine_core' \
+              ':!lib/testmap.py' \
+          >&2 || echo "::set-output name=changed::true"
 
       - name: Clone cockpituous repository
         if: steps.changes.outputs.changed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,14 @@ jobs:
           # need this to get origin/main for git diff
           fetch-depth: 0
 
-      - name: Rebase to current main
+      - name: Rebase to target branch
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git rebase origin/main
+          EMAIL='<>' git rebase origin/${{ github.event.pull_request.base.ref }}
 
       - name: Check whether there are changes that might affect the deployment
         id: changes
         run: |
-          changes=$(git diff --name-only origin/main..HEAD | grep -Ev '^(images/|naughty/|machine/machine_core/|lib/testmap.py)' || true)
+          changes=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD | grep -Ev '^(images/|naughty/|machine/machine_core/|lib/testmap.py)' || true)
           # print for debugging
           echo "changes:"
           echo "$changes"


### PR DESCRIPTION
These tests will fail to run unless the PR was proposed from a branch on the origin, so bomb out early with a meaningful error rather than trying to run them anyway.


plus two other nice changes

 - [x] #2904 for what the failure looks like.
 - [x] #2906 for a contrived test of what a successful PR from a fork looks like.