### PR TITLE
testmap: Remove cockpit-composer rhel-8-5 branch.

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -124,10 +124,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-6',
             'rhel-9-0'
         ],
-        'rhel-8-5': [
-            'rhel-8-5',
-            'rhel-8-5/firefox',
-        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-35',


### PR DESCRIPTION
It fails on Firefox but the branch is unmaintained.