### PR TITLE
tests-invoke: Ignore github errors in collision detection

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -36,6 +36,7 @@ from . import cache
 
 __all__ = (
     'GitHub',
+    'GitHubError',
     'Checklist',
     'TESTING',
     'NO_TESTING',

--- a/tests-invoke
+++ b/tests-invoke
@@ -48,7 +48,7 @@ def main():
 
         try:
             pull = api.get("pulls/{0}".format(opts.pull_number))
-        except (TimeoutError, socket.gaierror) as e:
+        except (TimeoutError, socket.gaierror, github.GitHubError) as e:
             sys.stderr.write('Warning: collision detection failed, skipping: %s\n' % e)
             # GitHub API is sometimes flaky, don't break test just because it sometimes does not respond
             return None


### PR DESCRIPTION
Every now and then github returns 500 and that kills all tests.

See for example here: https://logs.cockpit-project.org/logs/pull-17191-20220329-064120-19763bc5-fedora-35/log