### PR TITLE
image-upload: Retry upload up to three times

### DIFF
--- a/image-upload
+++ b/image-upload
@@ -22,6 +22,7 @@ import getpass
 import os
 import subprocess
 import sys
+import time
 import urllib.parse
 
 from lib.constants import IMAGES_DIR
@@ -58,10 +59,17 @@ def upload(dest, source, public):
         return 1
 
     print("Uploading to", dest, file=sys.stderr)
-    try:
-        subprocess.check_call(cmd)
-        return 0
-    except subprocess.CalledProcessError:
+
+    # Retry with exponential back-off, to defend against short-term networking errors
+    for retry in range(3):
+        try:
+            subprocess.check_call(cmd)
+            return 0
+        except subprocess.CalledProcessError:
+            delay = 10 * 4 ** retry
+            sys.stderr.write(f"image-upload: retrying upload to {dest} in {delay}s..\n")
+            time.sleep(delay)
+    else:
         sys.stderr.write(f"image-upload: unable to upload image: {dest}\n")
         return 1
 

--- a/image-upload
+++ b/image-upload
@@ -36,7 +36,7 @@ def upload(dest, source, public):
     url = urllib.parse.urlparse(dest)
 
     # Start building the command
-    cmd = ["curl", "--progress-bar", "--fail", "--upload-file", source]
+    cmd = ["curl", "--no-progress-meter", "--fail", "--upload-file", source]
 
     # Pass credentials, if present
     if s3.is_key_present(url):
@@ -58,15 +58,12 @@ def upload(dest, source, public):
         return 1
 
     print("Uploading to", dest, file=sys.stderr)
-    curl = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    cat = subprocess.Popen(["cat"], stdin=curl.stdout)
-    curl.stdout.close()
-    ret = curl.wait()
-    cat.wait()
-    if ret != 0:
+    try:
+        subprocess.check_call(cmd)
+        return 0
+    except subprocess.CalledProcessError:
         sys.stderr.write(f"image-upload: unable to upload image: {dest}\n")
-
-    return ret
+        return 1
 
 
 def main():


### PR DESCRIPTION
We recently ran into a lot of image refreshes which failed to upload on
Linode 403 or other errors. These have all been transient.

It is a waste of human attention and bandwidth to restart the entire
image build and upload from the beginning, so retry the upload up to
three times with exponential back-off (10, 40, and 160 seconds).

----

See [this failure](https://logs.cockpit-project.org/logs/image-refresh-3150-20220327-025151/log) for a recent example.

I also added a commit to get rid of these pesky progress bars in [successful logs](https://logs.cockpit-project.org/logs/image-refresh-3159-20220330-054949/log).

Tested locally with:
```
❱❱ ./image-upload --store https://localhost cirros
Uploading to https://localhost/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2
curl: (7) Failed to connect to localhost port 443 after 0 ms: Connection refused
image-upload: retrying upload to https://localhost/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2 in 10s..
curl: (7) Failed to connect to localhost port 443 after 0 ms: Connection refused
image-upload: retrying upload to https://localhost/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2 in 40s..
curl: (7) Failed to connect to localhost port 443 after 0 ms: Connection refused
image-upload: retrying upload to https://localhost/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2 in 160s..
image-upload: unable to upload image: https://localhost/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2
```

 * [x] image-refresh cirros