### PR TITLE
Debug failed image-refresh

### DIFF
--- a/image-create
+++ b/image-create
@@ -118,6 +118,9 @@ class MachineBuilder:
         """Start the system to make sure it can boot, then shutdown cleanly"""
 
         self.machine.start()
+        self.machine.message("SPAWNING VIRSH CONSOLE")
+        self.machine.spawn("virsh -c qemu:///session console %s > /tmp/consoleoutput" % str(self.machine._domain.name()), "consoleoutput")
+
         # avoid too long boot times -- they cause painfully long tests, and are a bug
         try:
             timeout = 30

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -478,21 +478,36 @@ class VirtMachine(Machine):
         if self._domain:
             start_time = time.time()
             while (time.time() - start_time) < timeout_sec:
+                self.message("HERE1")
                 try:
                     with stdchannel_redirected(sys.stderr, os.devnull):
                         if not self._domain.isActive():
                             break
                 except libvirt.libvirtError as le:
+                    self.message("LOG1")
+                    self.message(str(le))
                     if 'no domain' in str(le) or 'not found' in str(le):
                         break
                     raise
                 time.sleep(1)
             else:
+                self.message("HERE2")
+                domain_name = self._domain.name()
+                home = os.path.expanduser('~')
+                self.message("CONSOLE OUTPUT:")
+                self.message(self.execute("cat /tmp/consoleoutput"))
+                with open(f'{home}/.cache/libvirt/qemu/log/{domain_name}.log') as f:
+                    contents = f.read()
+                    self.message("LOG2")
+                    self.message(contents)
                 raise Failure("Waiting for machine poweroff timed out")
             try:
+                self.message("HERE3")
                 with stdchannel_redirected(sys.stderr, os.devnull):
                     self._domain.destroyFlags(libvirt.VIR_DOMAIN_DESTROY_DEFAULT)
             except libvirt.libvirtError as le:
+                self.message("LOG3")
+                self.message(str(le))
                 if 'not found' not in str(le) and 'not running' not in str(le):
                     raise
         self._cleanup(quick=True)


### PR DESCRIPTION
https://github.com/cockpit-project/bots/issues/4100 and https://github.com/cockpit-project/bots/issues/4103 are failing with `image-create: Waiting for machine poweroff timed out`
Cannot reproduce failures locally.
Add some more useful logs to see what happens.

 * [ ] FAIL: image-refresh fedora-37