### PR TITLE
images: install and use duperemove on fedora

### DIFF
--- a/images/scripts/fedora.setup
+++ b/images/scripts/fedora.setup
@@ -139,7 +139,7 @@ dnf remove -y kernel-headers
 # we only need cloud-init for the initial boot, afterwards it just slows down booting
 dnf remove -y cloud-init
 
-dnf $DNF_OPTS -y install mock dnf-plugins-core rpm-build
+dnf $DNF_OPTS -y install mock dnf-plugins-core rpm-build duperemove
 useradd -c Builder -G mock builder
 
 if [ "${IMAGE%-testing}" != "$IMAGE" ]; then

--- a/images/scripts/lib/zero-disk.setup
+++ b/images/scripts/lib/zero-disk.setup
@@ -47,6 +47,10 @@ rm -rf /var/tmp/*
 journalctl --relinquish-var || true
 rm -rf /var/log/journal/*
 
+if [ -x /usr/sbin/duperemove ]; then
+    /usr/sbin/duperemove -rd / || true
+fi
+
 if [ $(findmnt / -n -o fstype) != "btrfs" ]; then
   dd if=/dev/zero of=/root/junk || true
   sync


### PR DESCRIPTION
Fedora is using btrfs these days, and we often end up with several
copies of the same files installed (because of mock, and containers).

Install duperemove and use it with btrfs's deduplication features, to
reduce the size of our images.

 * [x] image-refresh fedora-36