### PR TITLE
testmap: drop rhel-8 from subscription-manager/main

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -149,7 +149,6 @@ REPO_BRANCH_CONTEXT = {
     },
     'candlepin/subscription-manager': {
         'main': [
-            'rhel-8-8',
             'rhel-9-0',
             'rhel-9-1',
             'rhel-9-2',


### PR DESCRIPTION
We recently decided to not keep support for Python 3.6 anymore in the 'main' branch of subscription-manager, as it is targeting RHEL 9.x only.