### PR TITLE
naughty: Add pattern for grubby default args regression in RHEL 9

### DIFF
--- a/naughty/rhel-9/3295-grubby-default-args
+++ b/naughty/rhel-9/3295-grubby-default-args
@@ -1,0 +1,7 @@
+Traceback (most recent call last):*
+  File "test/verify/check-system-info", line *, in testCPUSecurityMitigationsEnable
+    m.execute(r"""set -e
+*
+    grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
+*
+' returned non-zero exit status 1.


### PR DESCRIPTION
Current cockpit integration test does not catch that as it is too
lenient. https://github.com/cockpit-project/cockpit/pull/17279 makes
this tighter and spots this bug.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2078397

---

Running tests in https://github.com/cockpit-project/cockpit/pull/17279