### PR TITLE
naughty: Close 2703: "tuned-adm recommend" reports non-existing "atomic-guest"

### DIFF
--- a/naughty/rhel-9/2703-tuned-atomic-guest
+++ b/naughty/rhel-9/2703-tuned-atomic-guest
@@ -1,5 +1,0 @@
-  File "tests/test/verify/check-system-tuned", line *, in testBasic
-    b.wait_text('#tuned-status-button', recommended_profile)
-*
-testlib.Error: timeout
-wait_js_cond(ph_text_is("#tuned-status-button","atomic-guest")): timeout


### PR DESCRIPTION
Known issue which has not occurred in 23 days

"tuned-adm recommend" reports non-existing "atomic-guest"

Fixes #2703