### PR TITLE
Move prometheus export to S3

### DIFF
--- a/image-prune
+++ b/image-prune
@@ -212,12 +212,6 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
 
     if args.s3:
-        if args.s3.scheme != 'https':
-            sys.exit("S3 args must be https")
-
-        if not s3.is_key_present(args.s3):
-            sys.exit(f"No key found for {args.s3.hostname}")
-
         collection = S3ImageStore(args.s3)
 
     else:

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -72,7 +72,12 @@ def sign_request(url: urllib.parse.ParseResult, method, headers, checksum) -> Di
     If the method is PUT then the checksum of the data to be uploaded must be provided.
     @headers, if given, are a dict of additional headers to be signed (eg: `x-amz-acl`)
     """
-    access_key, secret_key = get_key(url.hostname)
+    if url.scheme != 'https':
+        sys.exit("S3 URLs must be https")
+    try:
+        access_key, secret_key = get_key(url.hostname)
+    except TypeError:
+        sys.exit(f"No key found for {url.hostname}")
 
     amzdate = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
 

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -25,3 +25,5 @@ PUBLIC_STORES = [
 REDHAT_STORES = [
     "https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com/images/",
 ]
+
+LOG_STORE = "https://cockpit-logs.us-east-1.linodeobjects.com/"

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -34,6 +34,8 @@ HOUR = 3600
 def main():
     parser = argparse.ArgumentParser(description='Generate infrastructure and test statistics')
     parser.add_argument("--db", default="test-results.db", help="Database name")
+    parser.add_argument("--s3", metavar="URL", type=urllib.parse.urlparse,
+                        help="Upload generated file to given S3 URL")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     opts = parser.parse_args()
 
@@ -198,9 +200,13 @@ merged_failures {merged_failures}
         for uri, size in space_usage.items():
             output += f's3_usage_bytes{{store="{uri}"}} {size}\n'
 
-    print(output)
-
     db_conn.close()
+
+    print(output)
+    if opts.s3:
+        with s3.urlopen(opts.s3, data=output.encode("UTF-8"), method="PUT",
+                        headers={"Content-Type": "text/plain", s3.ACL: s3.PUBLIC}):
+            pass
 
     return 0
 

--- a/run-queue
+++ b/run-queue
@@ -31,6 +31,7 @@ import pika
 
 from lib.directories import get_images_data_dir
 from lib.network import redhat_network
+from lib.stores import LOG_STORE
 from task import distributed_queue
 
 logging.basicConfig(level=logging.INFO)
@@ -65,9 +66,8 @@ def consume_webhook_queue(channel, amqp):
         elif action == 'closed' and pull_request.get('merged', False):
             sha = pull_request['head']['sha']
             db = os.path.join(get_images_data_dir(), "test-results.db")
-            data = os.path.join(get_images_data_dir(), "prometheus")
-            cmd = "./store-tests --db {0} --repo {1} {2} && ./prometheus-stats --db {0} > {3}".format(
-                db, repo, sha, data)
+            cmd = (f"./store-tests --db {db} --repo {repo} {sha} && "
+                   f"./prometheus-stats --db {db} --s3 {LOG_STORE}/prometheus")
             body = {
                 "command": cmd,
             }

--- a/s3-streamer
+++ b/s3-streamer
@@ -34,6 +34,7 @@ import time
 import urllib.parse
 
 from lib.constants import LIB_DIR
+from lib.stores import LOG_STORE
 from lib import s3
 from task import github
 
@@ -273,7 +274,7 @@ def main():
         destination = LocalDestination(os.path.join(args.directory, subdir))
         status = LocalStatus(destination.directory)
     else:
-        url = args.s3 or os.getenv('S3_LOGS_URL') or 'https://cockpit-logs.us-east-1.linodeobjects.com/'
+        url = args.s3 or os.getenv('S3_LOGS_URL', LOG_STORE)
         destination = S3Destination(urllib.parse.urljoin(url, subdir))
         status = GitHubStatus(args.repo, args.revision, args.github_context, destination.directory + 'log.html')
 

--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -56,7 +56,8 @@ arguments = {
         "x-max-priority": MAX_PRIORITY
     },
     'statistics': {
-        "x-max-priority": MAX_PRIORITY
+        "x-max-priority": MAX_PRIORITY,
+        "x-single-active-consumer": True,
     },
 }
 


### PR DESCRIPTION
This still leaves the test results database, but I'd like to do this in baby steps in case I break anything.

I tested this by temporarily installing the log S3 key, and running

    ./prometheus-stats --db /tmp/test-results.db  --s3 https://cockpit-logs.us-east-1.linodeobjects.com/prometheus

https://cockpit-logs.us-east-1.linodeobjects.com/prometheus exists now. I uploaded several versions (with small changes) to confirm that updates work fine, and the ETag/LastModified in https://cockpit-logs.us-east-1.linodeobjects.com/ update as expected.

After this lands:
 - [ ] Redeploy webhook pod, so that the new RabbitMQ single-consumer action becomes effective
 - [ ] Adjust cockpituous metrics config to pull from S3 instead of CentOS CI: https://github.com/cockpit-project/cockpituous/pull/500
 - [ ] Adjust internal OSCI prometheus to pull from S3 instead of CentOS CI