### PR TITLE
image-download: Avoid walrus operator (quick alternative to #3430)

### DIFF
--- a/image-download
+++ b/image-download
@@ -86,7 +86,8 @@ def find(name, stores, latest, quiet):
         url = urllib.parse.urlparse(urllib.parse.urljoin(store, name))
 
         args = []
-        if ca := get_host_ca(url.netloc):
+        ca = get_host_ca(url.netloc)
+        if ca:
             args += ['--cacert', ca]
 
         # First, check if this is an S3 store for which we have a key


### PR DESCRIPTION
image-download is called in cockpit-machines tests, which also run on
RHEL/CentOS 8. This has a too old Python to recongnize the `:=`
operator, so replace it.

---

See [this machines c8s failure](https://artifacts.dev.testing-farm.io/98ac3343-6c32-4374-b3e8-c48312f7f750/)