### PR TITLE
setup-deploy-keys: move website to its own environment

### DIFF
--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -53,7 +53,7 @@ deploy_to cockpit-project/cockpit-weblate \
 
 deploy_to cockpit-project/cockpit-project.github.io \
     --deploy-from \
-        cockpit-project/cockpit/release/WEBSITE_DEPLOY_KEY
+        cockpit-project/cockpit/website/DEPLOY_KEY
 
 deploy_to cockpit-project/cockpit-container \
     --deploy-from \


### PR DESCRIPTION
The release workflow in Cockpit currently runs as a monolithic job under
the "release" environment.

cockpit-project/cockpit#17365 changes that, so that each part of the
process runs in its own environment and the "release" environment
no longer exists.

Install the deploy key for the website into the "website" environment
instead.



I didn't run this yet, and we shouldn't run it until we land cockpit-project/cockpit#17365.