### PR TITLE
naughty: Add pattern for RHEL 8 ksmtuned SELinux violation

### DIFF
--- a/naughty/rhel-8/2919-selinux-ksmtuned
+++ b/naughty/rhel-8/2919-selinux-ksmtuned
@@ -1,0 +1,1 @@
+avc:  denied  { module_request } for .* comm="ksmtuned" .* scontext=system_u:system_r:ksmtuned_t:s0 tcontext=system_u:system_r:kernel_t:s0


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2052554
Known issue #2919

---

Seen [here](https://logs.cockpit-project.org/logs/pull-16942-20220209-123107-22d91db9-rhel-8-6/log.html#106)