### PR TITLE
services: add ansible.posix to candlepin container

### DIFF
--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -143,6 +143,7 @@ echo 'candlepin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/candlepin
 EOF
 
 podman exec -i -u candlepin candlepin sh -eux <<EOF
+ansible-galaxy collection install ansible.posix
 ansible-galaxy install rvm.ruby
 
 cd


### PR DESCRIPTION
candlepin/ansible-role-candlepin#27 switched to using the
`ansible.posix` version of the `firewalld` interface, which is not
installed by default.  Use `ansible-galaxy` to install it before trying
to run the script.

 * [ ] FAIL: image-refresh services