### PR TITLE
naughty: Fix pattern for #2919

### DIFF
--- a/naughty/rhel-8/2919-selinux-ksmtuned
+++ b/naughty/rhel-8/2919-selinux-ksmtuned
@@ -1,1 +1,1 @@
-avc:  denied  { module_request } for .* comm="ksmtuned" .* scontext=system_u:system_r:ksmtuned_t:s0 tcontext=system_u:system_r:kernel_t:s0
+avc:  denied  { module_request } for * comm="ksmtuned" * scontext=system_u:system_r:ksmtuned_t:s0 tcontext=system_u:system_r:kernel_t:s0


### PR DESCRIPTION
Write it a hundred times:
This is NOT a regular expression.
This is NOT a regular expression.
...

Fixes [this failure](https://logs.cockpit-project.org/logs/pull-17080-20220303-081612-4ef167f5-rhel-8-6/log.html#107). I tested this with `bots/test-failure-policy -o rhel-8-6 < /tmp/out`.