### PR TITLE
s3: lowercase headers for S3 signing

### DIFF
--- a/lib/s3.py
+++ b/lib/s3.py
@@ -75,7 +75,8 @@ def sign_request(url: urllib.parse.ParseResult, method, headers, checksum) -> Di
 
     amzdate = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
 
-    headers = headers.copy()  # don't modify the user's copy, or the default
+    # Header canonicalisation demands all header names in lowercase
+    headers = {key.lower(): value for key, value in headers.items()}
     headers.update({'host': url.hostname, 'x-amz-content-sha256': checksum, 'x-amz-date': amzdate})
     headers_str = ''.join(f'{k}:{v}\n' for k, v in sorted(headers.items()))
     headers_list = ';'.join(sorted(headers))


### PR DESCRIPTION
According to the S3 documentation:

  https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html

CanonicalHeaders must be calculated with all-lowercase header names:

    CanonicalHeaders is a list of request headers with their values.
    Individual header name and value pairs are separated by the newline
    character ("\n"). Header names must be in lowercase. You must sort
    the header names alphabetically to construct the string.

All of the headers we were sending, until recently, were lowercase, but
s3-streamer sets a (very much non-lowercase) `Content-Type` header.

Linode was letting us get away with having uppercase headers, but MinIO
is stricter on this point.

Lowercase the names of our headers before signing them.