### PR TITLE
naughty: Add alternative chage pattern for #2898

### DIFF
--- a/naughty/fedora-35/2898-selinux-chage-sss_cache
+++ b/naughty/fedora-35/2898-selinux-chage-sss_cache
@@ -1,0 +1,1 @@
+avc:  denied  { execute } for * comm="chage" name="sss_cache" * tcontext=system_u:object_r:sssd_exec_t:s0

--- a/naughty/fedora-36/2898-selinux-chage-sss_cache
+++ b/naughty/fedora-36/2898-selinux-chage-sss_cache
@@ -1,0 +1,1 @@
+avc:  denied  { execute } for * comm="chage" name="sss_cache" * tcontext=system_u:object_r:sssd_exec_t:s0


### PR DESCRIPTION
This does not only affect sss_cache running `chpasswd`, but `chage` as
well. See https://bugzilla.redhat.com/show_bug.cgi?id=2050952#c3

---

See [this failure](https://logs.cockpit-project.org/logs/pull-17135-20220315-133402-92539075-fedora-35-firefox/log.html#307-2), which was previously hidden by a bug in check-users. That gets fixed in https://github.com/cockpit-project/cockpit/pull/17135

I validated this with `bots/test-failure-policy -o fedora-35 < /tmp/out` against that log from above.