### PR TITLE
Refresh fedora-rawhide-boot

### DIFF
--- a/images/fedora-rawhide-boot
+++ b/images/fedora-rawhide-boot
@@ -1,1 +1,1 @@
-fedora-rawhide-boot-d336ac417adccbbfd5d6548f9f4afc7c7a90860eb27b8a23bb80fc63936381ea.iso
+fedora-rawhide-boot-43cf4caf8177929a742927e69b9beba174d3f1c0f6e01dabf04e8817473ccde3.iso


### PR DESCRIPTION
@M4rtinK says: We need a newer PyKickstart in the image, as a new kickstart command has been added since the current image was fetched.

 * [x] image-refresh fedora-rawhide-boot