### PR TITLE
testmap: Drop cockpit-podman fedora-35/rawhide scenario

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -85,7 +85,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-9-0',
             'fedora-34',
             'fedora-35',
-            'fedora-35/rawhide',
             'debian-testing',
             'ubuntu-stable',
         ],


### PR DESCRIPTION
Installing rawhide packages on Fedora 35 does not work any more due to
GPG key changes for Fedora 36. That scenario also got obsoleted by
running Fedora 36 and Rawhide tests in PackIt, so just drop it.