### PR TITLE
workflows: don't test on image-trigger changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
               ':!images' \
               ':!image-create' \
               ':!image-customize' \
+              ':!image-trigger' \
               ':!naughty' \
               ':!machine/machine_core' \
               ':!lib/testmap.py' \


### PR DESCRIPTION
This is pretty similar to a testmap change, and it isn't part of the
tests, anyway.

Exempt changes to this script from requiring a full testing round.