### PR TITLE
Make image-customize --verbose more verbose

### DIFF
--- a/image-create
+++ b/image-create
@@ -97,7 +97,7 @@ class MachineBuilder:
 
             try:
                 self.machine.execute(f"/var/tmp/SETUP {self.machine.image}",
-                                     environment=env, stdout=sys.stdout, quiet=not self.machine.verbose, timeout=7200)
+                                     environment=env, stdout=None, quiet=not self.machine.verbose, timeout=7200)
                 self.machine.execute("rm -f /var/tmp/SETUP")
 
                 if self.machine.image == 'openshift':

--- a/image-customize
+++ b/image-customize
@@ -28,6 +28,7 @@ from machine import testvm
 opt_quick = False
 opt_verbose = False
 opt_build_options = None
+stdout_disposition = None
 
 
 def prepare_install_image(base_image, install_image, resize, fresh):
@@ -140,7 +141,7 @@ class BuildAction(ActionBase):
 
         # build binary packages
         machine.execute(f"cd /var/tmp/build; DEB_BUILD_OPTIONS='{build_opts}' pbuilder build --buildresult . "
-                        f"{opt_build_options} *.dsc", timeout=1800)
+                        f"{opt_build_options} *.dsc", timeout=1800, stdout=stdout_disposition)
 
         # install packages
         machine.execute("dpkg -i /var/tmp/build/*.deb")
@@ -167,7 +168,7 @@ class BuildAction(ActionBase):
         # as the mock is offline and pre-installed
         machine.execute("su builder -c 'mock --no-clean --no-cleanup-after --disablerepo=* "
                         f"--offline --resultdir /var/tmp/build {mock_opts} --rebuild {srpm}'",
-                        timeout=1800)
+                        timeout=1800, stdout=stdout_disposition)
 
         # install RPMs
         machine.execute('packages=$(find /var/tmp/build -name "*.rpm" -not -name "*.src.rpm"); '
@@ -192,7 +193,8 @@ class BuildAction(ActionBase):
         machine.execute(f"su builder {opt_build_options} /var/tmp/mkbuild.sh")
 
         # build binaries
-        machine.execute("cd /var/tmp/build; makechrootpkg -r /var/lib/archbuild/cockpit -U builder", timeout=1800)
+        machine.execute("cd /var/tmp/build; makechrootpkg -r /var/lib/archbuild/cockpit -U builder",
+                        timeout=1800, stdout=stdout_disposition)
 
         # install packages
         machine.execute("pacman -U --noconfirm /var/tmp/build/*.pkg.tar.zst")
@@ -275,10 +277,12 @@ def main():
 
     args.base_image = testvm.get_test_image(args.base_image)
 
-    global opt_quick, opt_verbose, opt_build_options
+    global opt_quick, opt_verbose, opt_build_options, stdout_disposition
     opt_quick = args.quick
     opt_verbose = args.verbose
     opt_build_options = args.build_options
+    if not args.verbose:
+        stdout_disposition = subprocess.DEVNULL
 
     if '/' not in args.base_image:
         subprocess.check_call([os.path.join(BOTS_DIR, "image-download"), args.base_image])

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -260,7 +260,7 @@ class SSHConnection(object):
             return ["-o", "ControlPath=" + self.ssh_master]
 
     def execute(self, command, input=None, environment={},
-                stdout=None, quiet=False, direct=False, timeout=120,
+                stdout=subprocess.PIPE, quiet=False, direct=False, timeout=120,
                 ssh_env=["env", "-u", "LANGUAGE", "LC_ALL=C"], check=True):
         """Execute a shell command in the test machine and return its output.
 
@@ -306,10 +306,9 @@ class SSHConnection(object):
         with timeoutlib.Timeout(seconds=timeout, error_message="Timed out on '%s'" % command, machine=self):
             res = subprocess.run(command_line,
                                  input=input.encode("UTF-8") if input else b'',
-                                 stdout=stdout or subprocess.PIPE,
-                                 check=check)
+                                 stdout=stdout, check=check)
 
-        return None if stdout else res.stdout.decode("UTF-8", "replace")
+        return None if res.stdout is None else res.stdout.decode("UTF-8", "replace")
 
     def upload(self, sources, dest, relative_dir=TEST_DIR, use_scp=False):
         """Upload a file into the test machine

--- a/vm-run
+++ b/vm-run
@@ -89,7 +89,7 @@ try:
     if args.execute:
         for cmd in args.execute:
             print('#', cmd)
-            machine.execute(cmd, stdout=1)
+            machine.execute(cmd, stdout=None)
 
     # Graphics console necessary
     if args.graphics:


### PR DESCRIPTION
In a nutshell: we've been redirecting stdout, which is bad, because this is where the unit test failures end up.  Make that stuff visible if `-v` was given.