### PR TITLE
testmap: Current Fedora CoreOS is based on Fedora 35

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-ba42ca7cd69bb7754a3955637f4eb065cb3f3c3a21a4a5400316ca9f0ceb8bf1.qcow2
+fedora-coreos-4013b12e6b0b3b3dc051ed2ac07802e48a03f760ef2704810c71d2bef4012a4f.qcow2

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -183,7 +183,7 @@ REPO_BRANCH_CONTEXT = {
 # The OSTree variants can't build their own packages, so we build in
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
-    "fedora-coreos": "fedora-34",
+    "fedora-coreos": "fedora-35",
 }
 
 # only put auxiliary images here; triggers for primary OS images are computed from testmap


### PR DESCRIPTION
Adjust the build image accordingly.

 * [x] image-refresh fedora-coreos

 - Blocked on https://github.com/cockpit-project/cockpit/pull/16956