### PR TITLE
naughty: Add pattern for udisks loop partition regression on Fedora 36

### DIFF
--- a/naughty/fedora-36/2955-udisks-loop-partition
+++ b/naughty/fedora-36/2955-udisks-loop-partition
@@ -1,0 +1,3 @@
+> warning: Error wiping newly created partition /dev/loop12p1: Failed to open the device '/dev/loop12p1'
+*
+  File "tests/test/verify/check-storage*


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2055708
Known issue #2955

---

See current [cockpit runs on Fedora 36](http://artifacts.dev.testing-farm.io/70105deb-af52-4f0e-8ea4-b94a5b193306/) (on Testing Farm). We don't have a fedora-36 bots image yet, but it will be affected the same way.

The pattern is fairly loose because it breaks both `TestStorageLvm2.testUnpartitionedSpace` and `TestStoragePartitions.testPartitions`.