### PR TITLE
testmap: add my test of cockpit split from sub-man

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -178,6 +178,18 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
         ]
     },
+    'ptoscano/subscription-manager-cockpit': {
+        'main': [
+        ],
+        '_manual': [
+            'rhel-8-5',
+            'rhel-8-6',
+            'rhel-8-6/subscription-manager-1.28.29',
+            'rhel-9-0',
+            'rhel-9-0/subscription-manager-1.29.26',
+            'fedora-36',
+        ],
+    },
 }
 
 # The OSTree variants can't build their own packages, so we build in


### PR DESCRIPTION
Add my local repository with the test of the split of the cockpit plugin
of subscription-manager out of subscription-manager.git; this way I can
test the cockpit CI on that testing repository before the official
split.