### PR TITLE
testmap: Allow manual fedora-35/devel for cockpit-podman

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -88,6 +88,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'centos-8-stream',
+            'fedora-35/devel',
         ],
     },
     'cockpit-project/cockpit-machines': {


### PR DESCRIPTION
The "devel" scenario will do code coverage.
