### PR TITLE
images: don't assume libvirt networking is disabled

### DIFF
--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -211,8 +211,8 @@ pbuilder --create --extrapackages "fakeroot $PBUILDER_EXTRA"
 /usr/lib/pbuilder/pbuilder-satisfydepends-classic --control /tmp/out/tools/debian/control --force-version --echo|grep apt-get | pbuilder --login --save-after-login
 rm -rf /tmp/out
 
-# Debian does not automatically start the default libvirt network
-virsh net-autostart default
+# (some) Debian does not automatically start the default libvirt network
+test -L /etc/libvirt/qemu/networks/autostart/default.xml || virsh net-autostart default
 
 # Disable services which we don't want running by default
 systemctl disable --now redis-server tuned

--- a/images/ubuntu-stable
+++ b/images/ubuntu-stable
@@ -1,1 +1,1 @@
-ubuntu-stable-e95f6d7b03e16dae9f3ecea5036687d1e72b76dbcd81614a4fb97adaa637cd38.qcow2
+ubuntu-stable-9d8c5c1591e1bf19732f86388aab68c195e0ec7cb540439bf83c5e5c78a5bedb.qcow2


### PR DESCRIPTION
The incoming ubuntu-stable image update contains a new version of
libvirt with the following change:

    - Autostart default bridged network (As upstream does, but not Debian).

This causes our unconditional attempt to enable the network to fail with
the following message:

    + virsh net-autostart default
    error: failed to mark network default as autostarted
    error: Failed to create symlink '/etc/libvirt/qemu/networks/autostart/default.xml' to '/etc/libvirt/qemu/networks/default.xml': File exists

Allow for both possibilities: check if the file exists before trying to
create it again.

 * [x] image-refresh ubuntu-stable