### PR TITLE
naughty: add alternative expression to match failures for selinux gssproxy regression

### DIFF
--- a/naughty/fedora-38/4160-selinux-gssproxy-alternative-0
+++ b/naughty/fedora-38/4160-selinux-gssproxy-alternative-0
@@ -1,0 +1,1 @@
+error: Failed to start pool nfs-pool*

--- a/naughty/fedora-38/4160-selinux-gssproxy-alternative-1
+++ b/naughty/fedora-38/4160-selinux-gssproxy-alternative-1
@@ -1,0 +1,1 @@
+RuntimeError: Timed out on 'virsh pool-start nfs-pool*'


### PR DESCRIPTION
This will mark as xfail noumerous tests on cockpit-machines rawhide test runs.