### PR TITLE
setup-deploy-keys: drop the webpack-jumpstart keys

### DIFF
--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -9,9 +9,6 @@
 # You might want this first:
 #   dnf install python3-pynacl
 #
-# Helpful command to check/update the lists below:
-#   git grep -l 'environment: cockpit-dist' (or whatever)
-#
 # Note: this script doesn't delete old secrets, so if you make adjustments,
 #       please do that manually.
 

--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -40,10 +40,6 @@ deploy_to cockpit-project/cockpit \
         cockpit-project/cockpit/npm-update/COCKPIT_DEPLOY_KEY \
         cockpit-project/cockpit/self/DEPLOY_KEY
 
-deploy_to cockpit-project/cockpit-dist \
-    --deploy-from \
-        cockpit-project/cockpit/cockpit-dist/DEPLOY_KEY
-
 deploy_to cockpit-project/cockpit-weblate \
     --deploy-from \
         cockpit-project/cockpit/cockpit-weblate/DEPLOY_KEY
@@ -61,10 +57,6 @@ deploy_to cockpit-project/cockpit-machines \
     --deploy-from \
         cockpit-project/cockpit-machines/npm-update/SELF_DEPLOY_KEY \
         cockpit-project/cockpit-machines/self/DEPLOY_KEY
-
-deploy_to cockpit-project/cockpit-machines-dist \
-    --deploy-from \
-        cockpit-project/cockpit-machines/cockpit-machines-dist/DEPLOY_KEY
 
 deploy_to cockpit-project/cockpit-machines-weblate \
     --deploy-from \


### PR DESCRIPTION
Drop the keys for the cockpit-dist and cockpit-machines-dist repositories.

 - [x] cockpit-project/cockpit#18538
 - [x] remove webpack-jumpstart from cockpit-machines: doesn't actually exist