### PR TITLE
machine: work around old curl in machine.curl()

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -358,8 +358,8 @@ class Machine(ssh_connection.SSHConnection):
             self.execute(script=WAIT_COCKPIT_RUNNING)
 
     def curl(self, *args, headers=None):
-        header_args = []
+        cmd = ['curl', '--silent', '--show-error']
         if headers is not None:
             for key, value in headers.items():
-                header_args.extend(['--header', f'{key}: {value}'])
-        return self.execute(['curl', '--no-progress-meter'] + header_args + list(args))
+                cmd.extend(['--header', f'{key}: {value}'])
+        return self.execute(cmd + list(args))


### PR DESCRIPTION
--no-progress-meter isn't available from the version of curl on rhel-8-6
and centos-8-stream.  Detect those OSes and patch it out.

This patch is done in a way that it could either be straight-reverted,
or the relevant section simply deleted, when the time comes.