### PR TITLE
testmap: Remove fedora-38-boot from anaconda "_manual"

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -215,7 +215,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'fedora-rawhide-boot/devel',
-            'fedora-38-boot/fedora-38',
         ]
     },
 }


### PR DESCRIPTION
No longer needed, and the "fedora-38" scenario was wrong anyway.