### PR TITLE
machine_core: Run execute() commands with `set -e`

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -302,7 +302,7 @@ class SSHConnection(object):
             self.ssh_address
         ]
         additional_ssh_params = []
-        cmd = []
+        cmd = ['set -e;']
 
         additional_ssh_params += self.__execution_opts(direct=direct)
 


### PR DESCRIPTION
In hindsight it was a major error to not run commands with `set -e`:

 - Tests silently ignore command failures, leading to test failures
   later on which are harder to debug

 - Tests accumulated a lot of `execute("a && b")` style calls, which
   silently succeed if `a` fails

 - Tests have to sprinkle `set -e` around a lot if they want to do the
   right thing.

Thus, do it by default, let's fix the fallout, and then clean up the
`&&` and `set -e` from tests afterwards.

Don't do this for the `execute(script=)` mode. It's obsolete and hardly
used (see https://github.com/osbuild/cockpit-composer/pull/1477).

----

See https://github.com/cockpit-project/cockpit-machines/pull/788 for the nasty effects that this did. 

We also have a lot of potential traps in cockpit:
```
❱❱❱ git grep '&&' test/verify  | wc -l
94
```
I'll clean these up once this PR lands.

Blocked on fixing tests for `set -e`:
 - https://github.com/cockpit-project/cockpit-machines/pull/788
 - https://github.com/cockpit-project/cockpit/pull/17624
 - https://github.com/candlepin/subscription-manager-cockpit/pull/36
 - https://github.com/cockpit-project/cockpit/pull/17630

```
     ./tests-trigger 3706 image:{fedora-36,debian-testing,ubuntu-stable,arch} image:rhel-{8-4,8-5,8-6,8-7,9-1}
```