### PR TITLE
image-upload: Fix "magic" checksum extraction

### DIFF
--- a/image-upload
+++ b/image-upload
@@ -20,6 +20,7 @@
 import argparse
 import getpass
 import os
+import re
 import subprocess
 import sys
 import time
@@ -43,9 +44,8 @@ def upload(dest, source, public):
     if s3.is_key_present(url):
         headers = {s3.ACL: s3.PUBLIC} if public else {}
 
-        # slightly magic: image filenames always end with -{sha256}.qcow2 or -{sha256}.iso
-        assert (source.endswith('.qcow2') or source.endswith('.iso'))
-        hash_value = source.rstrip(".qcow2").rstrip(".iso")[-64:]
+        # slightly magic: we already know the checksum: it's part of the filename
+        hash_value = re.search('[0-9a-f]{64}', source).group(0)
 
         cmd += s3.sign_curl(url, method='PUT', headers=headers, checksum=hash_value)
 


### PR DESCRIPTION
Since 477b771c03299502b7538a702d1d4b1a65f9a6c9 we've been having
semi-random failures to upload images to Linode.  That's been caused by
the logic in this line, introduced in that commit:

    hash_value = source.rstrip(".qcow2").rstrip(".iso")[-64:]

This doesn't do what it appears to.  `.rstrip()` takes a set of
characters to strip, so this will certainly remove ".qcow2" and ".iso",
but will also remove any mentioned single characters that it finds at
the end of the checksum, like `2` or `c`.

That's led to taking the wrong checksum from our images 1/8 of the
time, leading them to be rejected by Linode due to a calculated
signature (based on the incorrectly extracted value) which doesn't match
the actual file contents.

Let's replace this with a simple regexp to do what we want.


I've tested this on `cockpit-7` by uploading the `openshift-c618c4bec7d0322c0dc78a7d922b396cd72978f911b7b3567b1ef5a15db33662` image successfully.  Interestingly (but not coincidentally) this is the only image that contains a `c` or `2` in the last position of the checksum: we've refreshed the others since then, and failed to upload any `c`s or `2`s, requiring retries until we got a working checksum.