### PR TITLE
testmap: Stop hardcoding rhel-9-2 for cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -377,7 +377,12 @@ def tests_for_image(image):
 
 
 def tests_for_po_refresh(project):
+    # by default, run all tests
+    contexts = REPO_BRANCH_CONTEXT.get(project, {}).get(get_default_branch(project), [])
+    # cockpit's are expensive, so only run a few
     if project == "cockpit-project/cockpit":
-        # check-pages "all languages" test only runs on RHEL; plus required status
-        return ["rhel-9-2", "fedora-coreos"]
-    return REPO_BRANCH_CONTEXT.get(project, {}).get(get_default_branch(project), [])
+        # check-pages "all languages" test only runs on RHEL
+        contexts = sorted([c for c in contexts if c.startswith("rhel-")])[-1:]
+        # plus required f-coreos
+        contexts.append("fedora-coreos")
+    return contexts


### PR DESCRIPTION
This gets outdated whenever we move to a new RHEL image, and we keep forgetting about it. Make this dynamic and use the most recent rhel-* image instead.

----

This caused an abandonded test on https://github.com/cockpit-project/cockpit/pull/18576 as we moved to rhel-9-3 in the meantime.  Tested with

```
❱❱❱ python3 -c 'import lib.testmap; print(lib.testmap.tests_for_po_refresh("cockpit-project/cockpit"))'
['rhel-9-3', 'fedora-coreos']

❱❱❱ python3 -c 'import lib.testmap; print(lib.testmap.tests_for_po_refresh("cockpit-project/cockpit-podman"))'
['arch', 'rhel-8-9', 'rhel-9-3', 'rhel4edge', 'fedora-37', 'fedora-38', 'fedora-37/devel', 'fedora-37/pybridge', 'fedora-coreos', 'debian-testing', 'ubuntu-2204', 'ubuntu-stable']

```