### PR TITLE
naughty: Close 2626: Error importing insights.client for pre_update as /var/lib/insights/newest.egg: No module named 'insights'

### DIFF
--- a/naughty/rhel-8/2626-insights-client-import-error
+++ b/naughty/rhel-8/2626-insights-client-import-error
@@ -1,2 +1,0 @@
-testlib.Error: FAIL: Test completed, but found unexpected journal messages:
-Error importing insights.client for pre_update as /var/lib/insights/newest.egg: No module named 'insights'


### PR DESCRIPTION
Known issue which has not occurred in 22 days

Error importing insights.client for pre_update as /var/lib/insights/newest.egg: No module named 'insights'

Fixes #2626