### PR TITLE
task: Treat SSLEOFError as transient failure

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -25,6 +25,7 @@ import logging
 import os
 import re
 import socket
+from ssl import SSLEOFError
 import subprocess
 import time
 import urllib.parse
@@ -215,7 +216,7 @@ class GitHub(object):
                 if response.status != HTTPStatus.BAD_GATEWAY:
                     # success!
                     break
-            except (ConnectionResetError, http.client.BadStatusLine, socket.error) as e:
+            except (ConnectionResetError, http.client.BadStatusLine, socket.error, SSLEOFError) as e:
                 logging.warning(f"Transient error during GitHub request, attempt #{retry}: {e}")
 
             self.conn = None


### PR DESCRIPTION
Recently this started to happen annoyingly often:

   ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:2396)

This is some transient networking flake or GitHub protocol error. This
breaks otherwise successful image builds+uplodas or test runs at the
very last moment when posting the result to GitHub, and requires manual
retries, which is too expensive.

Fixes #3474

---

Note that I did not test this extensively, i. e. I didn't try this on production. I hope that the integtration test and my image refresh prove that the reworked GitHub.request() still works in general. If I keep seeing these errors, I will of course follow up.