### PR TITLE
images: Pull registry container from Dockerhub

### DIFF
--- a/images/scripts/lib/podman-images.setup
+++ b/images/scripts/lib/podman-images.setup
@@ -5,5 +5,7 @@ if [ $(uname -m) = x86_64 ]; then
     # images for testing cockpit-podman
     podman pull quay.io/libpod/busybox
     podman pull quay.io/libpod/alpine
-    podman pull quay.io/cockpit/registry:2
+    podman pull docker.io/registry:2
+    # FIXME: once all images were rebuilt to pick up the docker image, change cockpit-podman's tests and drop the alias
+    podman tag docker.io/registry:2 quay.io/cockpit/registry:2
 fi


### PR DESCRIPTION
This is an official image, and thus not subject to pull limits any more.
Our copy on quay.io is over a year old and the security scanner looks
like a Christmas tree, so let's phase this out.

Re-tag the dockerhub image as quay.io/cockpit/registry:2 so that we
don't break cockpit-podman tests. Once all our images picked this up, we
can change the image name in the tests and drop the alias.

 * [ ] FAIL: image-refresh rhel-8-7
 * [ ] FAIL: image-refresh