### PR TITLE
image-prune: two tweaks to relieve space pressure

### DIFF
--- a/image-prune
+++ b/image-prune
@@ -104,7 +104,7 @@ def get_image_links(ref, git_path):
         raise
     links = [subprocess.check_output(["git", "show", "{0}:{1}".format(ref, entry)], universal_newlines=True)
              for entry in entries]
-    return [link for link in links if link.endswith(".qcow2")]
+    return [link for link in links if link.endswith(".qcow2") or link.endswith(".iso")]
 
 
 def get_image_names(quiet=False, open_pull_requests=True, offline=False):
@@ -162,7 +162,7 @@ class ImageCache:
         expiry_threshold = time.time() - IMAGE_EXPIRE * 86400
 
         for image, mtime in self.list_files():
-            if not any(image.endswith(ext) for ext in ['.qcow2', '.partial']):
+            if not any(image.endswith(ext) for ext in ['.iso', '.qcow2', '.partial']):
                 debug(f'Skipping file {image} with unknown extension')
                 continue
 

--- a/image-prune
+++ b/image-prune
@@ -203,8 +203,8 @@ class LocalImageDirectory(ImageCache):
 class S3ImageStore(ImageCache):
     def __init__(self, url):
         self.url = url
-        # A bit magic: we have 2 buckets and 250GB quota.  Try to keep each bucket below ca. 80GB.
-        self.max_bytes = float(os.environ.get("S3_IMAGES_MAX_GB", 80)) * 1000 * 1000 * 1000
+        # A bit magic: we have 2 buckets and 250GB quota.  Try to keep each bucket below ca. 100GB.
+        self.max_bytes = float(os.environ.get("S3_IMAGES_MAX_GB", 100)) * 1000 * 1000 * 1000
 
     def list_files(self):
         result = s3.list_bucket(self.url)


### PR DESCRIPTION
I've noticed that some files on Linode are getting pruned a bit early.  That turns out to be due to space pressure.  Here are a pair of fixes that will help resolve that in two different ways.