### PR TITLE
testmap: tweak images for sub-man/main

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -137,11 +137,9 @@ REPO_BRANCH_CONTEXT = {
     },
     'candlepin/subscription-manager': {
         'main': [
-            'rhel-8-5',
             'rhel-8-6',
             'rhel-9-0',
-            'fedora-35',
-            'fedora-35/rawhide',
+            'rhel-9-1',
             'fedora-36',
         ],
         'subscription-manager-1.28': [


### PR DESCRIPTION
Now that the cockpit plugin of sub-man was removed from
sub-man.git/main, there is a bit less need for cross-testing currently
done by the cockpit CI bits in sub-man.git/main (which test against
sub-man-cockpit from its git repository).

Hence:
- drop `rhel-8-5`, as backports to that old RHEL version (as ZStream) will
  be covered by the testing done by the `subscription-manager-1.28` branch
- drop `fedora-35` & its rawhide variant: `fedora-36` is enough here,
  sub-man-cockpit will test all the Fedora versions on its own
- add `rhel-9-1`, which is the current target version of sub-man.git/main