### PR TITLE
images: debian: pull podman test images for c-podman

### DIFF
--- a/images/debian-stable
+++ b/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-beefa459657a9fa0c62fb373766d87e1ef2b4a50c477e5c20fe507b0cb9bb9c3.qcow2
+debian-stable-295db33bf6c69be398d7effb06b1132e945fe119f3507eae3ae336a370c21475.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -251,3 +251,6 @@ ln -snf /bin/true /etc/network/if-up.d/openssh-server
 # Stop showing 'To run a command as administrator (user "root"), use "sudo <command>". See "man
 # sudo_root" for details.` message in admins terminal.
 touch /home/admin/.sudo_as_admin_successful
+
+# Pull podman containers
+/var/lib/testvm/podman-images.setup

--- a/images/scripts/fedora.setup
+++ b/images/scripts/fedora.setup
@@ -158,7 +158,11 @@ su builder -c "/usr/bin/mock --install /tmp/selinux-policy-rpms/*.rpm"
 # host system gets the versions with fedora-updates enabled
 dnf install -y $selinux_pkgs
 
-/var/lib/testvm/podman-images.setup "$version"
+# for containers.install and cockpit's container/* tests
+podman build --tag cockpit/base --build-arg VERSION=$version /var/tmp/cockpit-base
+
+# for c-podman tests
+/var/lib/testvm/podman-images.setup
 
 ln -sf ../selinux/config /etc/sysconfig/selinux
 printf "SELINUX=enforcing\nSELINUXTYPE=targeted\n" > /etc/selinux/config

--- a/images/scripts/lib/podman-images.setup
+++ b/images/scripts/lib/podman-images.setup
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -eux
 
-# Fedora version
-version="$1"
-
-# for containers.install and cockpit's container/* tests
-podman build --tag cockpit/base --build-arg VERSION=$version /var/tmp/cockpit-base
-
 if [ $(uname -m) = x86_64 ]; then
     # images for testing cockpit-podman
     podman pull quay.io/libpod/busybox


### PR DESCRIPTION
For debian/ubuntu distros pull the podman test images for cockpit-podman
so the tests can run offline. Split out the specific Fedora testing
container into fedora.setup.

 * [x] image-refresh debian-stable