### PR TITLE
naughty: Add very general pattern for pmlogger.service failure on debian-stable

### DIFF
--- a/naughty/debian-stable/2518-pmlogger-protocol-error
+++ b/naughty/debian-stable/2518-pmlogger-protocol-error
@@ -1,0 +1,2 @@
+*TestHistoryMetrics*
+  File "test/verify/check-metrics", line *


### PR DESCRIPTION
This bug is just impossible to work around [1][2], and it can make the
TestHistoryMetrics tests fail in lots of different ways, so precise
patterns are not possible.

Blanket-attribute all PCP failures on Debian 11 on this bug. This is
still a bit better than skipping the tests entirely, as at least someone
could actually fix the bug and then we'd learn about it.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2013937
Known issue #2518

[1] https://github.com/cockpit-project/cockpit/issues/16974
[2] https://github.com/cockpit-project/cockpit/pull/16979

----

I do realize that this is a last-resort kind of action. But I wasted hours and hours on a better solution already, I am running out of ideas. I updated and reopened https://github.com/cockpit-project/bots/issues/2518 and filed a Debian bug report.