### PR TITLE
Drop command= and script= kwarg usage from Machine.execute() calls

### DIFF
--- a/image-create
+++ b/image-create
@@ -96,7 +96,7 @@ class MachineBuilder:
             self.machine.message("run setup script on guest")
 
             try:
-                self.machine.execute(script="/var/tmp/SETUP " + self.machine.image,
+                self.machine.execute(f"/var/tmp/SETUP {self.machine.image}",
                                      environment=env, quiet=not self.machine.verbose, timeout=7200)
                 self.machine.execute("rm -f /var/tmp/SETUP")
 

--- a/image-create
+++ b/image-create
@@ -98,7 +98,7 @@ class MachineBuilder:
             try:
                 self.machine.execute(script="/var/tmp/SETUP " + self.machine.image,
                                      environment=env, quiet=not self.machine.verbose, timeout=7200)
-                self.machine.execute(command="rm -f /var/tmp/SETUP")
+                self.machine.execute("rm -f /var/tmp/SETUP")
 
                 if self.machine.image == 'openshift':
                     # update our local openshift kube config file to match the new image

--- a/images/debian-stable
+++ b/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-b0d51b1a95bf3d82e79abb89b8a0d12b750db7cfe10bd6e85eeaec1d2b0edfa5.qcow2
+debian-stable-cbfc5e9616362df2f4d0798b4a61b54ace159611ca65750f90e468cc3487a9af.qcow2

--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -224,7 +224,7 @@ class Machine(ssh_connection.SSHConnection):
             self.execute(cmd)
             self.wait_for_cockpit_running(atomic_wait_for_host or "localhost")
         elif tls:
-            self.execute(script="""#!/bin/sh
+            self.execute("""
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
             systemctl reset-failed 'cockpit*' &&
             systemctl daemon-reload &&
@@ -232,7 +232,7 @@ class Machine(ssh_connection.SSHConnection):
             systemctl start cockpit.socket
             """)
         else:
-            self.execute(script="""#!/bin/sh
+            self.execute("""
             mkdir -p /etc/systemd/system/cockpit.service.d/ &&
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
             printf "[Service]
@@ -295,13 +295,13 @@ class Machine(ssh_connection.SSHConnection):
         self.execute(cmd.format(mac=mac))
 
     def wait_for_cockpit_running(self, address="localhost", port=9090, seconds=30, tls=False):
-        WAIT_COCKPIT_RUNNING = """#!/bin/sh
+        WAIT_COCKPIT_RUNNING = """
         until curl --insecure --silent --connect-timeout 2 --max-time 3 %s://%s:%s >/dev/null; do
             sleep 0.5;
         done;
         """ % (tls and "https" or "http", address, port)
         with timeout.Timeout(seconds=seconds, error_message="Timeout while waiting for cockpit to start"):
-            self.execute(script=WAIT_COCKPIT_RUNNING)
+            self.execute(WAIT_COCKPIT_RUNNING)
 
     def curl(self, *args, headers=None):
         cmd = ['curl', '--silent', '--show-error']

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -594,4 +594,4 @@ class VirtMachine(Machine):
     def needs_writable_usr(self):
         # On atomic systems, we need a hack to change files in /usr/lib/systemd
         if self.ostree_image:
-            self.execute(command="mount -o remount,rw /usr")
+            self.execute("mount -o remount,rw /usr")

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -488,7 +488,7 @@ class SSHConnection(object):
             cmd += " && chown '%s' '%s'" % (owner, dest)
         if perm:
             cmd += " && chmod '%s' '%s'" % (perm, dest)
-        self.execute(command=cmd, input=content)
+        self.execute(cmd, input=content)
 
     def spawn(self, shell_cmd, log_id, check=True):
         """Spawn a process in the test machine.


### PR DESCRIPTION
After this lands we can drop the obsolete `script=` API and greatly simplify Machine.execute().

 * [x] image-refresh debian-stable