### PR TITLE
testmap: Rename "dnf-copr" scenario to "daily"

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -52,7 +52,7 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-testing',
-            'fedora-testing/dnf-copr',
+            'fedora-testing/daily',
             'fedora-rawhide',
         ],
     },
@@ -243,7 +243,7 @@ OSTREE_BUILD_IMAGE = {
 IMAGE_REFRESH_TRIGGERS = {
     "fedora-testing": [
         "fedora-testing@cockpit-project/cockpit",
-        "fedora-testing/dnf-copr@cockpit-project/cockpit",
+        "fedora-testing/daily@cockpit-project/cockpit",
         "fedora-testing@cockpit-project/cockpit-machines",
         "fedora-testing@cockpit-project/cockpit-podman",
     ],


### PR DESCRIPTION
This follows the same change in Cockpit, where this scenario now also installs daily udisks2 rpms.

https://github.com/cockpit-project/cockpit/pull/18616