### PR TITLE
images: add the CRB repository for RHEL

### DIFF
--- a/image-create
+++ b/image-create
@@ -93,6 +93,7 @@ class MachineBuilder:
                 "EXTRAS_REPO_URL": os.environ.get("EXTRAS_REPO_URL", ""),
                 "BASEOS_REPO_URL": os.environ.get("BASEOS_REPO_URL", ""),
                 "APPSTREAM_REPO_URL": os.environ.get("APPSTREAM_REPO_URL", ""),
+                "CRB_REPO_URL": os.environ.get("CRB_REPO_URL", ""),
             }
             self.machine.message("run setup script on guest")
 

--- a/image-create-rhel-compose
+++ b/image-create-rhel-compose
@@ -25,6 +25,7 @@ if [[ "$COMPOSE" =~ RHEL-7 ]]; then
 else
     export BASEOS_REPO_URL="http://download.devel.redhat.com/rhel-8/rel-eng/RHEL-8/$COMPOSE/compose/BaseOS/x86_64/os"
     export APPSTREAM_REPO_URL="http://download.devel.redhat.com/rhel-8/rel-eng/RHEL-8/$COMPOSE/compose/AppStream/x86_64/os"
+    export CRB_REPO_URL="http://download.devel.redhat.com/rhel-8/rel-eng/RHEL-8/$COMPOSE/compose/CRB/x86_64/os"
     install_url=$BASEOS_REPO_URL
 fi
 

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -33,7 +33,7 @@ set -x
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     # Configure repositories.
 
-    if [ -n "$BASEOS_REPO_URL" -a -n "$APPSTREAM_REPO_URL" ]; then
+    if [ -n "$BASEOS_REPO_URL" -a -n "$APPSTREAM_REPO_URL" -a -n "$CRB_REPO_URL" ]; then
     # disable all default repos
     rm -f --verbose /etc/yum.repos.d/*.repo
 cat <<EOF > /etc/yum.repos.d/rel-eng.repo
@@ -46,6 +46,12 @@ gpgcheck=0
 [RHEL-AppStream]
 name=rhel-appstream
 baseurl=$APPSTREAM_REPO_URL
+enabled=1
+gpgcheck=0
+
+[RHEL-CRB]
+name=rhel-crb
+baseurl=$CRB_REPO_URL
 enabled=1
 gpgcheck=0
 EOF
@@ -71,6 +77,12 @@ baseurl=http://download.devel.redhat.com/$REPO/compose/AppStream/x86_64/os/
 enabled=1
 gpgcheck=0
 
+[RHEL-NIGHTLY-CRB]
+name=crb
+baseurl=http://download.devel.redhat.com/$REPO/compose/CRB/x86_64/os/
+enabled=1
+gpgcheck=0
+
 [RHEL-NIGHTLY-BaseOS-Debug]
 name=baseos-debug
 baseurl=http://download.devel.redhat.com/$REPO/compose/BaseOS/x86_64/debug/tree/
@@ -80,6 +92,12 @@ gpgcheck=0
 [RHEL-NIGHTLY-AppStream-Debug]
 name=appstream-debug
 baseurl=http://download.devel.redhat.com/$REPO/compose/AppStream/x86_64/debug/tree/
+enabled=0
+gpgcheck=0
+
+[RHEL-NIGHTLY-CRB-Debug]
+name=appstream-debug
+baseurl=http://download.devel.redhat.com/$REPO/compose/CRB/x86_64/debug/tree/
 enabled=0
 gpgcheck=0
 EOF


### PR DESCRIPTION
RHEL has a CodeReady Linux Builder (CRB in short) with packages shipped
to customers, usually needed to build other software, and not supported:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/package_manifest/codereadylinuxbuilder-repository

Since we may want to install packages from there to enable building more
bits on RHEL, then add it to the repositories of each RHEL 8+ image.