### PR TITLE
testmap: Enable ubuntu-2204 for cockpit-podman

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -83,11 +83,11 @@ REPO_BRANCH_CONTEXT = {
             'fedora-35',
             'fedora-36',
             'debian-testing',
+            'ubuntu-2204',
             'ubuntu-stable',
         ],
         '_manual': [
             'centos-8-stream',
-            'ubuntu-2204',
         ],
     },
     'cockpit-project/cockpit-machines': {


### PR DESCRIPTION
Tests were enabled in https://github.com/cockpit-project/cockpit-podman/pull/947