### PR TITLE
lib: Drop cockpit-machines testing on ubuntu-2004

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -95,7 +95,6 @@ REPO_BRANCH_CONTEXT = {
             'arch',
             'debian-stable',
             'debian-testing',
-            'ubuntu-2004',
             'ubuntu-stable',
             'fedora-35',
             f'{TEST_OS_DEFAULT}/firefox',


### PR DESCRIPTION
We want to make c-machines more robust and simpler in
https://github.com/cockpit-project/cockpit-machines/pull/583
But this requires a newer virt-install. So let's stop backporting
c-machines to Ubuntu 20.04, so that we can move forward.