### PR TITLE
testmap: add official subscription-manager-cockpit repo

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -187,18 +187,6 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
         ]
     },
-    'ptoscano/subscription-manager-cockpit': {
-        'main': [
-        ],
-        '_manual': [
-            'rhel-8-5',
-            'rhel-8-6',
-            'rhel-8-6/subscription-manager-1.28.29',
-            'rhel-9-0',
-            'rhel-9-0/subscription-manager-1.29.26',
-            'fedora-36',
-        ],
-    },
 }
 
 # The OSTree variants can't build their own packages, so we build in

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -157,6 +157,18 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
         ],
     },
+    'candlepin/subscription-manager-cockpit': {
+        'main': [
+            'rhel-8-6/subscription-manager-1.28',
+            'rhel-9-0',
+            'fedora-35',
+            'fedora-36',
+        ],
+        '_manual': [
+            'centos-8-stream/subscription-manager-1.28',
+            'centos-9-stream',
+        ],
+    },
     'cockpit-project/cockpit-certificates': {
         'master': [
             'fedora-35',


### PR DESCRIPTION
The cockpit plugin of subscription-manager was split in its own repository, so add it with some contexts (for `main` and `_manual`) of combinations of distros & subscription-manager branch we want to test.

Also remove my own repository that was used to test the split.