### PR TITLE
npm-update: adjust to npm changes in cockpit repo

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -88,9 +88,6 @@ def run(context, verbose=False, **kwargs):
                     if task.verbose:
                         sys.stderr.write("Ignoring '{0}' as there is pending PR #{1}\n".format(pkg, issue["number"]))
 
-    # The only time git will checkout an empty subdir is if it's a gitlink
-    is_gitlink = not subprocess.call(['rmdir', 'node_modules'])
-
     package_json_path = os.path.join(BASE_DIR, "package.json")
     old = read_package_json(package_json_path)
     old_deps = old['dependencies']
@@ -145,16 +142,18 @@ def run(context, verbose=False, **kwargs):
     updated_packages = sorted(updates)
 
     if updated_packages and not kwargs["dry"]:
+        # If node_modules/ is a gitlink, run the script to update it
+        if os.path.exists('tools/node-modules'):
+            subprocess.check_call(['tools/node-modules', 'install'])
+            subprocess.check_call(['tools/node-modules', 'push'])
+            subprocess.check_call(['git', 'add', 'node_modules'])
+
         # Create a pull request from these changes
         title = "package.json: Update " + ', '.join(updated_packages)
         branch = task.branch(updated_packages[0], title, pathspec="package.json", **kwargs)
 
         kwargs["title"] = title
         pull = task.pull(branch, **kwargs)
-
-        # If node_modules/ is a gitlink, request `/npm install`
-        if is_gitlink:
-            task.comment(pull, "/npm install")
 
         # List of files that probably touch this package
         lines = output("git", "grep", "-Ew", '|'.join(updated_packages))


### PR DESCRIPTION
We no longer ask for `/npm install` on the PR in order to get a new
`node_modules` — we are now responsible for building it ourselves.

Also: replace the semi-gross `rmdir node_modules` trick to just check if
the `tools/node-modules` script is present: we need to call it in order
to do this stuff anyway.

See also cockpit-project/cockpit#17230