### PR TITLE
testmap: Drop rhel-8-7 for c-machines, declare rhel-9-2

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -104,7 +104,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-36',
             'fedora-37',
             f'{TEST_OS_DEFAULT}/firefox',
-            'rhel-8-7',
             'rhel-8-8',
             'rhel-9-1',
             'centos-8-stream',
@@ -113,6 +112,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-rawhide',
             'fedora-testing',
             f'{TEST_OS_DEFAULT}/devel',
+            'rhel-9-2',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
RHEL 8.7 is released, 8.8 is the current development focus. The tests still need adjustment on 9.2, so keep 9.1 for the time being and declare rhel-9-2 as manual test.