### PR TITLE
naughty: Close 3121: modprobe: FATAL: Module kvdo not found in directory /lib/modules/4.18.0-372.2.1.el8.x86_64

### DIFF
--- a/naughty/rhel-8/3121-no-kvdo
+++ b/naughty/rhel-8/3121-no-kvdo
@@ -1,1 +1,0 @@
-modprobe: FATAL: Module kvdo not found in directory /lib/modules/4.18.0


### PR DESCRIPTION
Known issue which has not occurred in 23 days

modprobe: FATAL: Module kvdo not found in directory /lib/modules/4.18.0-372.2.1.el8.x86_64

Fixes #3121