### PR TITLE
image-customize: Call pip as module

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -87,7 +87,7 @@ class InstallAction(ActionBase):
 
         # requesting install of Python wheel?
         if package.endswith('.whl'):
-            machine_instance.execute(f"pip install --no-index --prefix=/usr {package}", timeout=120)
+            machine_instance.execute(f"python3 -m pip install --no-index --prefix=/usr {package}", timeout=120)
             return
 
         # this will fail if neither is available -- exception is clear enough, this is a developer tool


### PR DESCRIPTION
`pip` does not exist on RHEL/CentOS 8, but it can be called as module name.

---

With that, `test/image-prepare -q --python centos-8-stream` succeeds. Now it's failing left and right on walruses and other py3.6-isms, but with this we can at least start tests.