### PR TITLE
testmap: Drop rhel-8-7 and rhel-9-1 for cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -38,11 +38,9 @@ REPO_BRANCH_CONTEXT = {
             f'{TEST_OS_DEFAULT}/firefox',
             f'{TEST_OS_DEFAULT}/pybridge',
             'fedora-coreos',
-            'rhel-8-7',
-            'rhel-8-7-distropkg',
             'rhel-8-8',
+            'rhel-8-8-distropkg',
             'centos-8-stream',
-            'rhel-9-1',
             'rhel-9-2',
         ],
         'rhel-7.9': [


### PR DESCRIPTION
These are released RHELs, and history for us. 8.8/9.2 is the current focus.

---

This introduces rhel-8-8-distropkg, which needs to be tested first.