### PR TITLE
naughty: rawhide is now Fedora 39

### DIFF
--- a/naughty/fedora-39/4160-selinux-gssproxy
+++ b/naughty/fedora-39/4160-selinux-gssproxy
@@ -1,0 +1,3 @@
+> warning: mount.nfs: Broken pipe
+*
+wait_js_cond(!ph_is_present("#dialog")): timeout

--- a/naughty/fedora-39/4160-selinux-gssproxy-alternative-0
+++ b/naughty/fedora-39/4160-selinux-gssproxy-alternative-0
@@ -1,0 +1,1 @@
+error: Failed to start pool nfs-pool*

--- a/naughty/fedora-39/4160-selinux-gssproxy-alternative-1
+++ b/naughty/fedora-39/4160-selinux-gssproxy-alternative-1
@@ -1,0 +1,1 @@
+RuntimeError: Timed out on 'virsh pool-start nfs-pool*'

--- a/naughty/fedora-39/4160-selinux-gssproxy-alternative-2
+++ b/naughty/fedora-39/4160-selinux-gssproxy-alternative-2
@@ -1,0 +1,3 @@
+# testStoragePoolsCreate (__main__.TestMachinesStoragePools.testStoragePoolsCreate)
+*
+wait_js_cond(ph_is_present("#my_dir_pool_two-system-create-volume-button:enabled")): timeout

--- a/naughty/fedora-39/4231-iscsi-selinux
+++ b/naughty/fedora-39/4231-iscsi-selinux
@@ -1,0 +1,3 @@
+# testAddDiskSCSI (__main__.TestMachinesDisks.testAddDiskSCSI)
+*
+RuntimeError: Timed out on 'virsh pool-start iscsi-pool'

--- a/naughty/fedora-39/4231-iscsi-selinux-alternative-0
+++ b/naughty/fedora-39/4231-iscsi-selinux-alternative-0
@@ -1,0 +1,4 @@
+# testCreateThenInstall (__main__.TestMachinesCreate.testCreateThenInstall)
+*
+error: Failed to start pool iscsi-pool
+error: internal error: Failed to get host number for iSCSI session with path '/sys/class/iscsi_session/session1/device'

--- a/naughty/fedora-39/4231-iscsi-selinux-alternative-1
+++ b/naughty/fedora-39/4231-iscsi-selinux-alternative-1
@@ -1,0 +1,3 @@
+# testCreateThenInstall (__main__.TestMachinesCreate.testCreateThenInstall)
+*
+RuntimeError: Timed out on 'virsh pool-define-as iscsi-pool --type iscsi --target /dev/disk/by-id --source-host 127.0.0.1 --source-dev iqn.2019-09.cockpit.lan; ls -la /dev/disk/by-id; virsh pool-start iscsi-pool'

--- a/naughty/fedora-39/4308-virt-edit-cdrom
+++ b/naughty/fedora-39/4308-virt-edit-cdrom
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "test/check-machines-disks", line *, in testInsertDiscCDROM
+*
+  File "test/check-machines-disks", line *, in verify
+    b.wait_not_present(".pf-c-modal-box")
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present(".pf-c-modal-box"))

--- a/naughty/fedora-rawhide
+++ b/naughty/fedora-rawhide
@@ -1,1 +1,1 @@
-fedora-38
+fedora-39


### PR DESCRIPTION
Since Fedora 38 branched, rawhide is now bumped to Fedora-39. Copy fedora-38 naughties over to fedora-39.