### PR TITLE
naughty: Close 2877: udev can't create /dev/stratis/poolname/fsname links any more: vc: denied { associate } for comm="systemd-udevd" name="stratis"

### DIFF
--- a/naughty/fedora-35/2877-selinux-stratis-devlinks
+++ b/naughty/fedora-35/2877-selinux-stratis-devlinks
@@ -1,3 +1,0 @@
-  File "test/verify/check-storage-stratis", line *, in test*
-*/dev/stratis/*
-subprocess.CalledProcessError

--- a/naughty/fedora-35/2877-selinux-stratis-devlinks-msg
+++ b/naughty/fedora-35/2877-selinux-stratis-devlinks-msg
@@ -1,1 +1,0 @@
-avc:  denied  { associate } for * comm="systemd-udevd" name="stratis"

--- a/naughty/rhel-8/2877-selinux-stratis-devlinks
+++ b/naughty/rhel-8/2877-selinux-stratis-devlinks
@@ -1,3 +1,0 @@
-  File "test/verify/check-storage-stratis", line *, in test*
-*/dev/stratis/*
-subprocess.CalledProcessError

--- a/naughty/rhel-8/2877-selinux-stratis-devlinks-msg
+++ b/naughty/rhel-8/2877-selinux-stratis-devlinks-msg
@@ -1,1 +1,0 @@
-avc:  denied  { associate } for * comm="systemd-udevd" name="stratis"


### PR DESCRIPTION
Known issue which has not occurred in 22 days

udev can't create /dev/stratis/poolname/fsname links any more: vc: denied { associate } for comm="systemd-udevd" name="stratis"

Fixes #2877