### PR TITLE
naughty: consolidate & generalize denial patterns for Insights

### DIFF
--- a/naughty/rhel-8/3590-insights-client-denials
+++ b/naughty/rhel-8/3590-insights-client-denials
@@ -1,1 +1,1 @@
-audit: type=1400 audit*: avc:  denied  { write } for  pid=* comm="gpg" name="*" dev="*" ino=* scontext=system_u:system_r:insights_client_t:s0 tcontext=unconfined_u:object_r:admin_home_t:*
+audit: type=1400 audit*: avc:  denied * scontext=system_u:system_r:insights_client_t:*

--- a/naughty/rhel-8/3590-insights-client-denials-2
+++ b/naughty/rhel-8/3590-insights-client-denials-2
@@ -1,1 +1,0 @@
-audit: type=1400 audit*: avc:  denied  { write } for  pid=* comm="insights-client" name="insights-client.pid" dev="tmpfs" ino=* scontext=system_u:system_r:insights_client_t:s0 tcontext=unconfined_u:object_r:var_run_t:*

--- a/naughty/rhel-8/3590-insights-client-denials-3
+++ b/naughty/rhel-8/3590-insights-client-denials-3
@@ -1,1 +1,0 @@
-audit: type=1400 audit*: avc:  denied  { read } for  pid=* comm="gpg" name="*" dev="*" ino=* scontext=system_u:system_r:gpg_t:s0 tcontext=system_u:object_r:insights_client_etc_t:*

--- a/naughty/rhel-8/3590-insights-client-denials-4
+++ b/naughty/rhel-8/3590-insights-client-denials-4
@@ -1,1 +1,0 @@
-audit: type=1400 audit*: avc:  denied  { write } for  pid=* comm="platform-python" name="cache" dev="*" ino=* scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:var_t:s0*

--- a/naughty/rhel-9/3590-insights-client-denials
+++ b/naughty/rhel-9/3590-insights-client-denials
@@ -1,1 +1,1 @@
-audit: type=1400 audit*: avc:  denied  { write } for  pid=* comm="gpg" name="*" dev="*" ino=* scontext=system_u:system_r:insights_client_t:s0 tcontext=unconfined_u:object_r:admin_home_t:*
+audit: type=1400 audit*: avc:  denied * scontext=system_u:system_r:insights_client_t:*

--- a/naughty/rhel-9/3590-insights-client-denials-2
+++ b/naughty/rhel-9/3590-insights-client-denials-2
@@ -1,1 +1,0 @@
-audit: type=1400 audit*: avc:  denied  { write } for  pid=* comm="insights-client" name="insights-client.pid" dev="tmpfs" ino=* scontext=system_u:system_r:insights_client_t:s0 tcontext=unconfined_u:object_r:var_run_t:*

--- a/naughty/rhel-9/3590-insights-client-denials-3
+++ b/naughty/rhel-9/3590-insights-client-denials-3
@@ -1,1 +1,0 @@
-audit: type=1400 audit*: avc:  denied  { read } for  pid=* comm="gpg" name="last_stable.egg.asc" dev="*" ino=* scontext=system_u:system_r:gpg_t:s0 tcontext=unconfined_u:object_r:insights_client_var_lib_t:*

--- a/naughty/rhel-9/3590-insights-client-denials-4
+++ b/naughty/rhel-9/3590-insights-client-denials-4
@@ -1,1 +1,0 @@
-audit: type=1400 audit*: avc:  denied  { write } for  pid=* comm="platform-python" name="cache" dev="*" ino=* scontext=system_u:system_r:insights_client_t:s0 tcontext=system_u:object_r:var_t:s0*


### PR DESCRIPTION
Sadly, it looks like fixing the SELinux policy for insights-client is
not going to happen soon, and new issues (related to new tools used by
insights-client for data collection) happen every now and then.
Hence, consolidate all the RHEL 8 & RHEL 9 naughties of insights-client
into a single one that basically accepts any failure in a
`insights_client_t` context.