### PR TITLE
Revert "naughty: Close 2976: virsh vol-create-as loop-disk fails: Storage volume not found: no storage vol with matching path '/dev/loopNp1'"

### DIFF
--- a/naughty/arch/2976-virsh-loop-pool-nodev
+++ b/naughty/arch/2976-virsh-loop-pool-nodev
@@ -1,0 +1,4 @@
+error: Failed to create vol loop0p1
+error: Storage volume not found: no storage vol with matching path '/dev/loop0p1'
+*
+  File "test/check-machines-disks", line *, in testAddDiskPool

--- a/naughty/debian-testing/2976-virsh-loop-pool-nodev
+++ b/naughty/debian-testing/2976-virsh-loop-pool-nodev
@@ -1,0 +1,4 @@
+error: Failed to create vol loop0p1
+error: Storage volume not found: no storage vol with matching path '/dev/loop0p1'
+*
+  File "test/check-machines-disks", line *, in testAddDiskPool

--- a/naughty/fedora-35/2976-virsh-loop-pool-nodev
+++ b/naughty/fedora-35/2976-virsh-loop-pool-nodev
@@ -1,0 +1,4 @@
+error: Failed to create vol loop0p1
+error: Storage volume not found: no storage vol with matching path '/dev/loop0p1'
+*
+  File "test/check-machines-disks", line *, in testAddDiskPool

--- a/naughty/fedora-36/2976-virsh-loop-pool-nodev
+++ b/naughty/fedora-36/2976-virsh-loop-pool-nodev
@@ -1,0 +1,4 @@
+error: Failed to create vol loop0p1
+error: Storage volume not found: no storage vol with matching path '/dev/loop0p1'
+*
+  File "test/check-machines-disks", line *, in testAddDiskPool

--- a/naughty/fedora-37/2976-virsh-loop-pool-nodev
+++ b/naughty/fedora-37/2976-virsh-loop-pool-nodev
@@ -1,0 +1,4 @@
+error: Failed to create vol loop0p1
+error: Storage volume not found: no storage vol with matching path '/dev/loop0p1'
+*
+  File "test/check-machines-disks", line *, in testAddDiskPool

--- a/naughty/rhel-9/2976-virsh-loop-pool-nodev
+++ b/naughty/rhel-9/2976-virsh-loop-pool-nodev
@@ -1,0 +1,4 @@
+error: Failed to create vol loop0p1
+error: Storage volume not found: no storage vol with matching path '/dev/loop0p1'
+*
+  File "test/check-machines-disks", line *, in testAddDiskPool


### PR DESCRIPTION
Still happens on the testing farm.

Reverts ef419cb8c1881bf732b07fbd37a8f78a82a85ca4