### PR TITLE
testmap: Update subman services trigger

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -213,7 +213,7 @@ IMAGE_REFRESH_TRIGGERS = {
         "debian-stable@cockpit-project/cockpit",
         "rhel-9-0@cockpit-project/cockpit",
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",
-        "rhel-8-4@candlepin/subscription-manager",
+        "rhel-8-5@candlepin/subscription-manager",
     ]
 }
 


### PR DESCRIPTION
rhel-8-4 is only now triggered on non-main branch. Move to 8-5.