### PR TITLE
images: Use last cloud image for bootstrapping, not first

### DIFF
--- a/images/scripts/arch.bootstrap
+++ b/images/scripts/arch.bootstrap
@@ -20,7 +20,7 @@
 set -eux
 
 URL='https://america.mirror.pkgbuild.com/images/latest/'
-IMAGE="$(curl -L -s "$URL" | grep -o '"Arch-Linux-x86_64-cloudimg-[^"]*.qcow2"' | tr -d '"' | head -n1)"
+IMAGE="$(curl -L -s "$URL" | grep -o '"Arch-Linux-x86_64-cloudimg-[^"]*.qcow2"' | tr -d '"' | tail -n1)"
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"

--- a/images/scripts/fedora-35.bootstrap
+++ b/images/scripts/fedora-35.bootstrap
@@ -20,7 +20,7 @@
 set -eux
 
 URL='https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/'
-IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"' | head -n1)"
+IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"' | tail -n1)"
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"

--- a/images/scripts/fedora-36.bootstrap
+++ b/images/scripts/fedora-36.bootstrap
@@ -20,7 +20,7 @@
 set -eux
 
 URL='https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/'
-IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"' | head -n1)"
+IMAGE="$(curl -L -s "$URL" | grep -o '"Fedora-Cloud-Base-[^"]*.qcow2"' | tr -d '"' | tail -n1)"
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"

--- a/images/scripts/fedora-rawhide.bootstrap
+++ b/images/scripts/fedora-rawhide.bootstrap
@@ -20,7 +20,7 @@
 set -eux
 
 URL='https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Cloud/x86_64/images/'
-IMAGE=$(curl -L -s "$URL"  | grep -o 'Fedora-Cloud-Base-Rawhide[^"]*qcow2' | tr -d '"' | head -n1)
+IMAGE=$(curl -L -s "$URL"  | grep -o 'Fedora-Cloud-Base-Rawhide[^"]*qcow2' | tr -d '"' | tail -n1)
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"


### PR DESCRIPTION
The last line in the directory listing is usually the most recent one,
and the first might be gone from the mirrors already.

 * [x] image-refresh fedora-36