### PR TITLE
image-prune tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,14 @@ on: [pull_request]
 jobs:
   bots:
     runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/cockpit-project/unit-tests
+      options: --user root
     permissions:
       pull-requests: none
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: sudo -n apt-get install -y python3-pyflakes python3-pycodestyle
 
       - name: Run test
         run: test/run

--- a/image-create
+++ b/image-create
@@ -207,7 +207,7 @@ try:
         builder.save()
         if args.upload:
             print("Uploading...")
-            cmd = [os.path.join(BOTS_DIR, "image-upload")]
+            cmd = [os.path.join(BOTS_DIR, "image-upload"), '--prune-s3']
             if args.store:
                 cmd += ["--store", args.store]
             cmd += [args.image]

--- a/image-download
+++ b/image-download
@@ -43,7 +43,7 @@ import urllib.parse
 
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir, xdg_config_home
-from lib.stores import HYBRID_STORES, PUBLIC_STORES, REDHAT_STORES, CA_PEM
+from lib.stores import S3_STORES, PUBLIC_STORES, REDHAT_STORES, CA_PEM
 from lib.testmap import get_test_image
 from lib import s3
 
@@ -142,7 +142,7 @@ def download(dest, force, state, quiet, stores):
                 stores = fp.read().strip().split("\n")
         except FileNotFoundError:
             stores = []
-        stores += HYBRID_STORES
+        stores += S3_STORES
         # skip testing public stores for private images
         if not name.startswith("rhel"):
             stores += PUBLIC_STORES

--- a/image-prune
+++ b/image-prune
@@ -187,8 +187,8 @@ class S3ImageStore(ImageCache):
 
 def main():
     parser = argparse.ArgumentParser(description='Prune downloaded images')
