### PR TITLE
Teach image-upload to parse the sha also from an .iso file

### DIFF
--- a/image-upload
+++ b/image-upload
@@ -42,9 +42,9 @@ def upload(dest, source, public):
     if s3.is_key_present(url):
         headers = {s3.ACL: s3.PUBLIC} if public else {}
 
-        # slightly magic: image filenames always end with -{sha256}.qcow2
-        assert source.endswith('.qcow2')
-        hash_value = source[-70:-6]
+        # slightly magic: image filenames always end with -{sha256}.qcow2 or -{sha256}.iso
+        assert (source.endswith('.qcow2') or source.endswith('.iso'))
+        hash_value = source.rstrip(".qcow2").rstrip(".iso")[-64:]
 
         cmd += s3.sign_curl(url, method='PUT', headers=headers, checksum=hash_value)
 

--- a/images/fedora-rawhide-boot
+++ b/images/fedora-rawhide-boot
@@ -1,0 +1,1 @@
+fedora-rawhide-boot-0b2fd35c87c4fc7f38149bb2a7675e3dcddc8f9c9da7bb739f02d5650359814a.iso


### PR DESCRIPTION
Image refresh for fedora-rawhide-boot
 * [x] image-refresh fedora-rawhide-boot