### PR TITLE
lib: Bring back support for per-user image-stores

### DIFF
--- a/lib/s3.py
+++ b/lib/s3.py
@@ -52,7 +52,7 @@ def get_key(hostname):
                 access, secret = fp.read().split()
                 return access, secret
         except ValueError:
-            print('ignoring invalid content of {s3_key_dir}/{hostname}', file=sys.stderr)
+            print(f'ignoring invalid content of {s3_key_dir}/{hostname}', file=sys.stderr)
         except FileNotFoundError:
             pass
         _, _, hostname = hostname.partition('.')  # strip a leading component

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -72,8 +72,8 @@ def sign_request(url: urllib.parse.ParseResult, method, headers, checksum) -> Di
     If the method is PUT then the checksum of the data to be uploaded must be provided.
     @headers, if given, are a dict of additional headers to be signed (eg: `x-amz-acl`)
     """
-    if url.scheme != 'https':
-        sys.exit("S3 URLs must be https")
+    if url.scheme not in ['http', 'https']:
+        sys.exit("S3 URLs must be http(s)")
     try:
         access_key, secret_key = get_key(url.hostname)
     except TypeError:

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+from lib.directories import xdg_config_home
+
 # hosted on public internet
 PUBLIC_STORES = [
     "https://cockpit-images.eu-central-1.linodeobjects.com/",
@@ -26,5 +28,13 @@ REDHAT_STORES = [
     # e2e down for maintenance
     # "https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com/images/",
 ]
+
+# local stores
+try:
+    with open(xdg_config_home('cockpit-dev', 'image-stores'), 'r') as fp:
+        PUBLIC_STORES += fp.read().strip().split("\n")
+except FileNotFoundError:
+    pass
+
 
 LOG_STORE = "https://cockpit-logs.us-east-1.linodeobjects.com/"


### PR DESCRIPTION
With our PSI OpenStack cluster arised the need for a local image store
for caching. These instances don't have any DNS name nor stable IPs, nor 
are they supposed to be used outside the PSI cluster. So we don't want
to add them to the static PUBLIC_STORES list.

Instead, we will write them to ~/.config/cockpit-dev/image-stores.
Support for that was dropped in commit 9afc3e6da30f; reintroduce this,
but in a way that it also applies to image-upload: Whenever we build an
image on PSI, we want to upload it to the local image store right away,
as that is by far the shortest and fastest round-trip.

---

This will be used in https://github.com/cockpit-project/cockpituous/pull/513 . That is already rolled out on rhos-01-1. I tested this on rhos-01-2. All instances now have the secret for that store, and the config:

```
$ cat ~/.config/cockpit-dev/image-stores 
http://10.0.190.195/images/

$ git clone -b image-store-config https://github.com/cockpit-project/bots b2; cd b2

$ ./image-upload --store http://10.0.190.195/images/ cirros
Uploading to http://10.0.190.195/images/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2

$ ./image-download cirros
 ✔ https://cockpit-images.eu-central-1.linodeobjects.com/ (authenticated)
 ✔ https://cockpit-images.us-east-1.linodeobjects.com/ (authenticated)
 ✔ http://10.0.190.195/images/ (authenticated)
❯❯ http://10.0.190.195/images/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2
################################################################################################################################# 100.0%
```
The download appears instantaneous, it's really fast. As opposed to some tests yesterday, where downloading from the US Linode took *45 minutes*!


 * [x] image-refresh fedora-coreos