### PR TITLE
naughty: Close 2248: unspecific systemd-resolved crash on Ubuntu 20.04

### DIFF
--- a/naughty/ubuntu-2004/2248-resolved-segfault
+++ b/naughty/ubuntu-2004/2248-resolved-segfault
@@ -1,4 +1,0 @@
-#* n/a (systemd-resolved + *)
-*
-testlib.Error: FAIL: Test completed, but found unexpected journal messages:
-Process * (systemd-resolve) of user * dumped core.


### PR DESCRIPTION
Known issue which has not occurred in 24 days

unspecific systemd-resolved crash on Ubuntu 20.04

Fixes #2248