### PR TITLE
lib: Enable fedora-37 tests for Cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -34,6 +34,7 @@ REPO_BRANCH_CONTEXT = {
             'ubuntu-stable',
             'fedora-35',
             'fedora-36',
+            'fedora-37',
             f'{TEST_OS_DEFAULT}/devel',
             f'{TEST_OS_DEFAULT}/firefox',
             'fedora-coreos',
@@ -49,7 +50,6 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             f'{TEST_OS_DEFAULT}/pybridge',
-            'fedora-37',
             'fedora-testing',
             'fedora-testing/dnf-copr',
             'fedora-rawhide',


### PR DESCRIPTION
I fixed the bulk of issues in https://github.com/cockpit-project/cockpit/pull/17690 and https://github.com/cockpit-project/bots/pull/3801 (plus a few smaller ones), so this by and large works now. However, I still saw [random timeouts](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17690-20220831-125954-2a247b8a-fedora-37/log.html). My suspicion is that current F37 still has rawhide's debug kernel, which [makes everything slow](https://lists.fedoraproject.org/archives/list/devel%40lists.fedoraproject.org/thread/HRJT4UF35MRJ7C4ZXVHBFXB4BTW64YSO/). So we may need to wait with this until it gets a proper kernel.

However, I'll spin the tests a few times here to get some data.