### PR TITLE
testmap: Drop rhel-8-7 for cockpit-podman

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -78,7 +78,6 @@ REPO_BRANCH_CONTEXT = {
     'cockpit-project/cockpit-podman': {
         'main': [
             'arch',
-            'rhel-8-7',
             'rhel-8-8',
             'rhel-9-1',
             'fedora-36',
@@ -92,6 +91,7 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'centos-8-stream',
             'fedora-rawhide',
+            'rhel-9-2',
         ],
     },
     'cockpit-project/cockpit-machines': {


### PR DESCRIPTION
These are released RHELs, and history for us. 8.8/9.2 is the current
focus. Unfortunately podman on 9.2 is completely broken, so keep 9.1 for 
now, but add rhel-9-2 as a manual context.
