### PR TITLE
naughty: Add the chage variant of #2898 to fedora-coreos as well

### DIFF
--- a/naughty/fedora-coreos/2898-selinux-chage-sss_cache
+++ b/naughty/fedora-coreos/2898-selinux-chage-sss_cache
@@ -1,0 +1,1 @@
+avc:  denied  { execute } for * comm="chage" name="sss_cache" * tcontext=system_u:object_r:sssd_exec_t:s0


### PR DESCRIPTION
The old "chpasswd" variant is already present.

See [these failures](https://logs.cockpit-project.org/logs/pull-17135-20220316-064406-42627872-fedora-coreos/log.html#291-1) from https://github.com/cockpit-project/cockpit/pull/17135