### PR TITLE
images: Actually keep original cockpit/ws image on fedora-coreos

### DIFF
--- a/images/scripts/fedora-coreos.install
+++ b/images/scripts/fedora-coreos.install
@@ -15,12 +15,13 @@ podman run --name build-cockpit -i \
 rpm --freshen --verbose /run/build-results/cockpit-ws-*.rpm /run/build-results/cockpit-bridge-*.rpm
 cp /run/containers/ws/atomic-* /container/
 '
-podman commit build-cockpit cockpit/ws
+# caveat: Without specifying CMD, the image gets the "rpm --freshen" start command
+podman commit --change CMD=/container/atomic-run build-cockpit localhost/cockpit/ws
 podman rm -f build-cockpit
 
-# move original docker image away, to make sure that our tests use the updated one
-podman tag quay.io/cockpit/ws:latest quay.io/cockpit/ws:released
+# move original image away, to make sure that our tests use the updated one
+podman tag quay.io/cockpit/ws:latest quay.io/cockpit/original-ws:released
 podman rmi quay.io/cockpit/ws:latest
 
 # run cockpit/ws once to generate certificate; avoids slow down on every start
-podman container runlabel INSTALL cockpit/ws
+podman container runlabel INSTALL localhost/cockpit/ws


### PR DESCRIPTION
The `podman commit` command did not actually create a new local
cockpit/ws image, but overwrites the quay.io/cockpit/ws tag.  Add an
explicit `localhost/` prefix to work around that.

`podman run cockpit-ws` happily and silently ran the `:released` tag 
implicitly. Avoid falling into this trap by renaming the original
container harder.

With the new container image, one needs to specify an explicit `CMD`. It
defaults to the command used to start the container, instead of the 
command of the original image (argh, unintuitive). There is no way to
actually tell `podman commit` to use the command as given (it always
wraps it into a `sh -c` wrapper), but that's harmless enough for us to
not care.