### PR TITLE
WIP: 2-cockpit-7: [no-test] images: Only run podman in debian.setup when it is available

### DIFF
--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -248,5 +248,7 @@ ln -snf /bin/true /etc/network/if-up.d/openssh-server
 # sudo_root" for details.` message in admins terminal.
 touch /home/admin/.sudo_as_admin_successful
 
-# Pull podman containers
-/var/lib/testvm/podman-images.setup
+# Pull podman containers if we have podman
+if [ "$RELEASE" != "focal" ]; then
+  /var/lib/testvm/podman-images.setup
+fi


### PR DESCRIPTION
The ubuntu-2004 image doesn't have it.

 * [x] image-refresh ubuntu-2004
 * [x] image-refresh ubuntu-stable
 * [x] image-refresh ubuntu-2204
 - [ ] image-refresh debian-testing
 - [ ] image-refresh debian-stable