### PR TITLE
npm-update: Pull prerelease versions on PF

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -59,6 +59,8 @@ def write_package_json(package_json_path, data):
 def prefix(name, version):
     if not version[0].isdigit():
         return version
+    if name.startswith("@patternfly"):
+        return "prerelease"
     if name not in FRAGILE:
         return "^" + version
     return "~" + version


### PR DESCRIPTION
I ran this in cockpit and it produced:
```diff
--- package.json
+++ package.json
@@ -3,11 +3,11 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "dependencies": {
-    "@patternfly/patternfly": "4.159.1",
-    "@patternfly/react-core": "4.175.4",
-    "@patternfly/react-icons": "4.26.4",
-    "@patternfly/react-styles": "4.25.4",
-    "@patternfly/react-table": "4.44.4",
+    "@patternfly/patternfly": "4.185.1",
+    "@patternfly/react-core": "4.202.14",
+    "@patternfly/react-icons": "4.53.14",
+    "@patternfly/react-styles": "4.52.14",
+    "@patternfly/react-table": "4.71.14",
```