### PR TITLE
image-customize: Add --fresh option, some bug fixes

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -29,7 +29,7 @@ opt_quick = False
 opt_verbose = False
 
 
-def prepare_install_image(base_image, install_image, resize):
+def prepare_install_image(base_image, install_image, resize, fresh):
     '''Create the necessary layered image for the build/install'''
 
     if "/" not in base_image:
@@ -37,12 +37,20 @@ def prepare_install_image(base_image, install_image, resize):
     if "/" not in install_image:
         install_image = os.path.join(os.path.join(TEST_DIR, "images"), os.path.basename(install_image))
 
-    # In vm-customize we don't force recreate images
+    qcow2_image = f"{install_image}.qcow2"
+
+    # Remove existing overlay if --fresh was requested
+    if fresh:
+        for f in [install_image, qcow2_image]:
+            try:
+                os.unlink(f)
+            except FileNotFoundError:
+                pass
+
     if not os.path.exists(install_image):
         install_image_dir = os.path.dirname(install_image)
         os.makedirs(install_image_dir, exist_ok=True)
         base_image = os.path.realpath(base_image)
-        qcow2_image = "{0}.qcow2".format(install_image)
         subprocess.check_call(["qemu-img", "create", "-q", "-f", "qcow2",
                                "-o", "backing_file={0},backing_fmt=qcow2".format(base_image), qcow2_image])
         if os.path.lexists(install_image):
@@ -232,6 +240,8 @@ def main():
     # options
     parser.add_argument('--base-image',
                         help='Base image name, if "image" does not match a standard Cockpit VM image name')
+    parser.add_argument('--fresh', action='store_true',
+                        help="Start fresh from the base image; by default, multiple image-customize calls are additive")
     parser.add_argument('--resize', help="Resize the image. Size in bytes with using K, M, or G suffix.")
     parser.add_argument('-n', '--no-network', action='store_true', help='Do not connect the machine to the Internet')
     parser.add_argument('-v', '--verbose', action='store_true',
@@ -259,7 +269,7 @@ def main():
     machine = testvm.VirtMachine(maintain=True,
                                  verbose=args.verbose,
                                  networking=network.host(restrict=args.no_network),
-                                 image=prepare_install_image(args.base_image, args.image, args.resize))
+                                 image=prepare_install_image(args.base_image, args.image, args.resize, args.fresh))
     machine.start()
     machine.wait_boot()
     try:

--- a/image-customize
+++ b/image-customize
@@ -126,10 +126,11 @@ class BuildAction(ActionBase):
             # cut off Debian revision
             ln -s '{vm_source}' ../${{source}}_${{version%-*}}.orig.tar.xz
 
-            DEB_BUILD_OPTIONS='{build_opts}' dpkg-buildpackage -S -us -uc -nc""")
+            dpkg-buildpackage -S -us -uc -nc""")
 
         # build binary packages
-        machine.execute("cd /var/tmp/build; pbuilder build --buildresult . *.dsc", timeout=1800)
+        machine.execute(f"cd /var/tmp/build; DEB_BUILD_OPTIONS='{build_opts}' pbuilder build --buildresult . *.dsc",
+                        timeout=1800)
 
         # install packages
         machine.execute("dpkg -i /var/tmp/build/*.deb")

--- a/image-customize
+++ b/image-customize
@@ -196,17 +196,14 @@ class RunCommandAction(ActionBase):
 class ScriptAction(ActionBase):
     @staticmethod
     def execute(machine_instance, script):
-        if os.path.isfile(script):
-            uploadpath = "/var/tmp/" + os.path.basename(script)
-            machine_instance.upload([os.path.abspath(script)], uploadpath)
-            machine_instance.execute("chmod a+x %s" % uploadpath)
-            try:
-                machine_instance.execute(uploadpath, timeout=1800)
-            except subprocess.CalledProcessError as e:
-                sys.stderr.write("%s\n" % e)
-                sys.exit(e.returncode)
-        else:
-            sys.stderr.write("Bad path to script: %s\n" % script)
+        uploadpath = "/var/tmp/" + os.path.basename(script)
+        machine_instance.upload([os.path.abspath(script)], uploadpath)
+        machine_instance.execute("chmod a+x %s" % uploadpath)
+        try:
+            machine_instance.execute(uploadpath, timeout=1800)
+        except subprocess.CalledProcessError as e:
+            sys.stderr.write("%s\n" % e)
+            sys.exit(e.returncode)
 
 
 class UploadAction(ActionBase):


### PR DESCRIPTION
By default, multiple image-customize calls are additive. This is useful,
and API by now. But our various `make vm` rules explicitly remove the
overlays, and hardcoding/duplicating overlay names in projects is ugly.
Let's give this a proper option.

---

Once this lands, I'll send starter-kit, c-podman, c-machines PRs to make use of this, and also adjust https://github.com/cockpit-project/cockpit/pull/16935 accordingly. For now I tested this manually.