### PR TITLE
testmap: add Fedora-36 to normally triggered images

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -33,6 +33,7 @@ REPO_BRANCH_CONTEXT = {
             'ubuntu-2004',
             'ubuntu-stable',
             'fedora-35',
+            'fedora-36',
             f'{TEST_OS_DEFAULT}/devel',
             f'{TEST_OS_DEFAULT}/firefox',
             f'{TEST_OS_DEFAULT}/container-bastion',
@@ -48,7 +49,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
-            'fedora-36',
             'fedora-testing',
             'fedora-testing/dnf-copr',
             'rhel-8-6-distropkg',


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/17028 was merged.