### PR TITLE
naughty: Close 773: rhel-7-9: rhsmd fails with 'ImportError: No module named psutil'

### DIFF
--- a/naughty/rhel-7/773-rhsmd-import-error
+++ b/naughty/rhel-7/773-rhsmd-import-error
@@ -1,1 +1,0 @@
-wait_js_cond(ph_is_present("label:contains('Status') + button:contains('Register')"))*

--- a/naughty/rhel-7/773-rhsmd-import-error-1
+++ b/naughty/rhel-7/773-rhsmd-import-error-1
@@ -1,1 +1,0 @@
-wait_js_cond(ph_in_text("#system_information_updates_text","Not Registered"))*

--- a/naughty/rhel-7/773-rhsmd-import-error-2
+++ b/naughty/rhel-7/773-rhsmd-import-error-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-packagekit", line *, in testAvailableUpdates
-    b.wait_not_present(".container-fluid div.blank-slate-pf")
-*
-testlib.Error: timeout

--- a/naughty/rhel-7/773-rhsmd-import-error-3
+++ b/naughty/rhel-7/773-rhsmd-import-error-3
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-packagekit", line *, in testNoUpdates
-    b.wait_present(".content-header-extra button")
-*
-testlib.Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 22 days

rhel-7-9: rhsmd fails with 'ImportError: No module named psutil'

Fixes #773