### PR TITLE
workflows: undo committer ID changes for rebase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: Rebase to target branch
         run: |
-          EMAIL='<>' git rebase origin/${{ github.event.pull_request.base.ref }}
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git rebase origin/${{ github.event.pull_request.base.ref }}
 
       - name: Check whether there are changes that might affect the deployment
         id: changes


### PR DESCRIPTION
This (partial) reverts commit a7ac56a027c8a86a900d7bd6dc0ce007983efee1.

The EMAIL='<>' tricks that work in webpack-jumpstart don't work here for
some reason.  That's presumably because we only ever call
`webpack-jumpstart --rebase` from the packit sandcastle, and there we
probably have a gecos field or something that is missing on the GitHub
runner.

Let's just put back what was there before: it was working just fine.