### PR TITLE
task: Switch over main AMQP server to AWS

### DIFF
--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -43,10 +43,8 @@ BASELINE_PRIORITY = 5
 MAX_PRIORITY = 9
 # see https://github.com/cockpit-project/cockpituous/blob/main/tasks/cockpit-tasks-webhook.yaml
 DEFAULT_SECRETS_DIR = '/run/secrets/webhook'
-# main deployment on CentOS CI
-DEFAULT_AMQP_SERVER = 'amqp-frontdoor.apps.ocp.ci.centos.org:443'
-# fallback deployment on AWS
-# DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
+# main deployment on AWS
+DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
 
 arguments = {
     'rhel': {


### PR DESCRIPTION
Our CentOS CI project will go away soon, so let's move to an EC2
instance as our primary webhook/queue. See
https://github.com/cockpit-project/cockpituous/pull/509

 - Land together with https://github.com/cockpit-project/cockpituous/pull/509 and updating all projects webhooks in their settings.