### PR TITLE
testmap: Drop cockpit container-bastion test

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -36,7 +36,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-36',
             f'{TEST_OS_DEFAULT}/devel',
             f'{TEST_OS_DEFAULT}/firefox',
-            f'{TEST_OS_DEFAULT}/container-bastion',
             'fedora-coreos',
             'rhel-8-7',
             'rhel-8-7-distropkg',


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/17457 made this
container and the corresponding test obsolete.