### PR TITLE
task: update legacy url

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -324,7 +324,7 @@ class GitHub(object):
         page = 1
         count = 100
         while count == 100:
-            data = self.get("statuses/{0}?page={1}&per_page={2}".format(revision, page, count))
+            data = self.get("commits/{0}/statuses?page={1}&per_page={2}".format(revision, page, count))
             count = 0
             page += 1
             result += data


### PR DESCRIPTION
The commit statuses endpoint still used the legacy route which makes it hard to find it in the Github docs and surely Github will drop this at some point.

See https://docs.github.com/en/rest/commits/statuses#list-commit-statuses-for-a-reference for the mention of the legacy url. This is used in store-tests, so should I trigger a test job somewhere?