### PR TITLE
Image refresh for fedora-37

### DIFF
--- a/images/fedora-37
+++ b/images/fedora-37
@@ -1,1 +1,1 @@
-fedora-37-ade98d5d634c57af2cbcfc32a3f082140dd4f9aa51d7fdb2fcefa849073bffb6.qcow2
+fedora-37-aac25f2f8bd9005e4dcebddf1ea4b50e62e19e9f30b6304a0964b690a0606e26.qcow2


### PR DESCRIPTION
Image refresh for fedora-37
 * [x] image-refresh fedora-37

* [x] to be landed in lockstep with https://github.com/cockpit-project/cockpit-machines/pull/984