### PR TITLE
task: Fix issue.number to be an integer

### DIFF
--- a/task/__init__.py
+++ b/task/__init__.py
@@ -180,7 +180,7 @@ def run(context, function, **kwargs):
             return "No such issue: {0}".format(number)
         elif issue["title"].startswith("WIP:"):
             return "Issue is work in progress: {0}: {1}\n".format(number, issue["title"])
-        issue["number"] = number
+        issue["number"] = int(number)
         kwargs["issue"] = issue
         kwargs["title"] = issue["title"]
 


### PR DESCRIPTION
This fixes a regression from commit e311d26c10 that fails to turn an existing issue into a pull request.

---

See failed image refresh in #4093. This is unfortunately hard to test in an existing PR, which is why I didn't catch it before.