### PR TITLE
npm: always pull latest node image

### DIFF
--- a/npm
+++ b/npm
@@ -20,6 +20,7 @@ cmd_sh() {
     # make sure the node user can write to the cache volume
     podman run \
         --rm \
+        --pull=always \
         --volume "${CACHE}":/home/node/.npm:U \
         "${IMAGE}" chown -R node:node /home/node >&2
 


### PR DESCRIPTION
To avoid pull requests which use an old npm version always pull the latest container. Github CI always has the latest container as it has to pull it.