### PR TITLE
log.html: port bootstrap to 5

### DIFF
--- a/task/log.html
+++ b/task/log.html
@@ -4,10 +4,9 @@
         <title>Cockpit Integration Tests</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js" type="text/javascript"></script>
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.2.1/mustache.min.js"></script>
         <!-- nicer arrows for the collapsible panels and preformatted text-->
         <style>
@@ -19,16 +18,24 @@
             margin: 10px;
         }
 
-        .card-header.failed {
+        body a {
+            text-decoration: none;
+        }
+
+        .accordion-button {
+            gap: 5px;
+        }
+
+        .accordion-button.failed {
             color: #A94442;
             background-color: #F2DEDE;
             border-color: #EBCCD1;
         }
-        .card-header.retried {
+        .accordion-button.retried {
             background-color: #f7bd7f;
             border-color: #b35c00;
         }
-        .card-header.skipped {
+        .accordion-button.skipped {
             color: #8A6D3B;
             background-color: #FCF8E3;
             border-color: #FAEBCC;
@@ -41,7 +48,7 @@
         }
         </style>
         <script id="Tests" type="text/template">
-            <div id="accordion">
+            <div id="accordion" class="accordion">
                 {{#tests}} {{{html}}} {{/tests}}
             </div>
         </script>
@@ -52,13 +59,16 @@
             </a>
         </script>
         <script id="TestEntry" type="text/template">
-            <div class="card" id="{{id}}">
-                <div class="card-header
-                            {{#collapsed}}collapsed{{/collapsed}}
-                            {{^passed}}failed{{/passed}}
-                            {{#retried}}retried{{/retried}}
-                            {{#skipped}}skipped{{/skipped}}" data-toggle="collapse" data-target="#collapse{{id}}"
-                            style="cursor: pointer">
+        <div class="accordion-item" id="{{id}}">
+             <h2 class="accordion-header
+                 style="cursor: pointer">
+                <button class="accordion-button collapsed
+                        {{#collapsed}}collapsed{{/collapsed}} {{^passed}}failed{{/passed}} {{#retried}}retried{{/retried}} {{#skipped}}skipped{{/skipped}}"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse{{id}}"
+                        aria-expanded="false"
+                        aria-controls="collapse{{id}}">
                     {{#failed}}
                         <span class="bi bi-exclamation-circle" aria-hidden="true"></span>
                     {{/failed}}
@@ -72,28 +82,28 @@
                     {{#links}}
                         {{{link_html}}}
                     {{/links}}
-                </div>
-                <div id="collapse{{id}}" class="collapse {{^collapsed}}show{{/collapsed}}" data-parent="#accordion">
-                    <pre class="card-body">{{text}}</pre>
-                </div>
-            </div>
+                 </button>
+             </h2>
+             <div id="collapse{{id}}" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#accordionExample">
+                  <div class="accordion-body">
+                  <pre>{{text}}</pre>
+                  </div>
+             </div>
+        </div>
         </script>
         <script id="TextOnly" type="text/template">
             <pre class="card-body">{{text}}</pre>
         </script>
         <script id="TestProgress" type="text/template">
             <div class="progress" style="width: 40%">
-                <div class="progress-bar bg-success" style="width: {{percentage_passed}}%">
+                <div class="progress-bar bg-success" role="progressbar" style="width: {{percentage_passed}}%">
                     {{num_passed}}
-                    <span class="sr-only">{{percentage_passed}}% Passed</span>
                 </div>
-                <div class="progress-bar bg-warning" style="width: {{percentage_skipped}}%">
+                <div class="progress-bar bg-warning" role="progressbar" style="width: {{percentage_skipped}}%">
                     {{num_skipped}}
-                    <span class="sr-only">{{percentage_skipped}}% Skipped</span>
                 </div>
-                <div class="progress-bar bg-danger" style="width: {{percentage_failed}}%">
+                <div class="progress-bar bg-danger" role="progressbar" style="width: {{percentage_failed}}%">
                     {{num_failed}}
-                    <span class="sr-only">{{percentage_failed}}% Failed</span>
                 </div>
             </div>
         </script>


### PR DESCRIPTION
Bootstrap 5 drops jQuery and introduces a new Accordion element to
replace the card accordion.

This looks visually a bit different:

![image](https://user-images.githubusercontent.com/67428/158638814-1048fcfc-957e-489c-86d0-d0feb866bb65.png)
