### PR TITLE
naughty: Close 3163: targetcli delete fails with: [Errno 20] Not a directory: '/sys/kernel/config/target/iscsi/cpus_allowed_list'

### DIFF
--- a/naughty/fedora-37/3163-targetcli-delete
+++ b/naughty/fedora-37/3163-targetcli-delete
@@ -1,3 +1,0 @@
-[Errno 20] Not a directory: '/sys/kernel/config/target/iscsi/cpus_allowed_list'
-*
-subprocess.CalledProcessError: Command 'targetcli /backstores/ramdisk delete test *' returned non-zero exit status 1.

--- a/naughty/fedora-37/3163-targetcli-delete-followup
+++ b/naughty/fedora-37/3163-targetcli-delete-followup
@@ -1,5 +1,0 @@
-Storage object ramdisk/test exists
-*
-subprocess.CalledProcessError: Command '
-* targetcli /backstores/ramdisk create test 50M
-*' returned non-zero exit status 1.


### PR DESCRIPTION
Known issue which has not occurred in 23 days

targetcli delete fails with: [Errno 20] Not a directory: '/sys/kernel/config/target/iscsi/cpus_allowed_list'

Fixes #3163