### PR TITLE
machine: add machine.curl()

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -356,3 +356,10 @@ class Machine(ssh_connection.SSHConnection):
         """ % (tls and "https" or "http", address, port)
         with timeout.Timeout(seconds=seconds, error_message="Timeout while waiting for cockpit to start"):
             self.execute(script=WAIT_COCKPIT_RUNNING)
+
+    def curl(self, *args, headers=None):
+        header_args = []
+        if headers is not None:
+            for key, value in headers.items():
+                header_args.extend(['--header', f'{key}: {value}'])
+        return self.execute(['curl', '--no-progress-meter'] + header_args + list(args))


### PR DESCRIPTION
An awful lot of our tests call `curl` on the VM and inspect the result.
Some variation of `-s -S` is common (~= `--no-progress-meter`) and
passing headers is also done from many locations.

Add a nice wrapper that executes `curl` on the VM with the correct
arguments, with support for passing headers as a dictionary.