### PR TITLE
lib: handle empty files

### DIFF
--- a/lib/stores.py
+++ b/lib/stores.py
@@ -32,7 +32,9 @@ REDHAT_STORES = [
 # local stores
 try:
     with open(xdg_config_home('cockpit-dev', 'image-stores'), 'r') as fp:
-        PUBLIC_STORES += fp.read().strip().split("\n")
+        data = fp.read().strip()
+        if data:
+            PUBLIC_STORES += data.split("\n")
 except FileNotFoundError:
     pass
 


### PR DESCRIPTION
When the `image-stores` file is empty, we still add an entry to the store as in Python `''.split('\n')` outputs `['']`. This breaks image-download which does not check if the parsed url is valid and has a hostname which is not None.

Tested here: https://github.com/cockpit-project/bots/pull/3974