### PR TITLE
Replace deprecated pipes.quote() with shlex.quote

### DIFF
--- a/issue-scan
+++ b/issue-scan
@@ -28,7 +28,7 @@ REDHAT_TASKS = [
 ]
 
 import argparse
-import pipes
+import shlex
 import sys
 import json
 import logging
@@ -153,7 +153,7 @@ def output_task(command, issue, repo, verbose):
         )
     else:
         if context:
-            context = pipes.quote(context)
+            context = shlex.quote(context)
         return (checkout + "cd make-checkout-workdir && " + cmd + " ; cd ..").format(
             issue=int(number),
             priority=distributed_queue.MAX_PRIORITY,

--- a/tests-scan
+++ b/tests-scan
@@ -19,7 +19,7 @@
 
 import argparse
 import json
-import pipes
+import shlex
 import sys
 import time
 import logging
@@ -169,18 +169,18 @@ def tests_invoke(priority, name, number, revision, ref, context, base,
     cmd = " ".join([checkout, "&& cd make-checkout-workdir &&", test_env, invoke])
     return (wrapper + ' -- /bin/sh -c "' + cmd + '"').format(
         priority=priority,
-        name=pipes.quote(name),
-        revision=pipes.quote(revision),
-        base=pipes.quote(str(base)),
-        ref=pipes.quote(ref),
-        bots_ref=pipes.quote(bots_ref),
-        image=pipes.quote(image),
-        scenario=(pipes.quote(scenario)),
+        name=shlex.quote(name),
+        revision=shlex.quote(revision),
+        base=shlex.quote(str(base)),
+        ref=shlex.quote(ref),
+        bots_ref=shlex.quote(bots_ref),
+        image=shlex.quote(image),
+        scenario=(shlex.quote(scenario)),
         github_context=github_context,
         current=current,
         pull_number=number,
-        repo=pipes.quote(repo),
-        github_base=pipes.quote(options.repo),
+        repo=shlex.quote(repo),
+        github_base=shlex.quote(options.repo),
     )
 
 


### PR DESCRIPTION
Spotted in integration tests:

    /work/bots/./tests-scan:22: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13

---


Lightly tested locally with `./tests-scan  --repo cockpit-project/cockpit`, but our CI covers this.