### PR TITLE
naughty: Add pattern for missing systemd reload signal on RHEL 8

### DIFF
--- a/naughty/rhel-8/4517-systemd-missing-reload
+++ b/naughty/rhel-8/4517-systemd-missing-reload
@@ -1,0 +1,6 @@
+  File "test/verify/check-system-services", line *, in _testBasic
+    self.toggle_onoff()
+  File "test/verify/check-system-services", line *, in toggle_onoff
+    self.browser.click(".service-top-panel .pf-c-switch__input")
+*
+testlib.Error: *ph_mouse(".service-top-panel*:not*disabled*click*

--- a/naughty/rhel-8/4517-systemd-missing-reload-2
+++ b/naughty/rhel-8/4517-systemd-missing-reload-2
@@ -1,0 +1,4 @@
+  File "test/verify/check-system-services", line *, in _testBasic
+    self.check_service_details*"Disabled"*"Start", "Disallow running*"Pin unit"*
+*
+testlib.Error: *ph_mouse*.service-top-panel*:not*disabled*click*


### PR DESCRIPTION
Known issue #4517

No downstream issue. There is no obvious reproducer, it's a relatively rare race condition, and only happens on RHEL 8. I.e. it's fixed in newer OSes.

--

See #4517 for details. I tested these locally against the failure logs from CI.