### PR TITLE
testmap: Drop cockpit rhel-9.0 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -46,9 +46,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-7-9',
             'centos-7',
         ],
-        'rhel-9.0': [
-            'rhel-9-0',
-        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-testing',
@@ -179,7 +176,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'rhel-8-7',
-            'rhel-9-0',
             'rhel-9-1',
             'centos-8-stream',
             'fedora-36',


### PR DESCRIPTION
We are trying to lose the rhel-9-0 image at some point.

The rhel-9.0 cockpit branch was just created for updating translations,
but is not interesting any more.

Drop `rhel-9-0` from cockpit-subscription's manual tests.