### PR TITLE
naughty: Adjust #2412 pattern for m.reboot()

### DIFF
--- a/naughty/fedora-34/2412-unlocking-stratis-during-boot
+++ b/naughty/fedora-34/2412-unlocking-stratis-during-boot
@@ -1,4 +1,4 @@
   File "check-storage-stratis", line *, in testEncrypted
-    m.wait_reboot()
+    m.*reboot()
 *
 machine_core.exceptions.Failure: Timeout waiting for system to reboot properly

--- a/naughty/fedora-35/2412-unlocking-stratis-during-boot
+++ b/naughty/fedora-35/2412-unlocking-stratis-during-boot
@@ -1,4 +1,4 @@
   File "check-storage-stratis", line *, in testEncrypted
-    m.wait_reboot()
+    m.*reboot()
 *
 machine_core.exceptions.Failure: Timeout waiting for system to reboot properly

--- a/naughty/rhel-8/2412-unlocking-stratis-during-boot
+++ b/naughty/rhel-8/2412-unlocking-stratis-during-boot
@@ -1,4 +1,4 @@
   File "check-storage-stratis", line *, in testEncrypted
-    m.wait_reboot()
+    m.*reboot()
 *
 machine_core.exceptions.Failure: Timeout waiting for system to reboot properly

--- a/naughty/rhel-9/2412-unlocking-stratis-during-boot
+++ b/naughty/rhel-9/2412-unlocking-stratis-during-boot
@@ -1,4 +1,4 @@
   File "check-storage-stratis", line *, in testEncrypted
-    m.wait_reboot()
+    m.*reboot()
 *
 machine_core.exceptions.Failure: Timeout waiting for system to reboot properly


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/17089 will change the
`m.wait_reboot()` into `m.reboot()`. Adjust the pattern to match on
both APIs.