### PR TITLE
testmap: update subscription-manager entries

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -139,7 +139,7 @@ REPO_BRANCH_CONTEXT = {
     },
     'candlepin/subscription-manager': {
         'main': [
-            'rhel-8-6',
+            'rhel-8-7',
             'rhel-9-0',
             'rhel-9-1',
             'fedora-36',
@@ -148,6 +148,7 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-4',
             'rhel-8-5',
             'rhel-8-6',
+            'rhel-8-7',
         ],
         'subscription-manager-1.28.21': [
             'rhel-8-5',
@@ -159,7 +160,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-9-0',
         ],
         '_manual': [
-            'rhel-8-7',
         ],
     },
     'candlepin/subscription-manager-cockpit': {
@@ -171,7 +171,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'centos-8-stream/subscription-manager-1.28',
-            'rhel-8-6/subscription-manager-1.28',
             'rhel-8-7',
             'rhel-8-7/subscription-manager-1.28',
         ],
@@ -223,7 +222,7 @@ IMAGE_REFRESH_TRIGGERS = {
         "debian-stable@cockpit-project/cockpit",
         "rhel-9-1@cockpit-project/cockpit",
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",
-        "rhel-8-6@candlepin/subscription-manager",
+        "rhel-8-7@candlepin/subscription-manager",
         "rhel-9-1@candlepin/subscription-manager-cockpit",
     ]
 }


### PR DESCRIPTION
- replace rhel-8-6 with rhel-8-7 for subscription-manager/main, to make
  sure to check backports to RHEL 8 (which are going first to 8.7
- remove rhel-8-7 from _manual, no more needed there
- add rhel-8-7 for subscription-manager/subscription-manager-1.28, as
  that is the target of that branch
- remove rhel-8-6/subscription-manager-1.28 from
  subscription-manager-cockpit, as it will not get in that version
- switch the services trigger to rhel-8-7, as it's the development
  version

The new combinations were tested successfully:
- https://cockpit-logs.us-east-1.linodeobjects.com/pull-3074-20220615-094740-686edabc-rhel-8-7/log.html
- https://cockpit-logs.us-east-1.linodeobjects.com/pull-3072-20220615-094746-4532c6b7-rhel-8-7/log.html