### PR TITLE
lib: Treat TODO TAP entries as skips in log.html

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -137,8 +137,9 @@
         <script>
 
 const tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
-const tap_result = /^(ok|not ok) ([0-9]+) (.*)(?: # duration: ([0-9]+s))?(?: # SKIP .*)?$/gm;
+const tap_result = /^(ok|not ok) ([0-9]+) (.*)(?: # duration: ([0-9]+s))?(?: # (?:SKIP|TODO) .*)?$/gm;
 const tap_skipped = /^ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # SKIP (.*$)/gm;
+const tap_todo = /^not ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # TODO (.*$)/gm;
 const tap_total_time = /^# (\d+ TESTS FAILED|TESTS PASSED) \[([0-9]+)s on .*\]$/m;
 
 const entry_template = document.querySelector("#TestEntry").innerHTML;
@@ -279,6 +280,7 @@ function extract(text) {
             tap_range.lastIndex = 0;
             tap_result.lastIndex = 0;
             tap_skipped.lastIndex = 0;
+            tap_todo.lastIndex = 0;
             const entry = { passed: true,
                           skipped: false,
                           retried: false,
@@ -299,6 +301,8 @@ function extract(text) {
                 if (m[4])
                     entry.title += ", duration: " + m[4];
 
+                const todo_match = tap_todo.exec(segment);;
+
                 if (segment.indexOf("# RETRY") !== -1) {
                     if (segment.indexOf("(test affected tests 3 times)") !== -1) {
                         affected_retries += 1;
@@ -310,7 +314,7 @@ function extract(text) {
                         entry.interesting = true;
                     }
                 } else if(m[1] == "ok") {
-                    const skip_match = tap_skipped.exec(segment);
+                    const skip_match = tap_skipped.exec(segment);;
                     if (skip_match) {
                         entry.title = entry.id + ": " + skip_match[1];
                         entry.reason = skip_match[3];
@@ -320,6 +324,11 @@ function extract(text) {
                     } else {
                         passed += 1;
                     }
+                } else if(todo_match) {
+                    entry.title = entry.id + ": " + todo_match[1];
+                    entry.reason = todo_match[3];
+                    entry.skipped = true;
+                    skipped += 1;
                 } else {
                     entry.passed = false;
                     entry.interesting = true;


### PR DESCRIPTION
The TAP specification defines "todo" tests [1]. Format failed TODO tests the same way as skipped tests, so that they stop appearing as failures, but still stand out the same way as skips are.

[1] https://testanything.org/tap-specification.html#todo-tests

----

I tested this on [this run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18045-20221215-133023-56f9e5e3-fedora-37/log.html) from https://github.com/cockpit-project/cockpit/pull/18045 , which currently looks like this:

![image](https://user-images.githubusercontent.com/200109/208359588-7df4dfde-9d0a-4dd9-9ae8-693e288ba27b.png)
[...]
![image](https://user-images.githubusercontent.com/200109/208359671-81a070cf-4066-49cc-8ba2-e760a46d5f57.png)

To test this PR, download the raw `log` next to log.html, start `python3 -m http.server`, and http://localhost:8000/log.html now looks like this:

![image](https://user-images.githubusercontent.com/200109/208359828-25875108-e7fc-459b-be66-e33e9eb98c7e.png)
[...]
![image](https://user-images.githubusercontent.com/200109/208359884-1611db6f-fef8-4357-a5fd-62ef0d99a9bf.png)

We can certainly debate the visual design, but IMHO that's at least some improvement.