### PR TITLE
naughty: Close 2998: selinux: systemd-sysctl was denied reading suid_dumpable, protected_hardlinks, and protected_symlinks

### DIFF
--- a/naughty/rhel-9/2998-selinux-systemd-sysctl
+++ b/naughty/rhel-9/2998-selinux-systemd-sysctl
@@ -1,1 +1,0 @@
-audit: type=1400 audit(*): avc:  denied  { read } for  pid=* comm="systemd-sysctl" name="*" dev="proc" * scontext=system_u:system_r:systemd_sysctl_t:s0 tcontext=system_u:object_r:proc_security_t:s0 tclass=file permissive=0


### PR DESCRIPTION
Known issue which has not occurred in 21 days

selinux: systemd-sysctl was denied reading suid_dumpable, protected_hardlinks, and protected_symlinks

Fixes #2998