### PR TITLE
log.html: use `Math.ceil()` for total test time

### DIFF
--- a/task/log.html
+++ b/task/log.html
@@ -203,7 +203,7 @@ function extract(text) {
         total = last-first+1;
         const t = tap_total_time.exec(text);
         if (t) {
-            total_test_time = Math.floor(parseInt(t[2], 10) / 60);
+            total_test_time = Math.ceil(parseInt(t[2], 10) / 60);
         }
 
         passed = 0;


### PR DESCRIPTION
Use `Math.ceil()` to show the total time for a test: it makes sense to
round to the upper minute rather than the lower one, otherwise the
actual test time seems lower than the actual one.

Updates commit 35eeba1360af1ea125a84526cb6a57e3ec4a59d3