### PR TITLE
s3-streamer improvements

### DIFF
--- a/s3-streamer
+++ b/s3-streamer
@@ -84,10 +84,14 @@ class S3Destination(Destination):
         raise NotImplementedError('use Index')
 
     def write(self, filename, data):
+        content_type, content_encoding = mimetypes.guess_type(filename)
         headers = {
-            'Content-Type': mimetypes.guess_type(filename)[0] or 'text/plain',
+            'Content-Type': content_type or 'text/plain',
             s3.ACL: s3.PUBLIC
         }
+        if content_encoding:
+            headers['Content-Encoding'] = content_encoding
+
         with s3.urlopen(self.url(filename), data=data, method='PUT', headers=headers) as _:
             pass
 

--- a/s3-streamer
+++ b/s3-streamer
@@ -160,8 +160,9 @@ class ChunkedUploader:
     SIZE_LIMIT = 1000000  # 1MB
     TIME_LIMIT = 30       # 30s
 
-    def __init__(self, index, filename, encoding=None):
-        self.input_decoder = codecs.getincrementaldecoder(encoding or locale.getpreferredencoding())()
+    def __init__(self, index, filename):
+        assert locale.getpreferredencoding() == 'UTF-8'
+        self.input_decoder = codecs.getincrementaldecoder('UTF-8')(errors='replace')
         self.suffixes = {'chunks'}
         self.chunks = []
         self.index = index

--- a/s3-streamer
+++ b/s3-streamer
@@ -24,6 +24,8 @@ import locale
 import logging
 import mimetypes
 import os
+import platform
+import shlex
 import subprocess
 import tempfile
 import textwrap
@@ -164,8 +166,9 @@ class ChunkedUploader:
         self.pending = b''
         self.send_at = 0  # Send the first write immediately
 
-    def init(self):
-        self.destination.write(f'{self.filename}.chunks', json.dumps([]).encode('ascii'))
+    def start(self, data):
+        # Send the initial data immediately, to get the chunks file written out.
+        self.append_block(data.encode('utf-8'))
         AttachmentsDirectory(self.index, f'{LIB_DIR}/s3-html').scan()
 
     def append_block(self, block):
@@ -293,10 +296,10 @@ def main():
             os.set_blocking(process.stdout.fileno(), False)
 
             # Send the static files to start
-            log_uploader.init()
+            log_uploader.start(f"Running on: {platform.node()}\nCommand: {shlex.join(args.cmd)}\n")
 
             # In progress...
-            status.post('pending', github.TESTING)
+            status.post('pending', f'Testing in progress [{platform.node()}]')
 
             process_exited = False
             while not process_exited:

--- a/s3-streamer
+++ b/s3-streamer
@@ -126,7 +126,7 @@ class Index(Destination):
                     <h1>Directory listing for /</h1>
                     <hr>
                     <ul>''' + ''.join(f'''
-                      <li><a href={f}>{f}</a></li> ''' for f in self.files) + '''
+                      <li><a href={f}>{f}</a></li> ''' for f in sorted(self.files)) + '''
                     </ul>
                   </body>
                 </html>


### PR DESCRIPTION
As discussed yesterday, after the first round of testing:
 - set Content-Encoding for .log.gz files
 - write hostname and command into the start of the log
 - sort index.html
 - insist on utf-8 locale, but accept non-utf-8 input