### PR TITLE
images: only pull the pause container when required

### DIFF
--- a/images/scripts/lib/podman-images.setup
+++ b/images/scripts/lib/podman-images.setup
@@ -6,5 +6,7 @@ if [ $(uname -m) = x86_64 ]; then
     podman pull quay.io/libpod/busybox
     podman pull quay.io/libpod/alpine
     podman pull quay.io/cockpit/registry:2
-    podman pull docker://k8s.gcr.io/pause:3.5
+    if [ "$(podman -v | awk '{ print substr($3, 1, 1) }')" -lt 4 ]; then
+        podman pull docker://k8s.gcr.io/pause:3.5
+    fi
 fi


### PR DESCRIPTION
Podman 4.0 ships the pause image so only pull it when required.