### PR TITLE
naughty: Close 61: rhel-7-9, Centos-7: SELinux is preventing /usr/lib/systemd/systemd-machined from 'search' accesses

### DIFF
--- a/naughty/rhel-7/61-selinux-systemd-machine-search
+++ b/naughty/rhel-7/61-selinux-systemd-machine-search
@@ -1,1 +1,0 @@
-* type=1400 audit*: avc:  denied  { search } for  pid=* comm="systemd-machine" name="*" dev="proc" ino=* scontext=system_u:system_r:systemd_machined_t:* tcontext=system_u:system_r:svirt_tcg_t:*


### PR DESCRIPTION
Known issue which has not occurred in 21 days

rhel-7-9, Centos-7: SELinux is preventing /usr/lib/systemd/systemd-machined from 'search' accesses

Fixes #61