### PR TITLE
workflows: Don't run deployment tests for VM handling scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,12 @@ jobs:
         run: |
           git log --exit-code --stat HEAD --not origin/${{ github.event.pull_request.base.ref }} -- \
               ':!images' \
+              ':!image-create' \
+              ':!image-customize' \
               ':!naughty' \
               ':!machine/machine_core' \
               ':!lib/testmap.py' \
+              ':!vm-run' \
           >&2 || echo "::set-output name=changed::true"
 
       - name: Ensure branch was proposed from origin


### PR DESCRIPTION
These scripts are not covered by the deployment test, as that can't run
VMs. This allows developers to send changes to these scripts from their
forks.