-    parser.add_argument("--debug", action="store_true", help="Enable debugging output")
-    parser.add_argument("--force", action="store_true", help="Delete images even if they aren't old")
+    parser.add_argument("--debug", '-d', action="store_true", help="Enable debugging output")
+    parser.add_argument("--force", '-f', action="store_true", help="Delete images even if they aren't old")
     parser.add_argument("-n", "--dry-run", dest="dryrun", action="store_true",
                         help="Don't actually delete images and links")
     parser.add_argument("-c", "--checkout-only", dest="checkout_only", action="store_true",

--- a/image-prune
+++ b/image-prune
@@ -105,7 +105,7 @@ def get_keepers(offline=False, checkout_only=False):
 
 class ImageCache:
     def list_files(self) -> Iterable[Tuple[str, float]]:
-        """yields tuples of (basename, mtime)"""
+        """yields tuples of (mtime, basename)"""
         raise NotImplementedError
 
     def delete_file(self, filename: str):
@@ -119,7 +119,8 @@ class ImageCache:
     def prune(self, keepers, force=False, dryrun=False):
         expiry_threshold = time.time() - IMAGE_EXPIRE * 86400
 
-        for image, mtime in self.list_files():
+        # Sort by mtime, oldest first.
+        for mtime, image in sorted(self.list_files()):
             if not any(image.endswith(ext) for ext in ['.iso', '.qcow2', '.partial']):
                 logger.debug('Skipping file %s with unknown extension', image)
                 continue
@@ -146,7 +147,7 @@ class LocalImageDirectory(ImageCache):
     def list_files(self):
         for entry in os.scandir(self.directory):
             if entry.is_file(follow_symlinks=False):
-                yield entry.name, entry.stat().st_mtime
+                yield entry.stat().st_mtime, entry.name
 
     def delete_file(self, filename):
         os.unlink(os.path.join(self.directory, filename))
@@ -172,7 +173,7 @@ class S3ImageStore(ImageCache):
 
         rfc3339ish = '%Y-%m-%dT%H:%M:%S.%f%z'
         for name, stamp in s3.parse_list(result, "Key", "LastModified"):
-            yield name, datetime.datetime.strptime(stamp, rfc3339ish).timestamp()
+            yield datetime.datetime.strptime(stamp, rfc3339ish).timestamp(), name
 
     def delete_file(self, filename):
         with s3.urlopen(self.url._replace(path='/' + filename), method='DELETE'):

--- a/image-prune
+++ b/image-prune
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-# Days after which images expire if not in use
-IMAGE_EXPIRE = 14
-
 import argparse
 import datetime
 import logging
@@ -38,6 +35,10 @@ from lib.directories import get_images_data_dir
 from lib import s3
 
 logger = logging.getLogger('image-prune')
+
+# Days after which images expire if not in use
+IMAGE_EXPIRE = 14
+
 
 def git(*args, cwd='.'):
     return subprocess.check_output(['git', *args], text=True, cwd=cwd)
@@ -151,8 +152,8 @@ class LocalImageDirectory(ImageCache):
         os.unlink(os.path.join(self.directory, filename))
 
     def enough_space(self):
-        st = os.statvfs(self.directory)
-        free = st.f_bavail * st.f_frsize / (1024 * 1024 * 1024)
+        buf = os.statvfs(self.directory)
+        free = buf.f_bavail * buf.f_frsize / (1024 * 1024 * 1024)
         return free >= self.space_threshold
 
 
@@ -161,6 +162,7 @@ class S3ImageStore(ImageCache):
         self.url = url
         # A bit magic: we have 2 buckets and 250GB quota.  Try to keep each bucket below ca. 100GB.
         self.max_bytes = float(os.environ.get("S3_IMAGES_MAX_GB", 100)) * 1000 * 1000 * 1000
+        self.sizes = {}
 
     def list_files(self):
         result = s3.list_bucket(self.url)
@@ -168,9 +170,9 @@ class S3ImageStore(ImageCache):
         # make sure this gets done before we start iterating
         self.sizes = dict(s3.parse_list(result, "Key", "Size"))
 
-        RFC3339ish = '%Y-%m-%dT%H:%M:%S.%f%z'
+        rfc3339ish = '%Y-%m-%dT%H:%M:%S.%f%z'
         for name, stamp in s3.parse_list(result, "Key", "LastModified"):
-            yield name, datetime.datetime.strptime(stamp, RFC3339ish).timestamp()
+            yield name, datetime.datetime.strptime(stamp, rfc3339ish).timestamp()
 
     def delete_file(self, filename):
         with s3.urlopen(self.url._replace(path='/' + filename), method='DELETE'):
@@ -189,7 +191,7 @@ def main():
     parser.add_argument("-n", "--dry-run", dest="dryrun", action="store_true",
                         help="Don't actually delete images and links")
     parser.add_argument("-c", "--checkout-only", dest="checkout_only", action="store_true",
-                        help="Consider neither pull requests on GitHub nor branches, only look at the current checkout")
+                        help="Consider only the current HEAD commit")
     parser.add_argument("-o", "--offline", dest="offline", action="store_true",
                         help="Don't access external sources such as GitHub")
     cache_arg = parser.add_argument_group(title='Cache location',

--- a/image-prune
+++ b/image-prune
@@ -231,8 +231,6 @@ def main():
     parser.add_argument("--force", action="store_true", help="Delete images even if they aren't old")
     parser.add_argument("-n", "--dry-run", dest="dryrun", action="store_true",
                         help="Don't actually delete images and links")
-    parser.add_argument("-b", "--branches-only", dest="branches_only", action="store_true",
-                        help="Don't consider pull requests on GitHub, only look at branches")
     parser.add_argument("-c", "--checkout-only", dest="checkout_only", action="store_true",
                         help="Consider neither pull requests on GitHub nor branches, only look at the current checkout")
     parser.add_argument("-o", "--offline", dest="offline", action="store_true",
@@ -259,8 +257,7 @@ def main():
     else:
         collection = LocalImageDirectory(args.directory)
 
-    keepers = get_keepers(open_pull_requests=(not args.branches_only),
-                          offline=args.offline,
+    keepers = get_keepers(offline=args.offline,
                           checkout_only=args.checkout_only)
 
     collection.prune(keepers,

--- a/image-prune
+++ b/image-prune
@@ -224,8 +224,6 @@ def main():
                      force=args.force,
                      dryrun=args.dryrun)
 
-    return 0
-
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()

--- a/image-prune
+++ b/image-prune
@@ -224,6 +224,9 @@ def main():
                      force=args.force,
                      dryrun=args.dryrun)
 
+    if not args.force and not collection.enough_space():
+        sys.exit('Insufficient free space after attempting to prune images')
+
 
 if __name__ == '__main__':
     main()

--- a/image-prune
+++ b/image-prune
@@ -29,7 +29,6 @@ import sys
 import time
 import urllib.parse
 from typing import Iterable, Tuple
-from logging import debug
 
 from task import github
 
@@ -37,6 +36,7 @@ from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
 from lib import s3
 
+logger = logging.getLogger('image-prune')
 
 def get_refs(open_pull_requests=True, offline=False):
     """Return dictionary for available refs of the format {'rhel-7.4': 'ad50328990e44c22501bd5e454746d4b5e561b7c'}
@@ -163,15 +163,15 @@ class ImageCache:
 
         for image, mtime in self.list_files():
             if not any(image.endswith(ext) for ext in ['.iso', '.qcow2', '.partial']):
-                debug(f'Skipping file {image} with unknown extension')
+                logger.debug('Skipping file %s with unknown extension', image)
                 continue
 
             if image in keepers:
-                debug(f'Skipping image {image} which is in the keepers list')
+                logger.debug('Skipping image %s which is in the keepers list', image)
                 continue
 
             if not force and self.enough_space() and mtime > expiry_threshold:
-                debug(f'Skipping image {image} which is new enough (and not forced or low on space)')
+                logger.debug('Skipping image %s which is new enough (and not forced or low on space)', image)
                 continue
 
             if not quiet:

--- a/image-prune
+++ b/image-prune
@@ -24,125 +24,82 @@ import argparse
 import datetime
 import logging
 import os
+import re
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.parse
 from typing import Iterable, Tuple
 
 from task import github
 
-from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
 from lib import s3
 
 logger = logging.getLogger('image-prune')
 
-def get_refs(open_pull_requests=True, offline=False):
-    """Return dictionary for available refs of the format {'rhel-7.4': 'ad50328990e44c22501bd5e454746d4b5e561b7c'}
-
-       Expects to be called from the top level of the git checkout
-       If offline is true, git show-ref is used instead of listing the remote
-    """
-    # get all remote heads and filter empty lines
-    # output of ls-remote has the format
-    #
-    # d864d3792db442e3de3d1811fa4bc371793a8f4f	refs/heads/main
-    # ad50328990e44c22501bd5e454746d4b5e561b7c	refs/heads/rhel-7.4
-
-    refs = {}
-
-    considerable = {}
-    g = github.GitHub()
-    if open_pull_requests:
-        if offline:
-            raise Exception("Unable to consider open pull requests when in offline mode")
-        for p in g.pulls():
-            files = g.get("pulls/{0}/files".format(p["number"]))
-            images = []
-            for fl in files:
-                fl_name = fl['filename']
-                if fl_name.startswith("images/"):
-                    fl_name_split = fl_name.split("/", 2)
-                    if "/" not in fl_name_split[1]:
-                        images.append(fl_name_split[1])
-            if images:
-                sha = p["head"]["sha"]
-                considerable[sha] = images
-                subprocess.call(["git", "fetch", "origin", "{0}".format(sha)])
-                refs["pull request #{} ({})".format(p["number"], p["title"])] = sha
-
-    git_cmd = "show-ref" if offline else "ls-remote"
-    ref_output = subprocess.check_output(["git", git_cmd], universal_newlines=True).splitlines()
-    # filter out the "refs/heads/" prefix and generate a dictionary
-    prefix = "refs/heads"
-    for ln in ref_output:
-        [ref, name] = ln.split()
-        if name.startswith(prefix):
-            refs[name[len(prefix):]] = ref
-
-    return (refs, considerable)
+def git(*args, cwd='.'):
+    return subprocess.check_output(['git', *args], text=True, cwd=cwd)
 
 
-def get_image_links(ref, git_path):
-    """Return all image links for the given git ref
+def get_images_in_commit(commit, cwd='.'):
+    """Returns all images pointed to by a symlink in images/ from the given commit"""
 
-       Expects to be called from the top level of the git checkout
-    """
-    # get all the links we have first
-    # trailing slash on path is important
-    if not git_path.endswith("/"):
-        git_path = "{0}/".format(git_path)
-
-    try:
-        entries = subprocess.check_output(["git", "ls-tree", "--name-only", ref, git_path],
-                                          universal_newlines=True).splitlines()
-    except subprocess.CalledProcessError as e:
-        if e.returncode == 128:
-            sys.stderr.write("Skipping {0} due to tree error.\n".format(ref))
-            return []
-        raise
-    links = [subprocess.check_output(["git", "show", "{0}:{1}".format(ref, entry)], universal_newlines=True)
-             for entry in entries]
-    return [link for link in links if link.endswith(".qcow2") or link.endswith(".iso")]
+    logger.debug('Keeping all images in %s...', commit)
+    for line in git('cat-file', '-p', f'{commit}:images/', cwd=cwd).splitlines():
+        mode, kind, blob, _name = line.split()
+        if mode == '120000' and kind == 'blob':
+            image = git('cat-file', 'blob', blob, cwd=cwd)
+            logger.debug('  - %s', image)
+            yield image
 
 
-def get_image_names(quiet=False, open_pull_requests=True, offline=False):
-    """Return all image names used by all branches and optionally in open pull requests
-    """
-    images = set()
-    # iterate over visible refs (mostly branches)
-    # this hinges on being in the top level directory of the the git checkout
-    (refs, considerable) = get_refs(open_pull_requests, offline)
-    # list images present in each branch / pull request
-    for name, ref in refs.items():
-        if not quiet:
-            sys.stderr.write("Considering images from {0} ({1})\n".format(name, ref))
-        for link in get_image_links(ref, "images"):
-            if ref in considerable:
-                for consider in considerable[ref]:
-                    if link.startswith(consider):
-                        images.add(link)
-            else:
-                images.add(link)
+def get_images_in_branches(merge_target, *branch_patterns, cwd='.'):
+    """Returns all images introduced by branches, relative to merge_target"""
 
-    return images
+    # KISS: just get a diff and grab anything that looks like an image update
+    for ref_line in git('for-each-ref', *branch_patterns, cwd=cwd).splitlines():
+        _rev, _kind, ref = ref_line.split()
+        logger.debug('Considering images changed in %s...', ref)
+        for patch_line in git('diff', f'{merge_target}...{ref}', '--', 'images/', cwd=cwd).splitlines():
+            if match := re.search(r'^\+([-0-9a-z]+-[0-9a-f]+.(qcow2|iso))', patch_line):
+                image = match.group(1)
+                logger.debug('  - %s', image)
+                yield image
 
 
-def get_keepers(quiet=False, open_pull_requests=True, offline=False, checkout_only=False):
-    if checkout_only:
-        targets = set()
-    else:
-        targets = get_image_names(quiet, open_pull_requests, offline)
+def get_remote_images():
+    """Returns all images currently used by PRs and origin branches on GitHub"""
 
-    # what we have in the current checkout might already have been added by its branch, but check anyway
-    for entry in os.scandir(IMAGES_DIR):
-        # only consider original image entries as trustworthy sources and ignore non-links
-        if '.' not in entry.name and entry.is_symlink():
-            target = os.readlink(entry.path)
-            targets.add(target)
+    api = github.GitHub()
+    logger.debug('Querying open PRs on %s', api.repo)
+    open_prs = [pr['number'] for pr in api.pulls()]
+    logger.debug('Open PRs: %s', open_prs)
 
-    return targets
+    # Use a temporary git repository to work in to avoid touching the local one
+    with tempfile.TemporaryDirectory() as tmpdir:
+        git('init', '-b', 'main', cwd=tmpdir)
+
+        # We store HEAD as `head`, origin branches as `origin/{name}` and PRs as `pr/{nr}`
+        patterns = {'HEAD:refs/heads/head', 'refs/heads/*:refs/heads/origin/*'}
+        patterns.update(f'refs/pull/{nr}/head:refs/heads/pr/{nr}' for nr in open_prs)
+        quiet = ['--quiet'] if not logger.isEnabledFor(logging.DEBUG) else []
+        git('fetch', *quiet, f'https://github.com/{api.repo}', *patterns, cwd=tmpdir)
+
+        yield from get_images_in_commit('head', cwd=tmpdir)
+        yield from get_images_in_branches('head', 'refs/heads/origin/*', 'refs/heads/pr/*', cwd=tmpdir)
+
+
+def get_keepers(offline=False, checkout_only=False):
+    keepers = set(get_images_in_commit('HEAD'))
+
+    if not checkout_only:
+        keepers.update(get_images_in_branches('HEAD', 'refs/heads/*'))
+        if not offline:
+            keepers.update(get_remote_images())
+
+    return keepers
 
 
 class ImageCache:

--- a/image-prune
+++ b/image-prune
@@ -158,7 +158,7 @@ class ImageCache:
         """returns True if disk space is not currently an issue"""
         raise NotImplementedError
 
-    def prune(self, keepers, force=False, dryrun=False, quiet=False):
+    def prune(self, keepers, force=False, dryrun=False):
         expiry_threshold = time.time() - IMAGE_EXPIRE * 86400
 
         for image, mtime in self.list_files():
@@ -174,8 +174,7 @@ class ImageCache:
                 logger.debug('Skipping image %s which is new enough (and not forced or low on space)', image)
                 continue
 
-            if not quiet:
-                print(f"Pruning {image}", file=sys.stderr)
+            print(f"Pruning {image}", file=sys.stderr)
 
             if not dryrun:
                 self.delete_file(image)
@@ -230,7 +229,6 @@ def main():
     parser = argparse.ArgumentParser(description='Prune downloaded images')
     parser.add_argument("--debug", action="store_true", help="Enable debugging output")
     parser.add_argument("--force", action="store_true", help="Delete images even if they aren't old")
-    parser.add_argument("--quiet", action="store_true", help="Make downloading quieter")
     parser.add_argument("-n", "--dry-run", dest="dryrun", action="store_true",
                         help="Don't actually delete images and links")
     parser.add_argument("-b", "--branches-only", dest="branches_only", action="store_true",
@@ -261,15 +259,13 @@ def main():
     else:
         collection = LocalImageDirectory(args.directory)
 
-    keepers = get_keepers(quiet=args.quiet,
-                          open_pull_requests=(not args.branches_only),
+    keepers = get_keepers(open_pull_requests=(not args.branches_only),
                           offline=args.offline,
                           checkout_only=args.checkout_only)
 
     collection.prune(keepers,
                      force=args.force,
-                     dryrun=args.dryrun,
-                     quiet=args.quiet and not args.dryrun)
+                     dryrun=args.dryrun)
 
     return 0
 

--- a/image-upload
+++ b/image-upload
@@ -26,7 +26,7 @@ import sys
 import time
 import urllib.parse
 
-from lib.constants import IMAGES_DIR
+from lib.constants import BOTS_DIR, IMAGES_DIR
 from lib.directories import get_images_data_dir
 from lib.stores import S3_STORES, PUBLIC_STORES, REDHAT_STORES, CA_PEM
 from lib import s3
@@ -34,7 +34,7 @@ from lib import s3
 from task import api
 
 
-def upload(dest, source, public):
+def upload(dest, source, public, prune=False):
     url = urllib.parse.urlparse(dest)
 
     # Start building the command
@@ -58,6 +58,10 @@ def upload(dest, source, public):
         sys.stderr.write(f"image-upload: no credentials for {dest}")
         return False
 
+    # Only prune after the above checks, to ensure that we have credentials.
+    if prune:
+        subprocess.check_call([f'{BOTS_DIR}/image-prune', '--s3', f'https://{url.hostname}/'])
+
     print("Uploading to", dest, file=sys.stderr)
 
     # Retry with exponential back-off, to defend against short-term networking errors
@@ -76,6 +80,7 @@ def upload(dest, source, public):
 
 def main():
     parser = argparse.ArgumentParser(description='Upload bot state or images')
+    parser.add_argument("--prune-s3", action="store_true", help="Run image-prune before upload to S3")
     parser.add_argument("--store", action="append", default=[], help="Where to send state or images")
     parser.add_argument("--state", action="store_true", help="Images or state not recorded in git")
     parser.add_argument('image', nargs='*')
@@ -113,7 +118,7 @@ def main():
         success = False
         for store in stores:
             dest = urllib.parse.urljoin(store, basename)
-            success |= upload(dest, source, public)
+            success |= upload(dest, source, public, prune=args.prune_s3 and store in S3_STORES)
 
         if not success:
             sys.exit('Failed to upload to any image store')

--- a/image-upload
+++ b/image-upload
@@ -28,7 +28,7 @@ import urllib.parse
 
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
-from lib.stores import HYBRID_STORES, PUBLIC_STORES, REDHAT_STORES, CA_PEM
+from lib.stores import S3_STORES, PUBLIC_STORES, REDHAT_STORES, CA_PEM
 from lib import s3
 
 from task import api
@@ -102,7 +102,7 @@ def main():
         # determine possible stores, unless explicitly given
         stores = args.store
         if not stores:
-            stores = list(HYBRID_STORES)
+            stores = list(S3_STORES)
 
             # these images are not freely redistributable, keep them Red Hat internal
             if public:

--- a/image-upload
+++ b/image-upload
@@ -56,7 +56,7 @@ def upload(dest, source, public):
     else:
         # No credentials?  That's not going to work...
         sys.stderr.write(f"image-upload: no credentials for {dest}")
-        return 1
+        return False
 
     print("Uploading to", dest, file=sys.stderr)
 
@@ -64,14 +64,14 @@ def upload(dest, source, public):
     for retry in range(3):
         try:
             subprocess.check_call(cmd)
-            return 0
+            return True
         except subprocess.CalledProcessError:
             delay = 10 * 4 ** retry
             sys.stderr.write(f"image-upload: retrying upload to {dest} in {delay}s..\n")
             time.sleep(delay)
-    else:
-        sys.stderr.write(f"image-upload: unable to upload image: {dest}\n")
-        return 1
+
+    sys.stderr.write(f"image-upload: unable to upload image: {dest}\n")
+    return False
 
 
 def main():
@@ -113,14 +113,11 @@ def main():
         success = False
         for store in stores:
             dest = urllib.parse.urljoin(store, basename)
-            ret = upload(dest, source, public)
-            if ret == 0:
-                success = True
+            success |= upload(dest, source, public)
 
         if not success:
-            # all stores failed, so return last exit code
-            return ret
+            sys.exit('Failed to upload to any image store')
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()

--- a/lib/stores
+++ b/lib/stores
@@ -1,3 +1,3 @@
-hybrid	https://cockpit-images.eu-central-1.linodeobjects.com/
-hybrid	https://cockpit-images.us-east-1.linodeobjects.com/
+s3	https://cockpit-images.eu-central-1.linodeobjects.com/
+s3	https://cockpit-images.us-east-1.linodeobjects.com/
 redhat	https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com:8493/

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -35,7 +35,7 @@ PUBLIC_STORES = [url for scope, url in ALL_STORES if scope == 'public']
 REDHAT_STORES = [url for scope, url in ALL_STORES if scope == 'redhat']
 
 # Servers which can host either public or private images (via ACL specification)
-HYBRID_STORES = [url for scope, url in ALL_STORES if scope == 'hybrid']
+S3_STORES = [url for scope, url in ALL_STORES if scope == 's3']
 
 
 def redhat_network():

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -185,7 +185,7 @@ merged_failures {merged_failures}
 
     # S3 space usage
     space_usage = {}
-    for uri in stores.HYBRID_STORES:
+    for uri in stores.S3_STORES:
         url = urllib.parse.urlparse(uri)
 
         if s3.is_key_present(url):


### PR DESCRIPTION
 - general `image-prune` cleanups
 - simplify the "keepers" algorithm of `image-prune`
 - prune the oldest images first and stop once we have enough free space
 - if we can't create enough free space, fail
 - call `image-prune` from `image-upload` as part of `image-create`: the correct place to prune images is when we want to make space for new ones.

 * [x] image-refresh cirros