### PR TITLE
image-trigger: auto-refresh rhel-8-8 & rhel-9-2

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -40,8 +40,10 @@ REFRESH = {
     "rhel-8-5": {},
     "rhel-8-6": {},
     "rhel-8-7": {},
+    "rhel-8-8": {},
     "rhel-9-0": {},
     "rhel-9-1": {},
+    "rhel-9-2": {},
     "services": {"refresh-days": 30},
 }
 


### PR DESCRIPTION
- `rhel-8-8` was forgotten in a80c66b53c0bb5e9ee5920cd4f4166a6943c8f94
- `rhel-9-2` was forgotten in 072936c85ac085f8b9f06362c690877f280a3f31