### PR TITLE
Revert "task: Move AMQP server to AWS fallback"

### DIFF
--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -43,10 +43,10 @@ BASELINE_PRIORITY = 5
 MAX_PRIORITY = 9
 # see https://github.com/cockpit-project/cockpituous/blob/main/tasks/cockpit-tasks-webhook.yaml
 DEFAULT_SECRETS_DIR = '/run/secrets/webhook'
-# main deployment on CentOS CI: broken networking: https://pagure.io/centos-infra/issue/674
-# DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
+# main deployment on CentOS CI
+DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
 # fallback deployment on AWS
-DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
+# DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
 
 arguments = {
     'rhel': {


### PR DESCRIPTION
CentOS CI is  back.

This reverts commit 3a9082f6d9dbfa6929fbd36007fc49f58edfd50f.