### PR TITLE
store-tests: Only accept TAP messages on line starts

### DIFF
--- a/store-tests
+++ b/store-tests
@@ -39,8 +39,7 @@ from task import github
 # not ok 117 test/verify/check-metrics TestMetrics.testPcp
 # not ok 305 test/verify/check-networking-bond TestBonding.testActive [ND@1]
 # not ok 24 test/verify/check-foobar TestExample.testBasic [ND] # RETRY 2 (be robust against unstable tests)
-re_run = re.compile(r"(not )?ok \d+ (\S+) (\S+)")
-re_retry = re.compile(r"# RETRY .* \(([^)]+)\)")
+re_run = re.compile(r"(not )?ok \d+ (\S+) (\S+)[^#]*(?:# RETRY \d+ \(([^)]+))?")
 
 # duration appears in the line right above the ok/not okTAP result:
 # 1 TEST PASSED [26s on centosci-tasks-6w5w6]
@@ -219,16 +218,15 @@ def find_tests(fp):
         if "FAIL: Test completed, but found unexpected" in line and "raise" not in line:
             save_message = True
 
-        m = re_run.search(line)
-        if (m):
+        m = re_run.match(line)
+        if m:
             # sometimes line breaks are missing:
             # not ok 117 test/verify/check-metrics TestMetrics.testPcp
             testname = "{0} {1}".format(m.group(2), m.group(3)).rstrip("#")
             if "make-checkout-workdir" in testname:
                 testname = testname.split("make-checkout-workdir")[1]
-            r = re_retry.search(line)
-            t = re_duration.search(prev_msg)
-            yield (testname, bool(m.group(1)), last_msg or (r and r.group(1) or None), t and t.group(2) or 0)
+            t = re_duration.match(prev_msg)
+            yield (testname, bool(m.group(1)), last_msg or (m.group(4) or None), t and t.group(2) or 0)
 
             last_msg = ""
 

--- a/store-tests
+++ b/store-tests
@@ -54,11 +54,16 @@ def main():
     parser.add_argument("--db", default="test-results.db", help="Database name")
     parser.add_argument("--repo", help="Repository from which to process failures")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument("--test-parser", metavar="LOGFILE", help="Scan given log file for tests and print results; for testing the parser")
     parser.add_argument("revision", help="SHA for which failures should be stored")
     opts = parser.parse_args()
 
     if opts.verbose:
         logging.basicConfig(level=logging.DEBUG)
+
+    if opts.test_parser:
+        test_parser(opts.test_parser)
+        return 0
 
     ctx = ssl.create_default_context()
     ctx.load_verify_locations(cafile=CA_PEM)
@@ -228,6 +233,12 @@ def find_tests(fp):
             last_msg = ""
 
         prev_msg = line.strip()
+
+
+def test_parser(logfile):
+    with open(logfile, 'rb') as f:
+        for (testname, failed, retry_reason, seconds) in find_tests(f):
+            print(f"{'FAIL' if failed else 'PASS'} {testname} {('RETRY:' + retry_reason) if retry_reason else ''} time {seconds}s")
 
 
 if __name__ == '__main__':

--- a/store-tests
+++ b/store-tests
@@ -39,11 +39,11 @@ from task import github
 # not ok 117 test/verify/check-metrics TestMetrics.testPcp
 # not ok 305 test/verify/check-networking-bond TestBonding.testActive [ND@1]
 # not ok 24 test/verify/check-foobar TestExample.testBasic [ND] # RETRY 2 (be robust against unstable tests)
-
-# older logs look like this instead:
-# not ok 78 testNodeNavigation (check_openshift.TestOpenshift) # duration: 172s
 re_run = re.compile(r"(not )?ok \d+ (\S+) (\S+)")
 re_retry = re.compile(r"# RETRY .* \(([^)]+)\)")
+
+# duration appears in the line right above the ok/not okTAP result:
+# 1 TEST PASSED [26s on centosci-tasks-6w5w6]
 re_duration = re.compile(r"# \d TEST (FAILED|PASSED) \[(\d+)s")
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"


### PR DESCRIPTION
cockpit's `check-testlib` sometimes causes TAP-like messages to appear
as part of assertions:
```
Traceback (most recent call last):
  File "/work/bots/make-checkout-workdir/test/verify/check-testlib", line 133, in testRetry
    self.assertRegex(stdout, rb"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)\n")
  File "/usr/lib64/python3.10/unittest/case.py", line 1322, in assertRegex
    raise self.failureException(msg)
AssertionError: Regex didn't match: b'\\nnot ok 1 .*test\\/verify\\/check-example TestExample.testFail # RETRY 1 \\(be robust against unstable tests\\)\\n' not found in b'1..2\n# -- [...]
```

This led to our test database now having two 100% failure entries for
TestExample.testFail.

Don't consider these as top-level failures on their own. Tighten the
regular expression to only match at line starts, and parse the whole TAP
line as a single RE.