### PR TITLE
testmap: add fedora-testing to for manual podman testing

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -89,6 +89,7 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'centos-8-stream',
             'fedora-rawhide',
+            'fedora-testing',
             'rhel-9-2',
         ],
     },


### PR DESCRIPTION
Allow testing fedora-testing in cockpit-podman.

Let's test it first manually, then if it's all good add it to `IMAGE_REFRESH_TRIGGERS`. I see that cockpit-machines is also missing there so I'll make a test PR for that as well.