### PR TITLE
Revert "machine: Allow SELinux messages for NM calling mv"

### DIFF
--- a/images/fedora-testing
+++ b/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-ababe93d0ef69d2cab658c09db04fc1d67cfd302c1ee3d073ebc8e733a7b31d5.qcow2
+fedora-testing-9fd2539129732a26f17eb8e66aa37f1baba03265daa1292b70fd97b961315c45.qcow2

--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -198,10 +198,6 @@ class Machine(ssh_connection.SSHConnection):
             # Default PAM configuration logs motd for cockpit-session
             allowed.append(".*cockpit-session: pam: Web console: .*")
 
-        if self.image in ['fedora-testing']:
-            # regression in https://bodhi.fedoraproject.org/updates/FEDORA-2022-320775eb9a (blocked)
-            allowed.append('audit.*denied.* comm="mv" .*NetworkManager_dispatcher_console_t:s0.*')
-
         return allowed
 
     def get_admin_group(self):


### PR DESCRIPTION
The latest selinux-policy update fixes this again:
https://bodhi.fedoraproject.org/updates/FEDORA-2022-139ec288ca

This reverts commit 47ac1b8834d1bfaed0f7b7a896bc1eeedb54eb47.

----

I don't actually know whether that update fixes it -- let's find out!

 * [x] image-refresh fedora-testing