### PR TITLE
[no-test] naughty: Close 3068: avc: denied { create } for comm="timedatex" scontext=system_u:system_r:timedatex_t:s0 tcontext=system_u:system_r:timedatex_t:s0 tclass=unix_dgram_socket

### DIFF
--- a/naughty/rhel-8/3068-timedatex-naughty
+++ b/naughty/rhel-8/3068-timedatex-naughty
@@ -1,3 +1,0 @@
-audit: * avc:  denied  { create } for * comm="timedatex" scontext=system_u:system_r:timedatex_t:s0 tcontext=system_u:system_r:timedatex_t:s0 tclass=unix_dgram_socket*
-*
-testlib.Error: FAIL: Test completed, but found unexpected journal messages:


### PR DESCRIPTION
Known issue which has not occurred in 21 days

avc: denied { create } for comm="timedatex" scontext=system_u:system_r:timedatex_t:s0 tcontext=system_u:system_r:timedatex_t:s0 tclass=unix_dgram_socket

Fixes #3068