### PR TITLE
Add missing fedora-38-boot to image-trigger

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -29,6 +29,7 @@ REFRESH = {
     "fedora-36": {},
     "fedora-37": {},
     "fedora-38": {},
+    "fedora-38-boot": {},
     "fedora-testing": {"refresh-days": 3},
     "fedora-coreos": {},
     "fedora-rawhide": {},


### PR DESCRIPTION
This image is supported already but it was missing from the list.