### PR TITLE
naughty: #2787 now affects CentOS 8

### DIFF
--- a/naughty/rhel-8/2787-selinux-ioctl-iptables-containers
+++ b/naughty/rhel-8/2787-selinux-ioctl-iptables-containers
@@ -1,0 +1,1 @@
+avc:  denied  { ioctl } for * comm="iptables" path="/var/lib/containers/storage/*" dev="overlay" * scontext=unconfined_u:system_r:iptables_t:* tcontext=system_u:object_r:container_file_t:s0:*


### PR DESCRIPTION
See [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17500-20220712-134830-92565072-centos-8-stream/log.html#51). I [cloned the downstream bug for c8s](https://bugzilla.redhat.com/show_bug.cgi?id=2106396)  and [updated the naughty](https://github.com/cockpit-project/bots/issues/2787).