### PR TITLE
lib: Fix TAP parsing of initialization section

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -209,10 +209,22 @@ function extract(text) {
         first = parseInt(m[1], 10);
         last = parseInt(m[2], 10);
         total = last-first+1;
+        const test_start_offset = m.index + m[0].length + 1;
+        const text_init = text.slice(0, test_start_offset);
+        const text_tests = text.slice(test_start_offset);
         const t = tap_total_time.exec(text);
         if (t) {
             total_test_time = Math.ceil(parseInt(t[2], 10) / 60);
         }
+
+        const init_entry = { idx: 0,
+                             id: "initialization",
+                             title: "initialization",
+                             passed: true,
+                             links: [],
+                             text: text_init,
+                           };
+        entries.push({ idx: init_entry.idx, entry: init_entry, html: Mustache.render(entry_template, init_entry) });
 
         passed = 0;
         failed = 0;
@@ -223,9 +235,9 @@ function extract(text) {
         const segments = [];
         let last_offset = 0;
         // tap_result RE marks the *end* of a test, so test output is everything until, and including, the match
-        for (const m of text.matchAll(tap_result)) {
+        for (const m of text_tests.matchAll(tap_result)) {
             const offset = m.index + m[0].length;
-            segments.push(text.slice(last_offset, offset + 1));
+            segments.push(text_tests.slice(last_offset, offset + 1));
             last_offset = offset;
         }
 
@@ -243,14 +255,7 @@ function extract(text) {
                           interesting: false,
                           links: [],
                           text: segment};
-            if (m = tap_range.exec(segment)) {
-                entry.idx = 0;
-                entry.id = "initialization"
-                entry.title = entry.id;
-                // hide this by default
-                // maybe we can have better criteria?
-                entry.passed = true;
-            } else if (m = tap_result.exec(segment)) {
+            if (m = tap_result.exec(segment)) {
                 entry.idx = m[2];
                 entry.id = m[2];
                 let r = 0;


### PR DESCRIPTION
The "initialization" section ought to be everything up to the TAP
initializer (1..N), i.e. the matching offset of `tap_range`).

But this never happened, instead we just considered the first segment of
`tap_result` as the initialization. This worked reasonably well until
commit 3a90fb073230, which changed what `tap_result` matched on. As a
result, the first test result appeared inside the "initialization"
segment, and was hidden from the total result as well.

Clean this up and robustify it: The "initialization" segment is special
enough (different values, different regex) to treat it in its own code
path. Split the text on `tap_range` first, consider everything up to that as
"initialization", and everything after that as TAP tests.

----

This can be seen on recent test results. It is particularly pronounced for projects with few tests, such as [this sub-man run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-3640-20220725-054847-36fcfd65-rhel-8-6-candlepin-subscription-manager-subscription-manager-1.28.29/log.html), but it happens everywhere -- e.g. [this cockpit run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17579-20220720-160952-0320ae8a-fedora-35/log.html) is also missing a bit on the progress bar. Opening the "initialization" section shows the missing first test.

I tested this locally on the two raw log files, with symlinking in log.html and running `python3 -m http.server`. I'll also trigger two tests here, but the results will still have broken html as s3-streamer always runs from main.