### PR TITLE
machine: Ignore systemd-gpt-aut sys_admin SELinux violation on Fedora 37

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -198,6 +198,10 @@ class Machine(ssh_connection.SSHConnection):
             # Default PAM configuration logs motd for cockpit-session
             allowed.append(".*cockpit-session: pam: Web console: .*")
 
+        if self.image == "fedora-37":
+            # https://bugzilla.redhat.com/show_bug.cgi?id=2083900
+            allowed.append('audit.*denied  { sys_admin } .* comm="systemd-gpt-aut".*')
+
         return allowed
 
     def get_admin_group(self):


### PR DESCRIPTION
This happens during boot, thus affects every test which boots a fresh
VM. It's therefore too big for a naughty.

See https://bugzilla.redhat.com/show_bug.cgi?id=2083900

---

I tested this locally. This will unblock enabling f37 for our projects.