### PR TITLE
images: Pull cockpit-podman test images onto fedora-coreos

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-52c33ea336676c8b65f09adecd9a256254368faac262650ddbcfdd1b26ff318f.qcow2
+fedora-coreos-a896a195b09eb3d996768fb813d4e67a668ad32faba63cde2c8d0c5c1f347bda.qcow2

--- a/images/scripts/fedora-coreos.setup
+++ b/images/scripts/fedora-coreos.setup
@@ -6,6 +6,8 @@ systemctl disable --now zincati.service
 
 podman pull quay.io/cockpit/ws
 podman pull quay.io/jitesoft/nginx
+# for c-podman tests
+/var/lib/testvm/podman-images.setup
 
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config.d/10-no-usedns.conf


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit-podman/pull/972 introduced
testing of cockpit-podman on fedora-coreos. Pull the test images onto
the image, so that c-podman PRs can once again be tested fully offline.

 * [x] image-refresh fedora-coreos