### PR TITLE
images: add nginx test image to coreos image

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-1eb1fcb616578bb200409e055de35afbd9a41cc98fba780d7f6aa36e178a0e5b.qcow2
+fedora-coreos-b00caafa7f66bbaa14f86592a86fb39635dc128880aa9bb8e414a23cc78f23cd.qcow2

--- a/images/scripts/fedora-coreos.setup
+++ b/images/scripts/fedora-coreos.setup
@@ -5,6 +5,7 @@ set -eux
 systemctl disable --now zincati.service
 
 podman pull quay.io/cockpit/ws
+podman pull quay.io/jitesoft/nginx
 
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config.d/10-no-usedns.conf


### PR DESCRIPTION
The tests require a nginx image to be available, it is currently
downloaded by `test/vm.install`. Moving it to the image allows the test
image to be done offline.

 * [x] image-refresh fedora-coreos