### PR TITLE
image-customize: use check=False on .execute()

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -107,7 +107,7 @@ class BuildAction(ActionBase):
         machine_instance.upload([source], vm_source, relative_dir=".")
 
         # this will fail if neither is available -- exception is clear enough, this is a developer tool
-        out = machine_instance.execute("(which pbuilder || which mock || which pacman) 2>/dev/null")
+        out = machine_instance.execute("(which pbuilder || which mock || which pacman) 2>/dev/null", check=False)
         if 'pbuilder' in out:
             BuildAction.build_deb(machine_instance, vm_source)
         elif 'mock' in out:


### PR DESCRIPTION
We expect this invocation to fail sometimes (and even have a case for it
below).