### PR TITLE
task: Switch over main AMQP server to CentOS CI

### DIFF
--- a/task/distributed_queue.py
+++ b/task/distributed_queue.py
@@ -43,8 +43,10 @@ BASELINE_PRIORITY = 5
 MAX_PRIORITY = 9
 # see https://github.com/cockpit-project/cockpituous/blob/main/tasks/cockpit-tasks-webhook.yaml
 DEFAULT_SECRETS_DIR = '/run/secrets/webhook'
-# main deployment on AWS
-DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
+# main deployment on CentOS CI
+DEFAULT_AMQP_SERVER = 'amqp-cockpit.apps.ocp.cloud.ci.centos.org:443'
+# fallback deployment on AWS
+# DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
 
 arguments = {
     'rhel': {


### PR DESCRIPTION
We got an account on the new CentOS CI cluster. Move our primary webhook back to that, as it's much easier to administer on OpenShift than maintaining a whole AWS instance just for that.

Keep the AWS one as commened out fallback, so that we by and large go back to the state before commit 17e33a31285ce (except for the changed route hostname).

-----

The new webhook is already deployed, see https://github.com/cockpit-project/cockpituous/pull/540. In order to use it, we need to switch the GitHub setup for all projects, in lockstep with landing this. Go to https://github.com/ORG/PROJECT/settings/hooks , select the "ec2-3-228-126.." one, and change it to "http://amqp-cockpit.apps.ocp.cloud.ci.centos.org

 - [ ] @pitti: change for cockpit, c-{podman,machines,ostree,certificates}, starter-kit
 - [ ] @pitti: change for osbuild/cockpit-composer
 - [ ] @jkonecny12: change for rhinstaller/anaconda
 - [ ] @ptoscano : change for candlepin/subscription-manager{,-cockpit}

@jkonecny12 and @ptoscano, please let me know here if/when you can do this. If possible, I'd like to do the switch tomorrow morning. This needs to be coordinated a bit as once this lands, your PRs won't get any tests until you change the webhook.