### PR TITLE
naughty: Close 2840: No memory reserved when crashkernel=auto

### DIFF
--- a/naughty/rhel-9/2840-kdump-no-memory
+++ b/naughty/rhel-9/2840-kdump-no-memory
@@ -1,6 +1,0 @@
-Job for kdump.service failed because the control process exited with error code.
-*
-Traceback (most recent call last):*
-  File "test/verify/check-kdump", line *, in testBasic
-*
-    b.wait_in_text("#app", "Service is running")


### PR DESCRIPTION
Known issue which has not occurred in 26 days

No memory reserved when crashkernel=auto

Fixes #2840