### PR TITLE
naughty: Fix pattern for #2955

### DIFF
--- a/naughty/fedora-36/2955-udisks-loop-partition
+++ b/naughty/fedora-36/2955-udisks-loop-partition
@@ -1,3 +1,3 @@
 > warning: Error wiping newly created partition /dev/loop12p1: Failed to open the device '/dev/loop12p1'
 *
-  File "tests/test/verify/check-storage*
+  File "*test/verify/check-storage*


### PR DESCRIPTION
The automatic file name expansion does not work for this abbreviated
path, plus there was an extra tests/ prefix which did not belong there.

--

Sorry for the botched initial version.. this time I actually tested it against [the log](http://artifacts.dev.testing-farm.io/a23ddab3-2af6-467c-ab80-b009e99cf8a4/)