### PR TITLE
run-queue: Fix prometheus URL

### DIFF
--- a/run-queue
+++ b/run-queue
@@ -67,7 +67,7 @@ def consume_webhook_queue(channel, amqp):
             sha = pull_request['head']['sha']
             db = os.path.join(get_images_data_dir(), "test-results.db")
             cmd = (f"./store-tests --db {db} --repo {repo} {sha} && "
-                   f"./prometheus-stats --db {db} --s3 {LOG_STORE}/prometheus")
+                   f"./prometheus-stats --db {db} --s3 {os.path.join(LOG_STORE, 'prometheus')}")
             body = {
                 "command": cmd,
             }


### PR DESCRIPTION
Commit 6c5fa61e83331 mis-constructed the S3 URL for the prometheus
export: It ended up having two adjacent slashes, which is invalid for S3
and resulted in a 403 error.

Robustify this by using `os.path.join()` instead, which gets along with
or without a trailing slash in LOG_STORE.

----

I noticed today that our new [prometheus S3 export](https://cockpit-logs.us-east-1.linodeobjects.com/) still was at the original version that I initially deployed last week. The [pod log](https://console-openshift-console.apps.ocp.ci.centos.org/api/kubernetes/api/v1/namespaces/frontdoor/pods/centosci-tasks-dbxc7/log?container=cockpit-tasks) said why:
```
INFO:root:Consuming message with command: ./store-tests --db /cache/images/test-results.db --repo cockpit-project/cockpit 5a520ed3cd06c9bfd4475fe1367650324609b378 && ./prometheus-stats --db /cache/images/test-results.db --s3 https://cockpit-logs.us-east-1.linodeobjects.com//prometheus
[...]
Traceback (most recent call last):
  File "/work/bots/./prometheus-stats", line 215, in <module>
    sys.exit(main())
  File "/work/bots/./prometheus-stats", line 207, in main
    with s3.urlopen(opts.s3, data=output.encode("UTF-8"), method="PUT",
  File "/work/bots/lib/s3.py", line 117, in urlopen
    response = urllib.request.urlopen(request, context=host_ssl_context(url.netloc))
  File "/usr/lib64/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.10/urllib/request.py", line 525, in open
    response = meth(req, response)
  File "/usr/lib64/python3.10/urllib/request.py", line 634, in http_response
    response = self.parent.error(
  File "/usr/lib64/python3.10/urllib/request.py", line 563, in error
    return self._call_chain(*args)
  File "/usr/lib64/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.10/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
ERROR:root:./store-tests --db /cache/images/test-results.db --repo cockpit-project/cockpit 5a520ed3cd06c9bfd4475fe1367650324609b378 && ./prometheus-stats --db /cache/images/test-results.db --s3 https://cockpit-logs.us-east-1.linodeobjects.com//prometheus failed with exit code 1
```

I manually ran that commit with fixing the `//` to `/` in the URL, and it succeeded and updated the file.

```
>>> import os
>>> os.path.join('https://cockpit-logs.us-east-1.linodeobjects.com/', 'prometheus')
'https://cockpit-logs.us-east-1.linodeobjects.com/prometheus'
>>> os.path.join('https://cockpit-logs.us-east-1.linodeobjects.com', 'prometheus')
'https://cockpit-logs.us-east-1.linodeobjects.com/prometheus'
```