### PR TITLE
testmap: test sub-man 1.28.29 with `rhel-8-6`

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -151,6 +151,9 @@ REPO_BRANCH_CONTEXT = {
         'subscription-manager-1.28.21': [
             'rhel-8-5',
         ],
+        'subscription-manager-1.28.29': [
+            'rhel-8-6',
+        ],
         'subscription-manager-1.29.26': [
             'rhel-9-0',
         ],


### PR DESCRIPTION
The subscription-manager-1.28.29 branch of subscription-manager targets
RHEL 8.6, so test it with the `rhel-8-6` image only.