### PR TITLE
naughty: Close 73: rhel-7-9, centos-7: SELinux: avc:  denied  { getattr } comm="iscsid"

### DIFF
--- a/naughty/rhel-7/73-selinux-getattr-iscsid
+++ b/naughty/rhel-7/73-selinux-getattr-iscsid
@@ -1,1 +1,0 @@
-* type=1400 * avc:  denied  { getattr } * comm="iscsid"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

rhel-7-9, centos-7: SELinux: avc:  denied  { getattr } comm="iscsid"

Fixes #73