### PR TITLE
log.html: Show also link to html dump

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -171,6 +171,12 @@ let link_patterns = [
         "icon": "bi bi-camera-fill"
     },
     {
+        "label": "html",
+        "pattern": "Wrote HTML dump to ([A-Za-z0-9\\-\\.]+\\.html)$",
+        "url": "$1",
+        "icon": "bi bi-filetype-html"
+    },
+    {
         "label": "new pixels",
         "pattern": "New pixel test reference ([A-Za-z0-9\\-\\.]+\\.png)$",
         "url": "$1"


### PR DESCRIPTION
It used to be there some years ago and I think it is often useful, yet only very few people know where to look for it.

![Screenshot from 2022-09-13 14-48-48](https://user-images.githubusercontent.com/12330670/189905611-c6d1ffbd-ceb9-4081-9ef9-0c0f3d09106c.png)
