### PR TITLE
Revert "naughty: Close 2955: Creating a file system on a loop device fails: Call failed: Error wiping newly created partition /dev/loop12p1: Failed to open the device '/dev/loop12p1'"

### DIFF
--- a/naughty/arch/2955-udisks-loop-partition
+++ b/naughty/arch/2955-udisks-loop-partition
@@ -1,0 +1,3 @@
+> warning: Error wiping newly created partition /dev/loop*: Failed to open the device '/dev/loop*'
+*
+  File "*test/verify/check-storage*

--- a/naughty/debian-testing/2955-udisks-loop-partition
+++ b/naughty/debian-testing/2955-udisks-loop-partition
@@ -1,0 +1,3 @@
+> warning: Error wiping newly created partition /dev/loop*: Failed to open the device '/dev/loop*'
+*
+  File "*test/verify/check-storage*

--- a/naughty/fedora-35/2955-udisks-loop-partition
+++ b/naughty/fedora-35/2955-udisks-loop-partition
@@ -1,0 +1,3 @@
+> warning: Error wiping newly created partition /dev/loop*: Failed to open the device '/dev/loop*'
+*
+  File "*test/verify/check-storage*

--- a/naughty/fedora-36/2955-udisks-loop-partition
+++ b/naughty/fedora-36/2955-udisks-loop-partition
@@ -1,0 +1,3 @@
+> warning: Error wiping newly created partition /dev/loop*: Failed to open the device '/dev/loop*'
+*
+  File "*test/verify/check-storage*

--- a/naughty/rhel-9/2955-udisks-loop-partition
+++ b/naughty/rhel-9/2955-udisks-loop-partition
@@ -1,0 +1,3 @@
+> warning: Error wiping newly created partition /dev/loop*: Failed to open the device '/dev/loop*'
+*
+  File "*test/verify/check-storage*


### PR DESCRIPTION
Still happens on the Testing Farm.

Reverts b2259f9957e70876a8983fa169ad965fbdd7aa57