### PR TITLE
testmap: update subscription-manager entries

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -142,25 +142,30 @@ REPO_BRANCH_CONTEXT = {
     },
     'candlepin/subscription-manager': {
         'main': [
-            'rhel-8-7',
+            'rhel-8-8',
             'rhel-9-0',
             'rhel-9-1',
+            'rhel-9-2',
             'fedora-36',
+            'fedora-37',
         ],
         'subscription-manager-1.28': [
             'rhel-8-4',
-            'rhel-8-5',
             'rhel-8-6',
             'rhel-8-7',
-        ],
-        'subscription-manager-1.28.21': [
-            'rhel-8-5',
+            'rhel-8-8',
         ],
         'subscription-manager-1.28.29': [
             'rhel-8-6',
         ],
+        'subscription-manager-1.28.32': [
+            'rhel-8-7',
+        ],
         'subscription-manager-1.29.26': [
             'rhel-9-0',
+        ],
+        'subscription-manager-1.29.30': [
+            'rhel-9-1',
         ],
         '_manual': [
         ],
@@ -171,6 +176,7 @@ REPO_BRANCH_CONTEXT = {
             'centos-9-stream',
             'fedora-35',
             'fedora-36',
+            'fedora-37',
         ],
         '_manual': [
             'centos-8-stream/subscription-manager-1.28',


### PR DESCRIPTION
- add `rhel-8-7` for `subscription-manager/subscription-manager-1.28.32`,
  as that is the target of that branch
- add `rhel-8-8` for `subscription-manager/subscription-manager-1.28`,
  as that is the target of that branch
- add `rhel-9-1` for `subscription-manager/subscription-manager-1.29.30`,
  as that is the target of that branch
- add `rhel-9-2` for `subscription-manager/main`, as that is the target
  of that branch
- switch `rhel-8-7` to `rhel-8-8` for `subscription-manager/main`, as that is
  the first target for backports to RHEL 8
- drop `subscription-manager/subscription-manager-1.28.21` & stop testing
  `rhel-8.5` altogether: that version is EOL [1]
- add `fedora-37` for `subscription-manager/main` and
  `subscription-manager-cockpit/main`, as we want to est on that distro
  as well (and it works fine currently)

[1] https://access.redhat.com/articles/rhel-eus

```
./tests-trigger 3829 rhel-8-7@candlepin/subscription-manager/subscription-manager-1.28.32 rhel-8-8@candlepin/subscription-manager/subscription-manager-1.28 rhel-9-1@candlepin/subscription-manager/subscription-manager-1.29.30 rhel-9-2@candlepin/subscription-manager rhel-8-8@candlepin/subscription-manager fedora-37@candlepin/subscription-manager fedora-37@candlepin/subscription-manager-cockpit
```