### PR TITLE
naughty: Relax #3066 pattern, drop it for Fedora 36/37

### DIFF
--- a/naughty/arch/3066-virt-install-iso-curl
+++ b/naughty/arch/3066-virt-install-iso-curl
@@ -4,4 +4,4 @@ Traceback (most recent call last):
   File "*test/check-machines-create", line *, in testCreateUrlSource
     runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
 *
-testlib.Error: Condition did not become true.
+testlib.Error*

--- a/naughty/fedora-36/3066-virt-install-iso-curl
+++ b/naughty/fedora-36/3066-virt-install-iso-curl
@@ -1,7 +1,0 @@
-*internal error: *CURL: Error opening file:*--cdrom*https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso*
-*
-Traceback (most recent call last):
-  File "*test/check-machines-create", line *, in testCreateUrlSource
-    runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
-*
-testlib.Error: Condition did not become true.

--- a/naughty/fedora-37/3066-virt-install-iso-curl
+++ b/naughty/fedora-37/3066-virt-install-iso-curl
@@ -1,7 +1,0 @@
-*internal error: *CURL: Error opening file:*--cdrom*https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso*
-*
-Traceback (most recent call last):
-  File "*test/check-machines-create", line *, in testCreateUrlSource
-    runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
-*
-testlib.Error: Condition did not become true.


### PR DESCRIPTION
curl is fixed in Fedora, but still broken on our Arch image. We are
going to slightly change the test in [1] so that it fails with
"testlib.Error: timeout" instead of "Condition did not become true", so
relax the pattern to accept either.

[1] https://github.com/cockpit-project/cockpit-machines/pull/583

----

arch run against this PR is in https://github.com/cockpit-project/cockpit-machines/pull/583 