### PR TITLE
testmap: Drop obsolete manual contexts

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -54,10 +54,8 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'fedora-testing',
             'fedora-testing/dnf-copr',
-            'rhel-8-6-distropkg',
             'rhel-9-0-distropkg',
             'ubuntu-2204',
-            f'{TEST_OS_DEFAULT}/firefox-devel',
         ],
     },
     'cockpit-project/starter-kit': {
@@ -107,8 +105,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'fedora-testing',
-            'fedora-35/firefox',
-            'fedora-35/mobile',
             'ubuntu-2204',
         ],
     },


### PR DESCRIPTION
For cockpit, rhel-8-6-distropkg is already in the "main" tests, and
we never actually used the "firefox-devel" scenario.

For c-machines, the firefox scenario is already in "main". Current
TEST_OS_DEFAULT now also covers mobile pixel test, so there is no
separate "mobile" scenario any more.