### PR TITLE
setup-deploy-keys: Add cockpit release keys for website and ws container

### DIFF
--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -51,6 +51,14 @@ deploy_to cockpit-project/cockpit-weblate \
     --deploy-from \
         cockpit-project/cockpit/cockpit-weblate/DEPLOY_KEY
 
+deploy_to cockpit-project/cockpit-project.github.io \
+    --deploy-from \
+        cockpit-project/cockpit/release/WEBSITE_DEPLOY_KEY
+
+deploy_to cockpit-project/cockpit-container \
+    --deploy-from \
+        cockpit-project/cockpit/container-release/DEPLOY_KEY
+
 # cockpit-machines
 deploy_to cockpit-project/cockpit-machines \
     --deploy-from \


### PR DESCRIPTION
At the moment, cockpit's release (ab)use the Fedora SSH key to commit to
the cockpit-container repo (through release-dockerhub) and the website
(through release-guide). Let's replace these with proper deploy keys.

Updating the guide only depends on the source tarball, so this part can
and should stay in the primary release workflow -- hence, add it to the
release environment. 

Updating cockpit-container will have to wait for the COPR or Fedora koji
build to finish, and thus will likely happen asynchronously soon -- not
right inside the "release" workflow. In anticipation of that, put the
deploy key into a separate new "container-release" environment.

---

https://github.com/cockpit-project/cockpit/pull/17356 will make use of this, at least the website part. We could drop the cockpit-container key for now if you prefer, as I don't yet have a replacement for it.