### PR TITLE
setup-deploy-keys: Add weblate deploy key for cockpit-composer

### DIFF
--- a/github-upload-secrets
+++ b/github-upload-secrets
@@ -112,7 +112,7 @@ def upload_deploy_key(api, repo, title, content, opts):
     else:
         # delete all existing keys
         keys = api.get(keys_path)
-        for key in keys:
+        for key in (keys or []):
             key_id = key['id']
             key_path = f'{keys_path}/{key_id}'
             if opts.dry_run or opts.verbose:

--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -82,6 +82,12 @@ deploy_to cockpit-project/cockpit-podman-weblate \
     --deploy-from \
         cockpit-project/cockpit-podman/cockpit-podman-weblate/DEPLOY_KEY
 
+# cockpit-composer
+
+deploy_to osbuild/cockpit-composer-weblate \
+    --deploy-from \
+        osbuild/cockpit-composer/cockpit-composer-weblate/DEPLOY_KEY
+
 # shared
 deploy_to cockpit-project/node-cache \
     --deploy-from \


### PR DESCRIPTION
See https://github.com/osbuild/cockpit-composer/pull/1436

----

I can't roll this out myself, as I am not an administrator of https://github.com/osbuild/cockpit-composer-weblate . @jkozol , @larskarlitski , @marusak , is any of you? If yes, can you please make me an admin temporarily? Or, if you are an admin of cockpit-composer itself, please run this command from bots:

    ./github-upload-secrets -n --deploy-to osbuild/cockpit-composer-weblate --deploy-from osbuild/cockpit-composer/cockpit-composer-weblate/DEPLOY_KEY

This will unblock https://github.com/osbuild/cockpit-composer/pull/1436 which will in turn improve translation handling and unblock secrets cleanup.

