### PR TITLE
naughty: Adjust pattern for #4308

### DIFF
--- a/naughty/fedora-38/4308-virt-edit-cdrom
+++ b/naughty/fedora-38/4308-virt-edit-cdrom
@@ -5,4 +5,4 @@ Traceback (most recent call last):
     b.wait_not_present(".pf-c-modal-box")
 *
 testlib.Error: timeout
-wait_js_cond(!ph_is_present(".pf-c-modal-box")): Uncaught (in promise) Error: condition did not become true
+wait_js_cond(!ph_is_present(".pf-c-modal-box"))


### PR DESCRIPTION
The traceback is formatted slightly differently with Python 3.11 on rawhide:

   wait_js_cond(!ph_is_present(".pf-c-modal-box")): timeout

Relax the pattern accordingly.

-----

This fixes c-machines rawhide tests on the TF, see [recent log](https://artifacts.dev.testing-farm.io/7f17b501-820c-40a8-8383-88b13a9019e2/);  [other example](https://artifacts.dev.testing-farm.io/7e0de186-65c0-470b-9cb7-87461b9f86b7/)