### PR TITLE
test: Move to flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+ignore=
+    # line break after binary operator
+    W504
+    # module level import not at top of file
+    E402
+
+max-line-length = 120

--- a/HACKING.md
+++ b/HACKING.md
@@ -29,8 +29,8 @@ There are static code and syntax checks which you should run often:
 
     $ test/run
 
-You will need to install the pyflakes and pycodestyle packages for python3 in
-order to run this script.
+You will need to install the python3-flake8 package for python3 in order to run
+this script.
 
 It is highly recommended to set this up as a git pre-push hook, to avoid
 pushing PRs that will fail on trivial errors:

--- a/test/run
+++ b/test/run
@@ -4,9 +4,6 @@ set -eu
 
 # run static code checks like pyflakes and pep8
 PYEXEFILES="$(git grep -lI '^#!.*python') $(git ls-files "*.py")"
-python3 -m pyflakes $PYEXEFILES
-
-# FIXME: Fix code for the warnings and re-enable them
-python3 -m pycodestyle --max-line-length=120 --ignore W504,E402 $PYEXEFILES
+flake8 $PYEXEFILES
 
 ./test-bots


### PR DESCRIPTION
This easier to use, more flexible as pycodestyle errors can be
overridden on specific lines, and IDEs/vim-ale can read .flake8 and
stop complaining about the line length and imports.