### PR TITLE
machine: don't `set -e` for m.execute(check=False)

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -287,7 +287,11 @@ class SSHConnection(object):
         ]
         additional_ssh_params = []
 
-        cmd = ['set -e;']
+        cmd = []
+
+        if check:
+            cmd.append('set -e;')
+
         cmd += [f'export {name}={shlex.quote(value)}; ' for name, value in environment.items()]
 
         additional_ssh_params += self.__execution_opts(direct=direct)


### PR DESCRIPTION
In case `check=False` was specified to Machine.execute(), skip the call
to `set -e`.

This pushes down the definition of `check=False` into the script itself:
in the case that multiple commands are given, we ignore failure of all
of them.