### PR TITLE
testmap: Fix services image triggers

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -260,7 +260,7 @@ IMAGE_REFRESH_TRIGGERS = {
         "debian-stable@cockpit-project/cockpit",
         "rhel-9-3@cockpit-project/cockpit",
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",
-        "rhel-8-8@candlepin/subscription-manager",
+        "rhel-8-8@candlepin/subscription-manager/subscription-manager-1.28",
         "rhel-9-2@candlepin/subscription-manager-cockpit",
     ],
     # Anaconda builds in fedora-37 and runs tests in fedora-rawhide-boot


### PR DESCRIPTION
This was forgotten in commit 484f42605c.

---

Spotted in services image refresh in #4587