### PR TITLE
images: add pod infra container

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-18f49ea8131bcb4d81c8937daebd95fc36c5590a3c9beb3aaab72887074d9136.qcow2
+debian-testing-3c970b6b7debbf6dd93b583a0646b013d820b989ca4b82db6711bdcad4171d98.qcow2

--- a/images/scripts/lib/podman-images.setup
+++ b/images/scripts/lib/podman-images.setup
@@ -6,4 +6,5 @@ if [ $(uname -m) = x86_64 ]; then
     podman pull quay.io/libpod/busybox
     podman pull quay.io/libpod/alpine
     podman pull quay.io/cockpit/registry:2
+    podman pull docker://k8s.gcr.io/pause:3.5
 fi


### PR DESCRIPTION
Include the pod infra container in the test image required for testing
cockpit-podman's new create pod feature.

 * [x] image-refresh debian-testing

Let's refresh debian-testing, as that's currently failing in this PR https://github.com/cockpit-project/cockpit-podman/pull/961 with

https://cockpit-logs.us-east-1.linodeobjects.com/pull-961-20220902-183236-bfe5b802-debian-testing/log.html#13

```
> error: Pod failed to be created: Internal Server Error: could not pull image: initializing source docker://k8s.gcr.io/pause:3.5: pinging container registry k8s.gcr.io: Get "https://k8s.gcr.io/v2/": dial tcp: lookup k8s.gcr.io: no such host
```