### PR TITLE
naughty: Add pattern for broken podman on RHEL 8.7

### DIFF
--- a/naughty/rhel-8/3378-podman-missing-plugin
+++ b/naughty/rhel-8/3378-podman-missing-plugin
@@ -1,0 +1,1 @@
+Error: plugin type="bridge" failed (add): failed to find plugin "bridge" in path [/usr/local/libexec/cni /usr/libexec/cni /usr/local/lib/cni /usr/lib/cni /opt/cni/bin]


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2086757

---

See https://github.com/cockpit-project/cockpit/pull/17345 . It doesn't make sense to test c-podman itself on 8.7 until this gets fixed, but for cockpit we can add this naughty, as it only breaks one test.