### PR TITLE
services: update Candlepin deployment

### DIFF
--- a/images/scripts/services.bootstrap
+++ b/images/scripts/services.bootstrap
@@ -15,7 +15,3 @@ xz -cd "$CACHE" > "$OUTPUT"
 # boot it once to run ignition
 qemu-system-x86_64 -enable-kvm -nographic -m 1024 -device virtio-rng-pci \
     -drive file="$OUTPUT",if=virtio -fw_cfg name=opt/com.coreos/config,file=$BASE/lib/cockpit-ci.ign
-
-# HACK: centos7 is incompatible with cgroupsv2 host (https://bugzilla.redhat.com/show_bug.cgi?id=1970237)
-# but candlepin is incompabile with anything newer than CentoS 7 (https://github.com/candlepin/ansible-role-candlepin/pull/12)
-./image-customize --run-command 'rpm-ostree kargs --append=systemd.unified_cgroup_hierarchy=0' --verbose --base-image "$OUTPUT" "$OUTPUT"

--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -122,13 +122,17 @@ chmod 755 /root/run-samba-domain
 #
 #############################
 cat <<EOF > ./Dockerfile
-FROM quay.io/fedora/fedora:35
+FROM quay.io/fedora/fedora:36
 RUN dnf -y install systemd && dnf clean all
+CMD ["/sbin/init"]
 EOF
 
 podman build --tag fedora_systemd .
 
-podman run --name=candlepin --uts=host --publish=8443:8443 --privileged --detach -t fedora_systemd /usr/sbin/init
+podman run --name=candlepin --uts=host --publish=8443:8443 --privileged --detach -t fedora_systemd
+
+# give systemd the time to start in the container
+sleep 5
 
 podman exec -i candlepin sh -eux <<EOF
 # wait until booted
@@ -136,27 +140,30 @@ systemctl start multi-user.target
 # ensure latest ca-certificates
 dnf update -y
 # Install dependencies
-dnf -y install ansible libselinux-python3 python3-firewall git-core openssl sudo which hostname initscripts gettext selinux-policy
+dnf -y install ansible libselinux-python3 python3-firewall git-core openssl sudo which hostname initscripts gettext selinux-policy acl
 
 useradd candlepin
 echo 'candlepin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/candlepin
 EOF
 
 podman exec -i -u candlepin candlepin sh -eux <<EOF
-ansible-galaxy install rvm.ruby
+ansible-galaxy collection install ansible.posix community.general community.mysql community.postgresql
 
 cd
 mkdir -p playbookdir/roles/
-
-# https://github.com/candlepin/ansible-role-candlepin/pull/27 regressed this, so pin it back
-git clone -n https://github.com/candlepin/ansible-role-candlepin.git playbookdir/roles/candlepin
-git -C playbookdir/roles/candlepin checkout 5fc50e9e83a7afe975f593fe6ed883a8b2d6bac9
+git clone --depth=1 https://github.com/candlepin/ansible-role-candlepin.git playbookdir/roles/candlepin
+# create an empty/fake rvm.ruby module
+mkdir playbookdir/roles/rvm.ruby
 
 cat > playbookdir/playbook.yml <<- EOP
 - hosts: localhost
+  connection: local
   roles:
      - role: candlepin
-       cp_deploy_args: "-g -a -f -t"
+       vars:
+         cp_configure_mariadb: false
+         cp_configure_ruby: false
+         cp_deploy_args: "-g -a -f -t"
 EOP
 
 ansible-playbook -v --skip-tags 'system_update' playbookdir/playbook.yml

--- a/images/services
+++ b/images/services
@@ -1,1 +1,1 @@
-services-3a80909dd605dcf3e1ffc4d3810f1ba88c523e8dbbcc1ffddc24e838ac05dd5e.qcow2
+services-09cdc85b6092abbe0f3cc95acd841894620630ff5c37c0c038f46d002301a3de.qcow2


### PR DESCRIPTION
services: update Candlepin deployment

Switch back to track the "master" branch of the "candlepin" Ansible
role, so we can be up-to-date with changes in it; this requires various
changes in lock-step:
- specify /bin/init (i.e. systemd) as entry point in the container
- sleep few seconds after starting the container before executing stuff
  in it (including starting services); hopefully should give systemd the
  time to start
- newer versions of the role use FQMD (Fully Qualified Module Names),
  which are not supported by Ansible in Fedora 35; hence, bump the OS
  version to Fedora 36
- install "acl", so Ansible can properly pass temporary files to
  non-root users (e.g. "postgres") when running the playbook as
  "ansible" user
- install the Ansible collections needed by the role
- newer versions of the role allow users to disable the Ruby bits; since
  they are needed for the spec tests of Candlepin, set
  "cp_configure_ruby" to false for that
- stop installing the "rvm.ruby" role, as it is not needed anymore;
  create an empty/fake "module" for it instead, to keep the "candlepin"
  role happy
- disable MariaDB, as PostgreSQL is the default DB
- fix passing the variables to the "candlepin" role, by properly
  specifying them in "vars"
- use a local connection for ansible, so there is no need for self-ssh

This also drops the usage of cgroupv1 for the base FCOS image: Candlepin
is no more on CentOS 7, so there is no need to force the old cgroup
hierarchy, and apparently doing so creates issues when running the
Fedora container of Candlepin using a newer podman.

 * [x] image-refresh services