### PR TITLE
github-upload-secrets: Fix TypeError crash when uploading environment

### DIFF
--- a/github-upload-secrets
+++ b/github-upload-secrets
@@ -189,7 +189,7 @@ def main():
     if opts.deploy_to and not re.fullmatch(REPO_RE, opts.deploy_to, re.I):
         parser.error('--deploy-to specifies an invalid repository name')
 
-    if not all(re.fullmatch(DEPLOY_FROM_RE, df) for df in opts.deploy_from):
+    if opts.deploy_from and not all(re.fullmatch(DEPLOY_FROM_RE, df) for df in opts.deploy_from):
         parser.error('--deploy-from specifies an invalid OWNER/REPO/ENV/SECRET quad')
 
     if opts.directory:


### PR DESCRIPTION
When uploading a directory as environment, i.e. when not specifying
`--deploy-from`, the script crashed with

```
  File "/var/home/martin/upstream/bots/./github-upload-secrets", line 192, in main
    if not all(re.fullmatch(DEPLOY_FROM_RE, df) for df in opts.deploy_from):
TypeError: 'NoneType' object is not iterable
```