### PR TITLE
workflows: Pacify git's permission check in unit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
+      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+      - name: Pacify git's permission check
+        run: git config --global --add safe.directory /__w/bots/bots
+
       - name: Run test
         run: test/run
 


### PR DESCRIPTION
The check has started to fail with "fatal: detected dubious ownership in repository" when it tries to call `git config`. The workflow work directory /__w is shared with the host in the container that runs the test, that's fine.

See https://github.blog/2022-04-12-git-security-vulnerability-announced/

---

See the [recent failures](https://github.com/cockpit-project/bots/actions/runs/3819205498/jobs/6496581725) of the "bots" workflow.