### PR TITLE
Add pattern for selinux prohibiting iscsi pool to start

### DIFF
--- a/naughty/fedora-38/4231-iscsi-selinux
+++ b/naughty/fedora-38/4231-iscsi-selinux
@@ -1,0 +1,3 @@
+# testAddDiskSCSI (__main__.TestMachinesDisks.testAddDiskSCSI)
+*
+RuntimeError: Timed out on 'virsh pool-start iscsi-pool'

--- a/naughty/fedora-38/4231-iscsi-selinux-alternative-0
+++ b/naughty/fedora-38/4231-iscsi-selinux-alternative-0
@@ -1,0 +1,4 @@
+# testCreateThenInstall (__main__.TestMachinesCreate.testCreateThenInstall)
+*
+error: Failed to start pool iscsi-pool
+error: internal error: Failed to get host number for iSCSI session with path '/sys/class/iscsi_session/session1/device'

--- a/naughty/fedora-38/4231-iscsi-selinux-alternative-1
+++ b/naughty/fedora-38/4231-iscsi-selinux-alternative-1
@@ -1,0 +1,3 @@
+# testCreateThenInstall (__main__.TestMachinesCreate.testCreateThenInstall)
+*
+RuntimeError: Timed out on 'virsh pool-define-as iscsi-pool --type iscsi --target /dev/disk/by-id --source-host 127.0.0.1 --source-dev iqn.2019-09.cockpit.lan; ls -la /dev/disk/by-id; virsh pool-start iscsi-pool'


### PR DESCRIPTION
Known issue #4231
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2157732