### PR TITLE
testmap: Move Fedora CoreOS to Fedora 37

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -224,7 +224,7 @@ REPO_BRANCH_CONTEXT = {
 # The OSTree variants can't build their own packages, so we build in
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
-    "fedora-coreos": "fedora-36",
+    "fedora-coreos": "fedora-37",
     "rhel4edge": "rhel-9-1",
 }
 


### PR DESCRIPTION
 - [x] https://github.com/cockpit-project/cockpit/pull/18338
 - [x] refresh fedora-coreos image to pick this up: #4402