### PR TITLE
HACKING.md: Cleanups, update test invocation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [pull_request]
 jobs:
   bots:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/cockpit-project/unit-tests
       options: --user root
@@ -16,7 +16,7 @@ jobs:
         run: test/run
 
   cockpituous:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       # enough permissions for tests-scan to work
       pull-requests: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,4 +74,4 @@ jobs:
               branch="${GITHUB_REF##*/}"
           fi
           cd cockpituous
-          sudo COCKPIT_BOTS_REPO=$repo COCKPIT_BOTS_BRANCH=$branch tasks/run-local.sh ${pr_args:-}
+          COCKPIT_BOTS_REPO=$repo COCKPIT_BOTS_BRANCH=$branch tasks/run-local.sh ${pr_args:-}

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,26 +1,12 @@
 # Hacking on the Cockpit Bots
 
-These are automated bots and testing that works on the Cockpit project. This
-includes updating operating system images, bringing in changes from other
-projects, releasing Cockpit and more.
+Most bots are python scripts. Shared code is in the tasks/ directory.
 
-## Environment for the bots
+## Environment
 
 The bots work in containers that are built in the [cockpituous](https://github.com/cockpit-project/cockpituous)
-repository. New dependencies should be added there in the `tests/Dockerfile`
+repository. New dependencies should be added there in the `tasks/Dockerfile`
 file in that repository.
-
-## Invoking the bots
-
- 1. The containers in the `cockpitous` repository invoke the `.tasks` file
-at root of this repository.
- 1. The ```.tasks``` file prints out a list of possible tasks on standard out.
- 1. The printed tasks are sorted in alphabetical reverse order, and one of the
-first items in the list is executed.
-
-## The bots themselves
-
-Most bots are python scripts. Shared code is in the tasks/ directory.
 
 ## Bots filing issues
 


### PR DESCRIPTION
Drop obsolete documentation for .tasks files, and the redundant and
outdated "what is this" -- the latter is better described in README.md.
    
Fix container definition path in cockpituous repo.

-----

This is mostly an excuse to run the integration tests. The container build broke in cockpituous. The actual test will likely work, but I want to make some cleanups there as well.