### PR TITLE
machine_virtual: bind multicast to localhost

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -125,7 +125,7 @@ TEST_KVM_XML = """
 # The main network interface which we use to communicate between VMs
 TEST_MCAST_XML = """
     <qemu:arg value='-netdev'/>
-    <qemu:arg value='socket,mcast=230.0.0.1:{mcast},id=mcast0'/>
+    <qemu:arg value='socket,mcast=230.0.0.1:{mcast},id=mcast0,localaddr=127.0.0.1'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='virtio-net-pci,netdev=mcast0,mac={mac},bus=pci.0,addr=0x0f'/>
 """


### PR DESCRIPTION
When using socket-based network devices, with the `mcast` option (but
without an explicitly specified local address), qemu attempts to find a
suitable interface to use by scanning the available "up" interfaces for
ones that have the MULTICAST flag enabled (as per `ip link`).

The loopback interface doesn't normally have this flag enabled, so if
it's the only one that's up, the search will fail, causing the following
message:

    libvirt: QEMU Driver error : internal error: qemu unexpectedly closed the monitor: 2022-08-09T15:52:35.668412Z qemu-system-x86_64: -netdev socket,mcast=230.0.0.1:5600,id=mcast0: can't add socket to multicast group 230.0.0.1: No such device

If we force qemu to use the loopback interface, however, it will
succeed — even without the multicast flag being set.  Since we're not
actually interested in communicating between machines, force
127.0.0.1 as the local address.

This allows `image-customize`, `vm-run`, and testing in general to work
without the presence of any network connection, and without hacks such
as adding a dummy bridge or veth device.

Fixes cockpit-project/cockpit#12782