### PR TITLE
testmap: add `rhel-8-6` for sub-man-cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -170,6 +170,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'centos-8-stream/subscription-manager-1.28',
+            'rhel-8-6/subscription-manager-1.28',
         ],
     },
     'cockpit-project/cockpit-certificates': {


### PR DESCRIPTION
Add a manual context to test subscription-manager-cockpit on `rhel-8-6`
with the `subscription-manager-1.28` branch of subscription-manager (which
is the version in 8.7). There is no `rhel-8-7` image yet, so `rhel-8-6` will
suffice for now.