### PR TITLE
testmap: Declare rhel-9-2 as manual context for sub-man-cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -179,6 +179,7 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream/subscription-manager-1.28',
             'rhel-8-7',
             'rhel-8-7/subscription-manager-1.28',
+            'rhel-9-2',
         ],
     },
     'cockpit-project/cockpit-certificates': {


### PR DESCRIPTION
Commit b85fb7d97edc7557ea47423f44bfe0bfad5dab86 introduced this variant for services image but not for sub-man-cockpit itself.