### PR TITLE
testmap: add cockpit-machines to fedora-testing

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -225,6 +225,7 @@ IMAGE_REFRESH_TRIGGERS = {
     "fedora-testing": [
         "fedora-testing@cockpit-project/cockpit",
         "fedora-testing/dnf-copr@cockpit-project/cockpit",
+        "fedora-testing@cockpit-project/cockpit-machines",
         "fedora-testing@cockpit-project/cockpit-podman",
     ],
     # some tests run against centos-7's cockpit-ws for backwards compat testing


### PR DESCRIPTION
When refreshing fedora-testing also test cockpit-machines.

https://github.com/cockpit-project/cockpit-machines/pull/948
Succeeded today here https://cockpit-logs.us-east-1.linodeobjects.com/pull-948-20230213-152917-323e5a0d-fedora-testing/log.html