### PR TITLE
images: add libappstream-glib-devel in RHEL 8

### DIFF
--- a/images/scripts/lib/build-deps.sh
+++ b/images/scripts/lib/build-deps.sh
@@ -37,4 +37,12 @@ case "$OS_VER" in
     *) EXTRA_DEPS="$EXTRA_DEPS nodejs" ;;
 esac
 
+# libappstream-glib-devel is needed for merging translations in AppStream XML files in starter-kit and derivatives
+# on RHEL 8 only: gettext in RHEL 8 does not know about .metainfo.xml files, and libappstream-glib-devel
+# provides /usr/share/gettext/its/appdata.{its,loc} for them
+case "$OS_VER" in
+    rhel*8|centos*8) EXTRA_DEPS="$EXTRA_DEPS libappstream-glib-devel" ;;
+    *) ;;
+esac
+
 echo "$EXTRA_DEPS"


### PR DESCRIPTION
Pull it so it is possible to use gettext to merge translations in
AppStream XML files named .metainfo.xml; gettext in RHEL 8 does not
know about them, and libappstream-glib-devel provides the extra metadata
for gettext to handle them.

This will be needed for cockpit-project/starter-kit#534.

 - [ ] image-refresh centos-8-stream
 - [ ] image-refresh rhel-8-6