### PR TITLE
testmap: Enable ubuntu-2204 for cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -31,6 +31,7 @@ REPO_BRANCH_CONTEXT = {
             'debian-stable',
             'debian-testing',
             'ubuntu-2004',
+            'ubuntu-2204',
             'ubuntu-stable',
             'fedora-35',
             'fedora-36',
@@ -55,7 +56,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-testing',
             'fedora-testing/dnf-copr',
             'rhel-9-0-distropkg',
-            'ubuntu-2204',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
Tests were adjusted in https://github.com/cockpit-project/cockpit/pull/17182