### PR TITLE
github-upload-secrets: allow multiple keys per target

### DIFF
--- a/github-upload-secrets
+++ b/github-upload-secrets
@@ -94,17 +94,22 @@ def upload_secret(api, path, name, value, pubkey, opts):
 
 
 def upload_deploy_key(api, repo, title, content, opts):
-    keys_path = f"/repos/{repo}/keys"
+    keys_path = f"/repos/{repo.lstrip('+')}/keys"
 
-    # delete all existing keys
-    keys = api.get(keys_path)
-    for key in keys:
-        key_id = key['id']
-        key_path = f'{keys_path}/{key_id}'
-        if opts.dry_run or opts.verbose:
-            print(opts.dry_run and "Would delete" or "Deleting", key_path)
-        if not opts.dry_run:
-            api.delete(key_path)
+    if repo.startswith('+'):
+        # add this key to the existing keys
+        pass
+
+    else:
+        # delete all existing keys
+        keys = api.get(keys_path)
+        for key in keys:
+            key_id = key['id']
+            key_path = f'{keys_path}/{key_id}'
+            if opts.dry_run or opts.verbose:
+                print(opts.dry_run and "Would delete" or "Deleting", key_path)
+            if not opts.dry_run:
+                api.delete(key_path)
 
     # upload new key
     if opts.dry_run or opts.verbose:
@@ -132,13 +137,13 @@ def main():
                       help="Upload given directory with one file per secret")
     megr.add_argument('--ssh-keygen', metavar="SECRET_NAME",
                       help="Generate an SSH key, upload private, public to stdout")
-    parser.add_argument('--deploy-to', metavar="OWNER/REPO",
+    parser.add_argument('--deploy-to', metavar="[+]OWNER/REPO",
                         help="with --ssh-keygen, upload public key as deploy key")
 
     opts = parser.parse_args()
 
     NAME_RE = r'[a-z][-0-9a-z_.]*'
-    REPO_RE = f'{NAME_RE}/{NAME_RE}'
+    REPO_RE = fr'\+?{NAME_RE}/{NAME_RE}'
 
     if opts.deploy_to and not opts.ssh_keygen:
         parser.error('--deploy-to can only be used with --ssh-keygen')


### PR DESCRIPTION
We're going to want this so that the npm-upload workflow can push to both `node-cache` and `cockpit` repos.

- [x] actually test this first