### PR TITLE
lib: Temporarily drop cockpit-11 internal store

### DIFF
--- a/lib/stores.py
+++ b/lib/stores.py
@@ -23,7 +23,8 @@ PUBLIC_STORES = [
 
 # hosted behind the Red Hat VPN
 REDHAT_STORES = [
-    "https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com/images/",
+    # e2e down for maintenance
+    # "https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com/images/",
 ]
 
 LOG_STORE = "https://cockpit-logs.us-east-1.linodeobjects.com/"


### PR DESCRIPTION
e2e has been down since last Friday due to some prolonged maintenance.
This causes all image refreshes to fail because running image-prune on
the store fails. We don't really want to ignore these failures, as
otherwise we could silently pile up lots of images and break our quota
eventually.

----

See [this log](https://logs.cockpit-project.org/logs/image-refresh-3650-20220723-224242/log) for an example refresh failure.