### PR TITLE
naughty: Close 2775: "virt-xml --remove-device --network" fails with QEMU 6.2 update

### DIFF
--- a/naughty/arch/2775-virtxml-remove-net
+++ b/naughty/arch/2775-virtxml-remove-net
@@ -1,5 +1,0 @@
-Traceback (most recent call last):*
-  File "test/check-machines-nics", line *, in testNICDelete
-    b.wait_not_present("#vm-subVmTest1-network-1-mac")
-*
-testlib.Error: timeout

--- a/naughty/debian-testing/2775-virtxml-remove-net
+++ b/naughty/debian-testing/2775-virtxml-remove-net
@@ -1,5 +1,0 @@
-Traceback (most recent call last):*
-  File "test/check-machines-nics", line *, in testNICDelete
-    b.wait_not_present("#vm-subVmTest1-network-1-mac")
-*
-testlib.Error: timeout

--- a/naughty/fedora-36/2775-virtxml-remove-net
+++ b/naughty/fedora-36/2775-virtxml-remove-net
@@ -1,5 +1,0 @@
-Traceback (most recent call last):*
-  File "test/check-machines-nics", line *, in testNICDelete
-    b.wait_not_present("#vm-subVmTest1-network-1-mac")
-*
-testlib.Error: timeout

--- a/naughty/rhel-8/2775-virtxml-remove-net
+++ b/naughty/rhel-8/2775-virtxml-remove-net
@@ -1,5 +1,0 @@
-Traceback (most recent call last):*
-  File "test/check-machines-nics", line *, in testNICDelete
-    b.wait_not_present("#vm-subVmTest1-network-1-mac")
-*
-testlib.Error: timeout

--- a/naughty/rhel-9/2775-virtxml-remove-net
+++ b/naughty/rhel-9/2775-virtxml-remove-net
@@ -1,5 +1,0 @@
-Traceback (most recent call last):*
-  File "test/check-machines-nics", line *, in testNICDelete
-    b.wait_not_present("#vm-subVmTest1-network-1-mac")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 21 days

"virt-xml --remove-device --network" fails with QEMU 6.2 update

Fixes #2775