### PR TITLE
naughty: Add pattern for Fedora 37 targetcli crash

### DIFF
--- a/naughty/fedora-37/3574-targetcli-getargspec-crash
+++ b/naughty/fedora-37/3574-targetcli-getargspec-crash
@@ -1,0 +1,3 @@
+module 'inspect' has no attribute 'getargspec'
+*targetcli*
+*returned non-zero exit status 1.


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2102058
Known issue #3574

---

I tested that locally with `bots/test-failure-policy -o fedora-37 < /tmp/out` against the [log](https://artifacts.dev.testing-farm.io/278549d8-c609-44d7-a85f-5907bb987e86/) from https://github.com/cockpit-project/cockpit-machines/pull/748