### PR TITLE
run-queue: Skip test queues on bots without /dev/kvm

### DIFF
--- a/run-queue
+++ b/run-queue
@@ -95,17 +95,22 @@ def consume_webhook_queue(channel, amqp):
 
 
 def consume_task_queue(channel, amqp, declare_public_result, declare_rhel_result, declare_stats_result):
-    queue = 'public'
-    if redhat_network():
-        # Try the rhel queue if the public queue is empty
-        if declare_public_result.method.message_count == 0:
-            queue = 'rhel'
-            # If both are non-empty, shuffle
-        elif declare_rhel_result.method.message_count > 0:
-            queue = ['public', 'rhel'][random.randrange(2)]
-
     if statistics_queue and declare_stats_result.method.message_count > 0:
-        queue = [queue, 'statistics'][random.randrange(2)]
+        # statistics queue is quick to process, always do that first
+        queue = 'statistics'
+    elif os.path.exists('/dev/kvm') or os.getenv('COCKPIT_TESTMAP_INJECT'):
+        # only process test queues in capable environments: with KVM support, or during integration tests
+        queue = 'public'
+        if redhat_network():
+            # Try the rhel queue if the public queue is empty
+            if declare_public_result.method.message_count == 0:
+                queue = 'rhel'
+                # If both are non-empty, shuffle
+            elif declare_rhel_result.method.message_count > 0:
+                queue = ['public', 'rhel'][random.randrange(2)]
+    else:
+        # nothing to do
+        return None, None
 
     method_frame, header_frame, body = channel.basic_get(queue=queue)
     if not method_frame:


### PR DESCRIPTION
On the old CentOS CI cluster we could also run integration tests. On the new one there is no KVM support. So change the logic to only process the 'public' and 'rhel' queues if /dev/kvm exists. That way, we can run a tasks container which *only* processes the statistics queue.

Also, if the statistics queue has entries, always process them first, instead of flipping a coin. statistics are quick to process and should get updated timely.

 -----

Note that there are no tasks containers on the old CentOS CI any more, i.e. there is *no* production infra that sets `$RUN_STATISTICS_QUEUE`. This must however still work on e2e and PSI.

 - [x] I expect unit tests to [fail](https://github.com/cockpit-project/bots/actions/runs/3686472793/jobs/6238744172) , as GitHub actions also don't have /dev/kvm. Add a test override for this.
 - [x] Test this on a tasks container on new CentOS CI: https://github.com/cockpit-project/cockpituous/pull/541