### PR TITLE
naughty: Add pattern for Fedora Rawhide targetcli regression

### DIFF
--- a/naughty/fedora-37/3163-targetcli-delete
+++ b/naughty/fedora-37/3163-targetcli-delete
@@ -1,0 +1,3 @@
+[Errno 20] Not a directory: '/sys/kernel/config/target/iscsi/cpus_allowed_list'
+*
+subprocess.CalledProcessError: Command 'targetcli /backstores/ramdisk delete test *' returned non-zero exit status 1.

--- a/naughty/fedora-37/3163-targetcli-delete-followup
+++ b/naughty/fedora-37/3163-targetcli-delete-followup
@@ -1,0 +1,5 @@
+Storage object ramdisk/test exists
+*
+subprocess.CalledProcessError: Command '
+* targetcli /backstores/ramdisk create test 50M
+*' returned non-zero exit status 1.


### PR DESCRIPTION
The first test will fail on `targetcli delete`. As that breaks the
cleanup, the next test that will try to set up an iSCSI device will fail
on creation as the previous device already exists. Add the "-followup"
pattern for that.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2069952
Known issue #3163

----

See [recent c-machines packit failure on rawhide](https://artifacts.dev.testing-farm.io/8ee1bdbc-fdcf-4b03-a4e7-41f9b223b5c3//work-alldJiNZH/log.txt). I tested the patterns against that log.