### PR TITLE
testmap: trigger cockpit-podman on fedora-testing refreshes

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -225,6 +225,7 @@ IMAGE_REFRESH_TRIGGERS = {
     "fedora-testing": [
         "fedora-testing@cockpit-project/cockpit",
         "fedora-testing/dnf-copr@cockpit-project/cockpit",
+        "fedora-testing@cockpit-project/cockpit-podman",
     ],
     # some tests run against centos-7's cockpit-ws for backwards compat testing
     "centos-7": [


### PR DESCRIPTION
We found that fedora-testing worked fine with cockpit-podman and we should really test it when we update fedora-testing. (podman usually lands in updates testing as now with 4.4.0)