### PR TITLE
test-failure-policy: add option to test other naughties

### DIFF
--- a/test-failure-policy
+++ b/test-failure-policy
@@ -38,6 +38,8 @@ def main():
     parser = argparse.ArgumentParser(description='Check a traceback for a known issue')
     parser.add_argument('-o', "--offline", action='store_true',
                         help="Work offline, don't fetch new data or contact servers")
+    parser.add_argument('-a', '--all', action='store_true',
+                        help='Look at other known naughties for matches')
     parser.add_argument('image', help="The image to check against")
     opts = parser.parse_args()
 
@@ -65,6 +67,12 @@ def main():
         if checkRetry(output):
             print("due to failure of test harness or framework")
             return 1
+
+        if not number and opts.all:
+            number, img = check_all_known_issues(api, output, opts.image)
+            if number:
+                print(f"Known issue #{number} in {img}")
+                return 77
 
     except RuntimeError as ex:
         sys.stderr.write("{0}: {1}\n".format(script, ex))
@@ -108,6 +116,22 @@ def checkRetry(trace):
 
 # -----------------------------------------------------------------------------
 # Known Issue Matching and Filing
+
+
+def check_all_known_issues(api, trace, image):
+    img = None
+    number = None
+    naughty_dir = os.path.join(BOTS_DIR, "naughty")
+
+    for img in os.listdir(naughty_dir):
+        # Skip the image we already checked
+        if img != get_test_image(image):
+            number = check_known_issue(api, trace, img)
+            if number:
+                break
+
+    return number, img
+
 
 def normalize_traceback(trace):
     # All file paths converted to basename


### PR DESCRIPTION
Add a new command line option --all which if no naughty is found, tries to find a match in all other naughties. This can be helpful for known issues which affect Fedora-37 and then land in Fedora-36, test-failure-policy will then emit: "Known issue 3899 in fedora-36".

Only the first found known issue is shown, the issue may in fact appear in other distributions as well.

This was tested with:

