### PR TITLE
tests-invoke: Don't break tests on socket errors during collision detection

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -19,6 +19,7 @@
 
 import argparse
 import os
+import socket
 import subprocess
 import sys
 import time
@@ -47,7 +48,7 @@ def main():
 
         try:
             pull = api.get("pulls/{0}".format(opts.pull_number))
-        except TimeoutError as e:
+        except (TimeoutError, socket.gaierror) as e:
             sys.stderr.write('Warning: collision detection failed, skipping: %s\n' % e)
             # GitHub API is sometimes flaky, don't break test just because it sometimes does not respond
             return None


### PR DESCRIPTION
Tests occasionally fail with

    socket.gaierror: [Errno -3] Temporary failure in name resolution

while running. This ruins the whole test, which is not worth the trouble
at all. Ignore that exception just as we already ignore timeouts.

---

Just seen in https://github.com/cockpit-project/cockpit/pull/17016 where it interrupted all tests due to that nework flake.