### PR TITLE
test-scan tweaks

### DIFF
--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -84,6 +84,13 @@ class DistributedQueue(object):
         if no_amqp:
             raise ImportError('pika is not available')
 
+        # Try looking in the XDG_RUNTIME_DIR instead.  Nice for local hacking.
+        if not os.path.isdir(secrets_dir) and secrets_dir.startswith('/run'):
+            if runtime_dir := os.environ.get('XDG_RUNTIME_DIR'):
+                user_secrets = secrets_dir.replace('/run', runtime_dir)
+                if os.path.isdir(user_secrets):
+                    secrets_dir = user_secrets
+
         try:
             host, port = amqp_server.split(':')
         except ValueError:

--- a/tests-scan
+++ b/tests-scan
@@ -313,8 +313,8 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
             # end up with a bunch of half tested pull requests
             baseline += 1.0 - (min(100000, float(number)) / 100000)
 
-        # Create list of statuses to process
-        todos = {}
+        # Create list of statuses to process: always process the requested contexts, if given
+        todos = {context: {} for context in contexts}
         for status in statuses:  # Firstly add all valid contexts that already exist in github
             if contexts and status not in contexts:
                 continue

--- a/tests-scan
+++ b/tests-scan
@@ -61,6 +61,8 @@ def main():
                         help='Display human readable output rather than tasks')
     parser.add_argument('-n', '--dry', action="store_true", default=False,
                         help='Don''t actually change anything on GitHub')
+    parser.add_argument('-f', '--force', action="store_true", default=False,
+                        help='Perform all actions, even those that should be skipped')
     parser.add_argument('--repo', default=None,
                         help='Repository to scan and checkout.')
     parser.add_argument('-c', '--context', action="append", default=[],
@@ -80,6 +82,10 @@ def main():
         return 1
     if opts.pull_data and (opts.pull_number or opts.sha):
         parser.error("--pull-data and --pull-number/--sha are mutually exclusive")
+
+    if opts.force:
+        if not opts.repo or not opts.context or not (opts.pull_number or opts.sha):
+            parser.error('--force requires --repo, --context, and one of --pull-number or --sha')
 
     api = github.GitHub(repo=opts.repo)
 
@@ -102,8 +108,8 @@ def main():
 
 
 # Prepare a human readable output
-def tests_human(priority, name, number, revision, ref, context, base, repo, bots_ref, github_context):
-    if not priority:
+def tests_human(priority, name, number, revision, ref, context, base, repo, bots_ref, github_context, options):
+    if not priority and not options.force:
         return
     try:
         priority = int(priority)
@@ -135,7 +141,7 @@ def tests_invoke(priority, name, number, revision, ref, context, base,
         priority = int(priority)
     except (ValueError, TypeError):
         priority = 0
-    if priority <= 0:
+    if priority <= 0 and not options.force:
         return
     current = time.strftime('%Y%m%d-%H%M%S')
     (image, _, scenario) = context.partition("/")
@@ -392,7 +398,7 @@ def scan_for_pull_tasks(api, contexts, opts, repo):
 
     if opts.human_readable:
         results.sort(reverse=True, key=lambda x: str(x))
-        return list([tests_human(*x) for x in results])
+        return list([tests_human(*x, options=opts) for x in results])
     if not opts.amqp:
         return list([tests_invoke(*x, options=opts) for x in results])
     with distributed_queue.DistributedQueue(opts.amqp, ['rhel', 'public']) as q:


### PR DESCRIPTION
Some improvements to `test-scan` to increase its usability as a local tool for queuing up test runs:

 - look for the secrets in the user's `XDG_RUNTIME_DIR` (aka "Martin mode")
 - make the `-c` flag more powerful: the given contexts are always considered, even if they're not present in the PR
 - drop the `-f`-bomb: ignore all checks and enqueue unconditionally.  Temper this potentially-explosive option by only allowing it to be used with a tightly-restricted scope.