```
# ----------------------------------------------------------------------
# testExpire (__main__.TestAccounts)
[1011/094941.075319:ERROR:bus.cc(398)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[1011/094941.075416:ERROR:bus.cc(398)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory

DevTools listening on ws://127.0.0.1:10091/devtools/browser/3b0e566c-057a-475c-ab73-28ec3097168b
[1011/094941.077498:WARNING:bluez_dbus_manager.cc(247)] Floss manager not present, cannot set Floss enable/disable.
[1011/094941.078365:ERROR:egl_util.cc(55)] Failed to load GLES library: /usr/lib64/chromium-browser/libGLESv2.so: /usr/lib64/chromium-browser/libGLESv2.so: cannot open shared object file: No such file or directory
[1011/094941.084218:ERROR:viz_main_impl.cc(186)] Exiting GPU process due to errors during initialization
[1011/094941.090336:ERROR:gpu_init.cc(486)] Passthrough is not supported, GL is disabled, ANGLE is 
[1011/094941.704696:ERROR:devtools_http_handler.cc(636)] Using unsafe HTTP verb GET to invoke /json/new. This action will stop supporting GET and POST verbs in future versions.
> error: Tracer failed: "{"problem":null,"exit_status":1,"exit_signal":null,"message":"Traceback (most recent call last):\n  File \"<string>\", line 2, in <module>\nModuleNotFoundError: No module named 'tracer'"}", data: """"
{"exceptionId":1,"text":"Uncaught","lineNumber":1,"columnNumber":417539,"scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","stackTrace":{"callFrames":[{"functionName":"ii","scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","lineNumber":1,"columnNumber":417539},{"functionName":"","scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","lineNumber":1,"columnNumber":472585},{"functionName":"","scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","lineNumber":1,"columnNumber":472137},{"functionName":"","scriptId":"24","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js","lineNumber":0,"columnNumber":12866},{"functionName":"","scriptId":"24","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js","lineNumber":0,"columnNumber":12977},{"functionName":"L","scriptId":"24","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js","lineNumber":0,"columnNumber":12382}]},"exception":{"type":"object","subtype":"error","className":"RangeError","description":"RangeError: Invalid time value\n    at ii (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:417540)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472586\n    at Array.forEach (<anonymous>)\n    at Function.<anonymous> (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472138)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12867\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12978\n    at L (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12383)","objectId":"256791718455975715.8.1","preview":{"type":"object","subtype":"error","description":"RangeError: Invalid time value\n    at ii (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:417540)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472586\n    at Array.forEach (<anonymous>)\n    at Function.<anonymous> (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472138)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12867\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12978\n    at L (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12383)","overflow":false,"properties":[{"name":"stack","type":"string","value":"RangeError: Invalid time value\n    at ii (http://1…7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12383)"},{"name":"message","type":"string","value":"Invalid time value"}]}},"executionContextId":8}
{"exceptionId":2,"text":"Uncaught","lineNumber":1,"columnNumber":417539,"scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","stackTrace":{"callFrames":[{"functionName":"ii","scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","lineNumber":1,"columnNumber":417539},{"functionName":"","scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","lineNumber":1,"columnNumber":472585},{"functionName":"","scriptId":"33","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js","lineNumber":1,"columnNumber":472137},{"functionName":"","scriptId":"24","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js","lineNumber":0,"columnNumber":12866},{"functionName":"","scriptId":"24","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js","lineNumber":0,"columnNumber":12977},{"functionName":"L","scriptId":"24","url":"http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js","lineNumber":0,"columnNumber":12382}]},"exception":{"type":"object","subtype":"error","className":"RangeError","description":"RangeError: Invalid time value\n    at ii (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:417540)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472586\n    at Array.forEach (<anonymous>)\n    at Function.<anonymous> (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472138)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12867\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12978\n    at L (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12383)","objectId":"256791718455975715.8.2","preview":{"type":"object","subtype":"error","description":"RangeError: Invalid time value\n    at ii (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:417540)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472586\n    at Array.forEach (<anonymous>)\n    at Function.<anonymous> (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/users/users.js:2:472138)\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12867\n    at http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12978\n    at L (http://127.0.0.2:9691/cockpit/$735f7b6167a54da41a40cce0a9edb1ea3a468dc5a7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12383)","overflow":false,"properties":[{"name":"stack","type":"string","value":"RangeError: Invalid time value\n    at ii (http://1…7e302a5bf0b9d8aea0cc653/base1/cockpit.js:1:12383)"},{"name":"message","type":"string","value":"Invalid time value"}]}},"executionContextId":8}
Traceback (most recent call last):
  File "/usr/lib64/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/work/bots/make-checkout-workdir/test/verify/check-users", line 483, in testExpire
    b.wait_in_text("#account-expiration-text", "Expire account on")
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 623, in wait_in_text
    self.wait_js_cond("ph_in_text(%s,%s)" % (jsquote(selector), jsquote(text)),
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 573, in wait_js_cond
    raise e
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 561, in wait_js_cond
    result = self.cdp.invoke("Runtime.evaluate",
  File "/work/bots/make-checkout-workdir/test/common/cdp.py", line 205, in invoke
    res = self.command(cmd)
  File "/work/bots/make-checkout-workdir/test/common/cdp.py", line 232, in command
    raise RuntimeError(res["error"])
RuntimeError: RangeError: Invalid time value
Wrote screenshot to TestAccounts-testExpire-debian-testing-127.0.0.2-2801-FAIL.png
Wrote HTML dump to TestAccounts-testExpire-debian-testing-127.0.0.2-2801-FAIL.html
Wrote JS log to TestAccounts-testExpire-debian-testing-127.0.0.2-2801-FAIL.js.log
Journal extracted to TestAccounts-testExpire-debian-testing-127.0.0.2-2801-FAIL.log.gz
> warning: transport closed: disconnected
Traceback (most recent call last):
  File "/work/bots/make-checkout-workdir/test/verify/check-users", line 483, in testExpire
    b.wait_in_text("#account-expiration-text", "Expire account on")
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 623, in wait_in_text
    self.wait_js_cond("ph_in_text(%s,%s)" % (jsquote(selector), jsquote(text)),
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 573, in wait_js_cond
    raise e
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 561, in wait_js_cond
    result = self.cdp.invoke("Runtime.evaluate",
  File "/work/bots/make-checkout-workdir/test/common/cdp.py", line 205, in invoke
    res = self.command(cmd)
  File "/work/bots/make-checkout-workdir/test/common/cdp.py", line 232, in command
    raise RuntimeError(res["error"])
RuntimeError: RangeError: Invalid time value

# Result testExpire (__main__.TestAccounts) failed
# 1 TEST FAILED [24s on rhos-01-5]
not ok 313 test/verify/check-users TestAccounts.testExpire [ND@5] # RETRY 1 (be robust against unstable tests)
```

[jelle@t14s][~/projects/cockpit-bots]%./test-failure-policy -o fedora-36 --all < debian-testing-test-failure
Known issue #3899 in debian-testing

This still needs changes in `./test/common/run-tests`, to detect if it's an `image-refresh` and then add the `--all` option.