### PR TITLE
npm-update updates

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -22,11 +22,6 @@
 #  * [ ] npm-update patternfly
 #
 
-# Dependencies where minor updates break, only bump microversion
-FRAGILE = [
-    "jquery",
-]
-
 # Dependencies which have to be updated in lockstep, not individually
 GROUP = [
     "@patternfly"
@@ -61,8 +56,6 @@ def prefix(name, version):
         return version
     if name.startswith("@patternfly"):
         return "prerelease"
-    if name not in FRAGILE:
-        return "^" + version
     return "~" + version
 
 

--- a/npm-update
+++ b/npm-update
@@ -19,7 +19,11 @@
 
 # To use this example add a line to an issue with the "bot" label
 #
-#  * [ ] npm-update patternfly
+#  * [ ] npm-update @patternfly
+#
+# To ignore specific package you can use `~` in front of context
+#
+# * [ ] npm-update ~@patternfly
 #
 
 # Dependencies which have to be updated in lockstep, not individually
@@ -68,6 +72,11 @@ def output(*args):
 def run(context, verbose=False, **kwargs):
     pending_updates = []
 
+    ignore_context = None
+    if context and context.startswith("~"):
+        ignore_context = context[1:]
+        context = None
+
     if not kwargs["dry"]:
         api = task.github.GitHub()
 
@@ -113,6 +122,12 @@ def run(context, verbose=False, **kwargs):
             if task.verbose:
                 sys.stderr.write("Ignoring '{0}' as it does not belong to current update group {1}\n"
                                  .format(package, group))
+            continue
+
+        # Ignore if context is specified and does not match
+        if context and not package.startswith(context):
+            continue
+        if ignore_context and package.startswith(ignore_context):
             continue
 
         # Check if we got an upgrade


### PR DESCRIPTION
The idea behind this is, that we would replace our `every second day do npm-update` with two tasks - one to do every other day npm update of anything except patternfly and then once per week do only PF update.
The reasoning behind this change is, that now that we moved to PF prerelease, we get every day new update. Since npm-update takes the first it sees, it might happen that we will be just updating PF every time and never get to anything else. Also we don't need to update PF every other day, once per week is often enough - especially since it might need a bit of manual labour to update pixel tests etc.
@martinpitt WDYT?