### PR TITLE
naughty: Close 2997: SELinux is preventing systemd-coredum from 'sys_admin' accesses to coredumps on rhel-9-0

### DIFF
--- a/naughty/rhel-9/2997-selinux-systemd-coredum
+++ b/naughty/rhel-9/2997-selinux-systemd-coredum
@@ -1,1 +1,0 @@
-audit: type=1400 audit(*): avc:  denied  { sys_admin } for  pid=* comm="systemd-coredum" * scontext=system_u:system_r:systemd_coredump_t:s0 tcontext=system_u:system_r:systemd_coredump_t:s0 tclass=cap_userns permissive=0


### PR DESCRIPTION
Known issue which has not occurred in 21 days

SELinux is preventing systemd-coredum from 'sys_admin' accesses to coredumps on rhel-9-0

Fixes #2997