### PR TITLE
Store test coverage

### DIFF
--- a/store-tests
+++ b/store-tests
@@ -153,8 +153,17 @@ def main():
 
                 with urllib.request.urlopen(raw_log,
                                             context=host_ssl_context(urllib.parse.urlparse(raw_log).netloc)) as fp:
-                    for (testname, failed, retry_reason, seconds) in find_tests(fp):
+                    data = fp.readlines()
+                    for (testname, failed, retry_reason, seconds) in find_tests(data):
                         insert_test(cursor, run_id, testname, failed, retry_reason, seconds)
+
+                    # Find coverage line - normally second to last line, so check only last 20 lines
+                    for line in data[-20:]:
+                        if b"Overall line coverage: " in line:
+                            coverage_str = line.split(b"Overall line coverage: ")[1].strip()
+                            coverage = float(coverage_str.strip(b"%"))
+                            insert_coverage(cursor, run_id, coverage)
+                            break
 
     db_conn.commit()
     db_conn.close()
@@ -183,6 +192,11 @@ def init_db(cursor):
                      seconds INTEGER NOT NULL,
                      FOREIGN KEY (run) REFERENCES TestRuns(id))
                    """)
+    cursor.execute("""CREATE TABLE if not exists TestCoverage
+                    (coverage REAL,
+                     run INTEGER NOT NULL,
+                     FOREIGN KEY (run) REFERENCES TestRuns(id))
+                   """)
 
 
 def insert_run(cursor, project, revision, context, url, time, retry, waited, took, state, desc):
@@ -193,6 +207,10 @@ def insert_run(cursor, project, revision, context, url, time, retry, waited, too
 def insert_test(cursor, run_id, testname, failed, retry_reason, seconds):
     cursor.execute("INSERT INTO Tests VALUES (?, ?, ?, ?, ?)",
                    (testname, retry_reason, int(failed), run_id, int(seconds)))
+
+
+def insert_coverage(cursor, run_id, coverage):
+    cursor.execute("INSERT INTO TestCoverage VALUES (?, ?)", (coverage, run_id))
 
 
 def find_tests(fp):


### PR DESCRIPTION
Creating a new table so that we don't need to migrate the current table.

Needs https://github.com/cockpit-project/cockpit/pull/17586

Running `./store-tests --repo cockpit-project/cockpit d48dca62da41978cf409ed6d9d01e3880c01eeca` (this is sha for https://github.com/cockpit-project/cockpit/pull/17586) it creates:

```
sqlite> select * from TestCoverage;
87.7|8

sqlite> select * from TestRuns;
1|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|arch|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-arch/log.html|1658479558|0|8|1290|success|
2|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|debian-stable|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-debian-stable/log.html|1658479559|0|26|1715|success|
3|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|debian-testing|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-debian-testing/log.html|1658479559|0|30|1898|success|
4|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|ubuntu-2204|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-ubuntu-2204/log.html|1658479559|0|45|4132|failure|
5|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|ubuntu-stable|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-ubuntu-stable/log.html|1658479559|0|51|1890|success|
6|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|fedora-35|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-fedora-35/log.html|1658479560|0|59|2795|success|
7|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|fedora-36|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-fedora-36/log.html|1658479560|0|79|2916|success|
8|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|fedora-36/devel|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-fedora-36-devel/log.html|1658479560|0|87|3328|success|
9|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|fedora-36/firefox|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-fedora-36-firefox/log.html|1658479560|0|4|2629|success|
10|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|fedora-coreos|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-fedora-coreos/log.html|1658479561|0|86|1959|success|
11|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|rhel-8-7|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-rhel-8-7/log.html|1658479561|0|5|2811|success|
12|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|rhel-8-7-distropkg|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-rhel-8-7-distropkg/log.html|1658479561|0|11|1344|success|
13|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|centos-8-stream|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-centos-8-stream/log.html|1658479562|0|86|3418|success|
14|cockpit-project/cockpit|d48dca62da41978cf409ed6d9d01e3880c01eeca|rhel-9-1|https://cockpit-logs.us-east-1.linodeobjects.com/pull-17586-20220722-084603-d48dca62-rhel-9-1/log.html|1658479562|0|17|2871|success|

```