### PR TITLE
machine_core: Simplify MachineSSHConnection.execute()

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -314,8 +314,7 @@ class SSHConnection(object):
 
         with timeoutlib.Timeout(seconds=timeout, error_message="Timed out on '%s'" % command, machine=self):
             res = subprocess.run(command_line,
-                                 stdin=None if input is not None else subprocess.DEVNULL,
-                                 input=input.encode("UTF-8") if input else None,
+                                 input=input.encode("UTF-8") if input else b'',
                                  stdout=stdout or subprocess.PIPE,
                                  check=check)
 


### PR DESCRIPTION
Our logic about when to pass the `input` and the `stdin` parameters
seems to cause some issues with specific versions of Python (like that
found in CentOS 8 stream), where we get complaints about giving both
kwargs.

The only case where the logic has a gap in it (the input string is not
truthy, but also not `None`) should result in both kwargs being `None`.
I suspect that this happens as a result of the default value of `stdin`
in that version of Python not actually being `None`, but nothing else.

In any case, let's always provide an `input=` kwarg, possibly as an
empty string, and leave `stdin` alone.  An empty string should hand over
a pipe which immediately reads EOF, which is fairly equivalent to
reading from `/dev/null`.

This should help with cockpit-project/cockpit#17634 (@skazi0).