### PR TITLE
Export more info to the test processes

### DIFF
--- a/s3-streamer
+++ b/s3-streamer
@@ -294,8 +294,9 @@ def main():
         index = Index(destination)
         attachments_directory = AttachmentsDirectory(index, tmpdir)
         log_uploader = ChunkedUploader(index, 'log')
+        env = dict(os.environ, TEST_ATTACHMENTS=tmpdir, TEST_ATTACHMENTS_URL=destination.directory)
 
-        with subprocess.Popen(args.cmd, env=dict(os.environ, TEST_ATTACHMENTS=tmpdir),
+        with subprocess.Popen(args.cmd, env=env,
                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                               stdin=subprocess.DEVNULL, pipesize=max_pipe_size) as process:
             # We want non-blocking reads so that we can send attachments and

--- a/tests-invoke
+++ b/tests-invoke
@@ -77,6 +77,9 @@ def main():
             entry_point = alt_entry_point
         cmd = ["timeout", "120m", entry_point]
 
+        os.environ["TEST_REVISION"] = opts.revision
+        os.environ["TEST_PULL"] = str(opts.pull_number)
+
         p = subprocess.Popen(cmd)
         while p.poll() is None:
             # Cancel test if PR gets updated while running


### PR DESCRIPTION
So that the test run itself might post review comments that contain
links to attached files.