### PR TITLE
s3-streamer: fix coverage url

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -190,7 +190,7 @@ let link_patterns = [
     {
         "label": "coverage",
         "pattern": "Code coverage report in ([A-Za-z0-9\\-\\.]+)$",
-        "url": "$1/"
+        "url": "$1/index.html"
     }
 ];
 


### PR DESCRIPTION
As s3 only saves objects and has no concept of directories we have to
link to the coverage report's index.html page.

See for example: 

https://cockpit-logs.us-east-1.linodeobjects.com/pull-17387-20220525-110025-0b536642-fedora-36-devel/log.html

The coverage report links to https://cockpit-logs.us-east-1.linodeobjects.com/pull-17387-20220525-110025-0b536642-fedora-36-devel/Coverage/ which is "404" it should be

https://cockpit-logs.us-east-1.linodeobjects.com/pull-17387-20220525-110025-0b536642-fedora-36-devel/Coverage/index.html