### PR TITLE
images: Install python3 into fedora-coreos

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-1d09957fd5eae84ffedee10e96179868fca4da17661de5a6617e953afbf5478f.qcow2
+fedora-coreos-3250dd9b37706a4f0fd035a843ac2efa32a3037a8eb20c86d8132f1115ae89be.qcow2

--- a/images/scripts/ostree.setup
+++ b/images/scripts/ostree.setup
@@ -16,7 +16,8 @@ if [ "$IMAGE" == "fedora-coreos" ]; then
     systemctl disable --now zincati.service
 
     # pre-install the distro version, which is useful for testing extensions and manual experiments
-    rpm-ostree install cockpit-system cockpit-bridge cockpit-networkmanager
+    # also install Python for future pybridge, until c-bridge package grows that package dependency
+    rpm-ostree install cockpit-system cockpit-bridge cockpit-networkmanager python3
 fi
 
 if [ "$IMAGE" == "rhel4edge" ]; then


### PR DESCRIPTION
Our future Python bridge will require this. Once we switch officially, the cockpit-bridge package will grow a `python3` package dependency; until that happens, install it explicitly so that we can run a /pytest scenario.

 * [x] image-refresh fedora-coreos