### PR TITLE
workflows: Run image-trigger earlier

### DIFF
--- a/.github/workflows/image-trigger.yml
+++ b/.github/workflows/image-trigger.yml
@@ -1,7 +1,8 @@
 name: image refresh trigger
 on:
   schedule:
-    - cron: '30 1 * * *'
+    # this is UTC-4
+    - cron: '30 22 * * *'
   # can be run manually on https://github.com/cockpit-project/bots/actions
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
In practice, this trigger runs every day around 03:30 UTC, just before
the early birds on the team wake up. Hence the tests are usually still
in progress in our mornings. The intention is that they run over the
European night, ready to land (or be investigated) in the morning.

It looks like the scheduler's timezone is UTC-2, not UTC (as the docs
say), so set back our timer by 3 hours -- this is then a reasonable
start in all of UTC-{0..4}.

----

See the start times on https://github.com/cockpit-project/bots/actions/workflows/image-trigger.yml