### PR TITLE
naughty: Close 3146: ubuntu 22.04: pam_faillock does not actually deny login after given number of failures

### DIFF
--- a/naughty/ubuntu-2204/3146-pam_faillock-no-lock
+++ b/naughty/ubuntu-2204/3146-pam_faillock-no-lock
@@ -1,7 +1,0 @@
-  File "test/verify/check-static-login", line *, in testFaillock
-    expect_failed_login("admin", "foobar", n)
-  File "test/verify/check-static-login", line *, in expect_failed_login
-    b.wait_text_not("#login-error-message", "")
-*
-testlib.Error: timeout
-


### PR DESCRIPTION
Known issue which has not occurred in 21 days

ubuntu 22.04: pam_faillock does not actually deny login after given number of failures

Fixes #3146