### PR TITLE
image-diff: Use default format for ubuntu and debian

### DIFF
--- a/image-diff
+++ b/image-diff
@@ -29,7 +29,7 @@ def get_packages(machine):
     # We'd ideally like to get source packages everywhere, but it's a
     # bit more difficult on RPM. (TODO)
     pkgcmd = """if type dpkg-query > /dev/null 2>&1; then
-                    dpkg-query -W -f='${source:Package}\t${version}\n' 2>/dev/null;
+                    dpkg-query -W 2>/dev/null;
                 elif type rpm > /dev/null 2>&1; then
                     rpm -qa --qf '%{NAME}\t%{EVR}\n' 2>/dev/null;
                 else pacman -Q | sed 's/ /\t/' 2>/dev/null; fi"""


### PR DESCRIPTION
Default format is `${binary:Package}\t${version}`. Difference between binary and source is that source shows name of source package while binary shows name of the binary package. This view shows actual package names which user can upgrade, downgrade, remove, install... The source package often does not align with actual package names.

@allisonkarlitskaya and @martinpitt what was the reason behind using source package name?