### PR TITLE
image-customize: add support for installing wheels

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -85,6 +85,11 @@ class InstallAction(ActionBase):
             machine_instance.upload([os.path.abspath(package)], dest)
             package = dest
 
+        # requesting install of Python wheel?
+        if package.endswith('.whl'):
+            machine_instance.execute(f"pip install --no-index --prefix=/usr {package}", timeout=120)
+            return
+
         # this will fail if neither is available -- exception is clear enough, this is a developer tool
         out = machine_instance.execute("which dnf || which yum || which apt-get")
         if 'dnf' in out:

--- a/image-customize
+++ b/image-customize
@@ -77,6 +77,14 @@ class InstallAction(ActionBase):
     '''Install local rpm or distro package'''
     @staticmethod
     def execute(machine_instance, package):
+        # If we have a '/' in the package name, or if a file with that name
+        # exists in the current directory, then assume that this is a package
+        # we're uploading from the host.
+        if '/' in package or os.path.isfile(package):
+            dest = "/var/tmp/" + os.path.basename(package)
+            machine_instance.upload([os.path.abspath(package)], dest)
+            package = dest
+
         # this will fail if neither is available -- exception is clear enough, this is a developer tool
         out = machine_instance.execute("which dnf || which yum || which apt-get")
         if 'dnf' in out:
@@ -85,14 +93,6 @@ class InstallAction(ActionBase):
             install_command = "yum --setopt=skip_missing_names_on_install=False -y install"
         else:
             install_command = "apt-get install -y"
-
-        if os.path.isfile(package):
-            pname = os.path.basename(package)
-            dest = "/var/tmp/" + pname
-            machine_instance.upload([os.path.abspath(package)], dest)
-            package = dest
-        elif '/' in package:
-            sys.stderr.write("Bad package name or path: %s\n" % package)
 
         machine_instance.execute(f"{install_command} {package}", timeout=1800)
 

--- a/image-customize
+++ b/image-customize
@@ -89,7 +89,7 @@ class InstallAction(ActionBase):
         if os.path.isfile(package):
             pname = os.path.basename(package)
             dest = "/var/tmp/" + pname
-            machine_instance.upload([package], dest)
+            machine_instance.upload([os.path.abspath(package)], dest)
             package = dest
         elif '/' in package:
             sys.stderr.write("Bad package name or path: %s\n" % package)

--- a/images/scripts/fedora.setup
+++ b/images/scripts/fedora.setup
@@ -40,6 +40,7 @@ openssl \
 PackageKit \
 pcp \
 pcp-libs \
+python3-pip \
 python3-tracer \
 qemu-block-curl \
 qemu-char-spice \


### PR DESCRIPTION
Here's a proposal to make the installation of Python binary packages (as per cockpit-project/cockpit#17922) more elegant.

It's possible to implement the functionality in the other PR without the addition of the option to `image-customize`, but:
 - we should install `pip` into at least `fedora-36` (and soon `fedora-37`) to avoid downloading it each time (and potentially failing due to infra issues, etc).
 - the abspath fix here makes sense in any case
 - after those two changes, the patch itself is rather small

Note: the reordering of the package-manager check vs. the file upload here made the logic a bit easier because it allowed an early exit for the python case.  Otherwise, we'd have ended up with either something like this:

```
   if whl:
      command = pip
   else:
      out = execute('which...')
      if out == 'dnf':
          ....
```
(ie: over-indented block)

or

```
    out = execute('which...')
    if whl:
        command = pip
    elif out == 'dnf':
        ...
```
(ie: unnecessary `which` invocations for the wheel case).


I'm open to implementing this as either of those options.  The re-odering was just my personal preference.

 * [x] image-refresh fedora-36