### PR TITLE
images: Fix Debian image builds

### DIFF
--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -180,10 +180,9 @@ $APT --no-install-recommends install cockpit
 # Prepare for building
 #
 
-# extract control files and adjust them for our release, so that we can parse the build deps
+# extract control files, so that we can parse the build deps
 mkdir -p /tmp/out
 curl -L https://github.com/cockpit-project/cockpit/archive/main.tar.gz | tar -C /tmp/out --strip-components=1 --wildcards -zxf - '*/debian/'
-/tmp/out/tools/debian/adjust-for-release $(lsb_release -sc)
 
 # Disable build-dep installation for the real builds
 cat > ~/.pbuilderrc <<- EOF


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/commit/b86c149e65ea24 dropped
the adjust-for-release script. It is not necessary any more.

Fixes #3457

 - [ ] image-refresh debian-stable