### PR TITLE
s3-streamer: don't append a slash to coverage report

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -190,7 +190,7 @@ let link_patterns = [
     {
         "label": "coverage",
         "pattern": "Code coverage report in ([A-Za-z0-9\\-\\.]+)$",
-        "url": "$1/"
+        "url": "$1"
     }
 ];
 


### PR DESCRIPTION
The coverage report link is a link to /Coverage/index.html so adding a
slash will make the link invalid.