### PR TITLE
npm: add no-op "prune" command

### DIFF
--- a/npm
+++ b/npm
@@ -68,6 +68,10 @@ cmd_outdated() {
     '
 }
 
+cmd_prune() {
+    : # npm install already produces a clean result each time
+}
+
 main() {
     if [ $# = 0 ]; then
         # don't list the "private" ones


### PR DESCRIPTION
This doesn't do anything, but is nice for using this script as a drop-in
replacement for npm in $PATH.  Some projects (like cockpit-machines)
call `npm prune` after `npm install`.