### PR TITLE
services: less aggressive wait for grafana startup

### DIFF
--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -191,7 +191,7 @@ podman run -d --rm --name grafana -p 3000:3000 \
     docker.io/bitnami/grafana
 
 # wait until set up completed
-until curl http://localhost:3000; do sleep 1; done
+until curl http://localhost:3000; do sleep 5; done
 podman stop grafana
 
 cat <<EOF > /root/run-grafana


### PR DESCRIPTION
According to what I noticed in refreshes of the services image either done automatically by cockpituous or manually, it seems grafana requires at least 10-15 seconds to start answering after the startup of its contained.

Hence, poll for its finished setup less aggressively than once per seconds, doing it only once every 5 seconds. In the worst case, it will take up to 4 seconds more to wait for grafana, with the advantage of spamming less with requests.