### PR TITLE
Image refresh for fedora-testing

### DIFF
--- a/images/fedora-testing
+++ b/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-580ef3be1de1cd79a0faf250b9cd58f7cc8dac47138fe4da9e65a2950562224d.qcow2
+fedora-testing-18c1b4e6af887ca01ebd412f1a5d6fb6ca8f59239da13876a21a2d29fbb32467.qcow2


### PR DESCRIPTION
Image refresh for fedora-testing
 * [x] image-refresh fedora-testing
 * [ ] Retract or fix selinux-policy regression in https://bodhi.fedoraproject.org/updates/FEDORA-2022-320775eb9a