### PR TITLE
image-customize: Install wheels into /usr/local/

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -87,7 +87,7 @@ class InstallAction(ActionBase):
 
         # requesting install of Python wheel?
         if package.endswith('.whl'):
-            machine_instance.execute(f"python3 -m pip install --no-index --prefix=/usr {package}", timeout=120)
+            machine_instance.execute(f"python3 -m pip install --no-index --prefix=/usr/local {package}", timeout=120)
             return
 
         # this will fail if neither is available -- exception is clear enough, this is a developer tool


### PR DESCRIPTION
Installing into /usr does not work on OSTree. And even on writable /usr it is unfriendly, as it clobbers distro files. With that we can much more easily compare the py and C bridge behaviour on the same image.

----

This is going to fail for cockpit, as some of the tests have /usr/bin/cockpit-bridge hardcoded. I'll fix that, but want to get a first test run.

 - https://github.com/cockpit-project/cockpit/pull/18333