### PR TITLE
naughty: Close 2996: sos-report crashes on fedora-36

### DIFF
--- a/naughty/fedora-36/2996-sos-report-crash
+++ b/naughty/fedora-36/2996-sos-report-crash
@@ -1,1 +1,0 @@
-wait_js_cond(ph_is_present("#sos-download")): Uncaught (in promise) Error: condition did not become true


### PR DESCRIPTION
Known issue which has not occurred in 24 days

sos-report crashes on fedora-36

Fixes #2996