### PR TITLE
Image refresh for fedora-rawhide

### DIFF
--- a/images/fedora-rawhide
+++ b/images/fedora-rawhide
@@ -1,1 +1,1 @@
-fedora-rawhide-4ecb7245728afa3bb3d3baae416775c54ef2eeff756c0e480070a456fa55d8f7.qcow2
+fedora-rawhide-a21e1fa9570630f89bdcf35a552c913d33459de286b6a189e222d77b1accc98a.qcow2


### PR DESCRIPTION
Image refresh for fedora-rawhide
 * Fix nodejs-devel installability in rawhide: https://bugzilla.redhat.com/show_bug.cgi?id=2110750
 * [x] image-refresh fedora-rawhide