### PR TITLE
testmap: test sub-man 1.29.26 with `rhel-9-0`

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -152,6 +152,9 @@ REPO_BRANCH_CONTEXT = {
         'subscription-manager-1.28.21': [
             'rhel-8-5',
         ],
+        'subscription-manager-1.29.26': [
+            'rhel-9-0',
+        ],
         '_manual': [
         ],
     },


### PR DESCRIPTION
The `subscription-manager-1.29.26` branch of subscription-manager targets
RHEL 9.0, so test it with the `rhel-9-0` image only.