### PR TITLE
Fix CodeQL scan HTML/JavaScript alerts

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -139,7 +139,7 @@
 const tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
 const tap_result = /^(ok|not ok) ([0-9]+) (.*)(?: # duration: ([0-9]+s))?(?: # SKIP .*)?$/gm;
 const tap_skipped = /^ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # SKIP (.*$)/gm;
-const tap_total_time = /^# (\d+ TESTS FAILED|TESTS PASSED) \[([0-9]+)s on .*\]$/m
+const tap_total_time = /^# (\d+ TESTS FAILED|TESTS PASSED) \[([0-9]+)s on .*\]$/m;
 
 const entry_template = document.querySelector("#TestEntry").innerHTML;
 Mustache.parse(entry_template);
@@ -467,7 +467,7 @@ async function fetch_content(filename) {
     content += await fetch_from(filename, bytes);
     set_content(content);
 
-    console.log('Thank you for using s3-streamer.  Have a nice day.')
+    console.log('Thank you for using s3-streamer.  Have a nice day.');
 }
 
 fetch_content('log');

--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -226,22 +226,20 @@ function find_patterns(segment) {
 }
 
 function extract(text) {
-    let m, s;
     let first, last, total, passed, failed, skipped, total_test_time;
     /* default is to show the text we have, unless we find actual results */
     let altered_text = Mustache.render(text_only_template, {
                     text: text
                 });
     const entries = [];
-    const indices = {};
     const testingElem = document.querySelector('#testing');
     const testingProgressElem = document.querySelector('#testing-progress');
-
-    if (m = tap_range.exec(text)) {
-        first = parseInt(m[1], 10);
-        last = parseInt(m[2], 10);
+    const tap_range_match = tap_range.exec(text)
+    if (tap_range_match) {
+        first = parseInt(tap_range_match[1], 10);
+        last = parseInt(tap_range_match[2], 10);
         total = last-first+1;
-        const test_start_offset = m.index + m[0].length + 1;
+        const test_start_offset = tap_range_match.index + tap_range_match[0].length + 1;
         const text_init = text.slice(0, test_start_offset);
         const text_tests = text.slice(test_start_offset);
         const t = tap_total_time.exec(text);
@@ -276,7 +274,6 @@ function extract(text) {
 
         document.querySelector('#test-info').textContent = text.slice(0, text.indexOf('\n'));
 
-        const test_links = {};
         const ids = { };
         segments.forEach(function (segment, segmentIndex) {
             tap_range.lastIndex = 0;

--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -4,10 +4,10 @@
         <title>Cockpit Integration Tests</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.2.1/mustache.min.js"></script>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha256-IUOUHAPazai08QFs7W4MbzTlwEWFo7z/4zw8YmxEiko=" crossorigin="anonymous">
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" integrity="sha256-h1OMS35Ij1pJ0S+Y1qBK/GHQDyankPMZVpeZrNQ062U="crossorigin="anonymous"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css" integrity="sha256-8M+b2Hj+vy/2J5tZ9pYDHeuPD59KsaEZn1XXj3xVhjg=" crossorigin="anonymous">
+        <script src="https://cdn.jsdelivr.net/npm/mustache@4.2.0/mustache.min.js" integrity="sha256-1/0GA1EkYejtvYFoa+rSq4LfM4m5zKI13Z1bQIhI4Co=" crossorigin="anonymous"></script>
         <!-- nicer arrows for the collapsible panels and preformatted text-->
         <style>
         * {

--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -210,6 +210,7 @@ function find_patterns(segment) {
         if (!p.pattern)
             continue
         let r = new RegExp(p.pattern, 'gm');
+        let m;
         while (m = r.exec(segment)) {
             links.push({link_html: Mustache.render(link_template,
                                                    {

--- a/tests.html
+++ b/tests.html
@@ -1,8 +1,8 @@
 <meta charset="utf8" />
 <head>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.2.1/dist/sql-wasm.js'></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha256-IUOUHAPazai08QFs7W4MbzTlwEWFo7z/4zw8YmxEiko=" crossorigin="anonymous">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.2.1/dist/sql-wasm.js" integrity="sha256-1mDb9YqGizNOF0OlwicJqO7i2swLOzZAFBAAOeIE+XM=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0" integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous"></script>
 </head>
 <html>
     <body>

--- a/tests.html
+++ b/tests.html
@@ -601,7 +601,7 @@
 
         // Create graph itself
         const ctx = document.getElementById(id);
-        const chart = new Chart(ctx, {
+        new Chart(ctx, {
             type: "line",
             data: {
                 labels: labels,

--- a/tests.html
+++ b/tests.html
@@ -144,7 +144,7 @@
                 repo = "%"; // Use SQL wildcard
 
             if (test) {
-                const top10 = []
+                const top10 = [];
                 const rows = db.exec(`
                         SELECT context, COUNT(*) AS failed
                         FROM TestRuns
@@ -270,7 +270,7 @@
                 // Get all failures sorted by number of occurrences
                 // Ignore selenium tests as they have a bug where skipped tests show up as failures.
                 // They are also deprecated and not very flaky, so not interesting to show.
-                const top10 = []
+                const top10 = [];
                 const rows = db.exec(`
                         SELECT t1.testname, TestRuns.project, (t2.failed * 100.0) / COUNT(run) AS percent
                         FROM Tests AS t1

--- a/tests.html
+++ b/tests.html
@@ -144,7 +144,7 @@
                 repo = "%"; // Use SQL wildcard
 
             if (test) {
-                top10 = []
+                const top10 = []
                 const rows = db.exec(`
                         SELECT context, COUNT(*) AS failed
                         FROM TestRuns
@@ -258,7 +258,7 @@
                 const data = [];
                 Object.keys(counter).forEach(m => {
                     if (counter[m] > 1) { // Don't show message that happened just once
-                        logs = messages.reduce((a, mx) => {if (mx[0] === m && a.indexOf(mx[1]) < 0) a.push(mx[1]); return a;}, []).splice(0, 2);
+                        const logs = messages.reduce((a, mx) => {if (mx[0] === m && a.indexOf(mx[1]) < 0) a.push(mx[1]); return a;}, []).splice(0, 2);
                         data.push([m, counter[m], logs]);
                     }
                 });
@@ -270,7 +270,7 @@
                 // Get all failures sorted by number of occurrences
                 // Ignore selenium tests as they have a bug where skipped tests show up as failures.
                 // They are also deprecated and not very flaky, so not interesting to show.
-                top10 = []
+                const top10 = []
                 const rows = db.exec(`
                         SELECT t1.testname, TestRuns.project, (t2.failed * 100.0) / COUNT(run) AS percent
                         FROM Tests AS t1
@@ -372,7 +372,7 @@
                                 WHERE t1.time > ${from.getTime() / 1000} AND t1.time < ${to.getTime() / 1000} AND project LIKE '${repo}'
                                 GROUP BY revision, context`);
                     if (prs.length) {
-                        shas = {};
+                        const shas = {};
                         prs[0].values.forEach(i => {
                             if (i[2] !== "success")
                                 shas[i[0]] = -1;


### PR DESCRIPTION
This takes care of all relevant HTML/JS alerts in PR #4039. Let's land this first and then re-run, to avoid losing the alerts the next time (due to comparison with the previous scan).

I tested this locally with downloading the raw log from [this test](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4044-20221110-231108-a4e66841-fedora-37-cockpit-project-cockpit/log.html#71-2), as well as downloading https://logs-https-frontdoor.apps.ocp.ci.centos.org/test-results.db and putting that next to tests.html; and then `python3 -m http.server` and checking http://localhost:8000/lib/s3-html/log.html and localhost:8000/tests.html