### PR TITLE
DBG - insights-client selinux labels

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -212,6 +212,8 @@ fi
 # rpm.egg, never at newest.egg. So copying newest.egg to
 # last_stable.egg makes that work as expected, too.
 
+ls -lZ /var/lib/insights-client
+
 if [ -x /usr/bin/insights-client ]; then
     rpm -q insights-client
     insights-client --version
@@ -222,6 +224,8 @@ if [ -x /usr/bin/insights-client ]; then
         rm -f /etc/insights-client/rpm.egg /etc/insights-client/rpm.egg.asc
     fi
 fi
+
+ls -lZ /var/lib/insights-client
 
 # Pre-install cockpit packages from base, to check for API breakages
 # and more convenient interactive debugging


### PR DESCRIPTION
Something is wrong with the labels of /var/lib/insights-client et al when we create our images...

- [ ] image-refresh rhel-8-6
