### PR TITLE
naughty: copy selinux podman naughty to fedora-36

### DIFF
--- a/naughty/fedora-36/2787-selinux-ioctl-iptables-containers
+++ b/naughty/fedora-36/2787-selinux-ioctl-iptables-containers
@@ -1,0 +1,1 @@
+avc:  denied  { ioctl } for * comm="iptables" path="/var/lib/containers/storage/*" dev="overlay" * scontext=unconfined_u:system_r:iptables_t:* tcontext=system_u:object_r:container_file_t:s0:*


### PR DESCRIPTION
Observed in https://logs.cockpit-project.org/logs/pull-17282-20220509-160521-075a2a9d-fedora-36/log.html#297-2