### PR TITLE
naughty: Close 2942: PackageKit has crashed due to libdnf assertion 

### DIFF
--- a/naughty/fedora-35/2942-packagekit-assert-fp_primary
+++ b/naughty/fedora-35/2942-packagekit-assert-fp_primary
@@ -1,3 +1,0 @@
-Process * (packagekitd) of user * dumped core*
-* __assert_fail *
-* dnf_sack_load_repo *


### PR DESCRIPTION
Known issue which has not occurred in 24 days

PackageKit has crashed due to libdnf assertion 

Fixes #2942