### PR TITLE
machine_core: Let SSHConnection.write() create the target directory

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -417,16 +417,18 @@ class SSHConnection(object):
             append: If True, append to existing file instead of replacing it
             owner: If set, call chown on the file with the given owner string
             perm: Optional file permission as chmod shell string (e.g. "0600")
+
+        The directory of dest is created automatically.
         """
         assert dest
         assert self.ssh_address
 
-        cmd = "cat %s '%s'" % (append and '>>' or '>', dest)
+        self.execute(["mkdir", "-p", os.path.dirname(dest)])
+        self.execute(f"cat {append and '>>' or '>'} {shlex.quote(dest)}", input=content)
         if owner:
-            cmd += " && chown '%s' '%s'" % (owner, dest)
+            self.execute(["chown", owner, dest])
         if perm:
-            cmd += " && chmod '%s' '%s'" % (perm, dest)
-        self.execute(cmd, input=content)
+            self.execute(["chmod", perm, dest])
 
     def spawn(self, shell_cmd, log_id, check=True):
         """Spawn a process in the test machine.


### PR DESCRIPTION
Test suites are full of this pattern:

    m.execute("mkdir -p /target/dir")
    m.write("/target/dir/file.txt", "...")

Let's make our lifes a bit easier by always creating the target
directory of dest.

Also replace the wrong `&&` with separate execute() invocations, to
ensure that all the commands actually succeed (see commit b7d0edba5d),
and to avoid messing around with line breaks.

Replace % with f-strings.

----

Doing an image refresh just to make sure that this still works. I also trigger a few tests across projects to make sure this doesn't break anything.

 * [x] image-refresh debian-stable