### PR TITLE
image-create: Allow slow fedora-rawhide boots

### DIFF
--- a/image-create
+++ b/image-create
@@ -120,7 +120,12 @@ class MachineBuilder:
         self.machine.start()
         # avoid too long boot times -- they cause painfully long tests, and are a bug
         try:
-            self.machine.wait_boot(timeout_sec=30)
+            timeout = 30
+            if self.machine.image == "fedora-rawhide":
+                # except with fedora-rawhide, which is slow by design:
+                # https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HRJT4UF35MRJ7C4ZXVHBFXB4BTW64YSO/
+                timeout = 120
+            self.machine.wait_boot(timeout_sec=timeout)
         finally:
             self.machine.stop(timeout_sec=30)
 


### PR DESCRIPTION
 * [x] image-refresh fedora-rawhide
 * [x] image-refresh fedora-36