### PR TITLE
naughty: Merge duplicate RHEL 9 grubby pattern

### DIFF
--- a/naughty/rhel-9/2090-no-nosmt-in-cmdline
+++ b/naughty/rhel-9/2090-no-nosmt-in-cmdline
@@ -1,5 +1,7 @@
-grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg ||
-  grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
-  ( grub2-editenv list | grep -q kernelopts.*nosmt &&
-    grep -q '^options.*$kernelopts' /boot/loader/entries/*42.0.0*.conf )
+Traceback (most recent call last):*
+  File "test/verify/check-system-info", line *, in testCPUSecurityMitigationsEnable
+    m.execute(r"""set -e
+*
+    grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
+*
 ' returned non-zero exit status 1.

--- a/naughty/rhel-9/3295-grubby-default-args
+++ b/naughty/rhel-9/3295-grubby-default-args
@@ -1,7 +1,0 @@
-Traceback (most recent call last):*
-  File "test/verify/check-system-info", line *, in testCPUSecurityMitigationsEnable
-    m.execute(r"""set -e
-*
-    grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
-*
-' returned non-zero exit status 1.


### PR DESCRIPTION
Yesterday's known issue #3295 is really a duplicate of #2090. But as the
code changed in https://github.com/cockpit-project/cockpit/pull/17279 ,
the pattern did not match any more. (I originally thought this was due to
the stricter test).

Move the new pattern to the old known issue, and close the new one.
Likewise, the new downstream bugzilla was marked as a duplicate.

Fixes #3295