### PR TITLE
naughty: Apply #2220 to more tests, and ensure they succeed

### DIFF
--- a/naughty/debian-stable/2220-libvirt-crashes-on-startup-2
+++ b/naughty/debian-stable/2220-libvirt-crashes-on-startup-2
@@ -1,5 +1,6 @@
-# testBasicWheelUserUnprivileged (__main__.TestMachinesLifecycle)
-*
+# test*.TestMachinesLifecycle*
 #0 * n/a (libvirt_driver_qemu.so + *)
 #1 * virStateShutdownPrepare (libvirt.so.0 + *)
 #2 * virNetDaemonRun (libvirt.so.0 + *)
+*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit-machines/pull/669 introduces
some more `testBasic*()` variants. Drop the precise test case name from
the pattern to accomodate that.

In exchange, ensure that this pattern only matches on successful tests
-- they are supposed to *only* fail on the unexpected message.

----

Running tests in https://github.com/cockpit-project/cockpit-machines/pull/669 , plus regression tests against the current c-machines main here.