### PR TITLE
naughty: Add pattern for sss_ssh_knownhostsproxy leak

### DIFF
--- a/naughty/fedora-37/4635-sssd-knownhostsproxy-leak
+++ b/naughty/fedora-37/4635-sssd-knownhostsproxy-leak
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+*
+  File "test/verify/check-system-realms", line *, in testQualifiedUsers
+    self.checkBackendSpecifics()
+*
+RuntimeError: Timed out on 'while loginctl --no-legend list-sessions | grep -qi 'admin@COCKPIT.LAN.*web console'; do sleep 1; done'

--- a/naughty/fedora-38/4635-sssd-knownhostsproxy-leak
+++ b/naughty/fedora-38/4635-sssd-knownhostsproxy-leak
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+*
+  File "test/verify/check-system-realms", line *, in testQualifiedUsers
+    self.checkBackendSpecifics()
+*
+RuntimeError: Timed out on 'while loginctl --no-legend list-sessions | grep -qi 'admin@COCKPIT.LAN.*web console'; do sleep 1; done'

--- a/naughty/fedora-39/4635-sssd-knownhostsproxy-leak
+++ b/naughty/fedora-39/4635-sssd-knownhostsproxy-leak
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+*
+  File "test/verify/check-system-realms", line *, in testQualifiedUsers
+    self.checkBackendSpecifics()
+*
+RuntimeError: Timed out on 'while loginctl --no-legend list-sessions | grep -qi 'admin@COCKPIT.LAN.*web console'; do sleep 1; done'

--- a/naughty/rhel-9/4635-sssd-knownhostsproxy-leak
+++ b/naughty/rhel-9/4635-sssd-knownhostsproxy-leak
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+*
+  File "test/verify/check-system-realms", line *, in testQualifiedUsers
+    self.checkBackendSpecifics()
+*
+RuntimeError: Timed out on 'while loginctl --no-legend list-sessions | grep -qi 'admin@COCKPIT.LAN.*web console'; do sleep 1; done'


### PR DESCRIPTION
Issue #4635
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2185785

---

This addresses one of our [current top flakes](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?days=7&test=test%2Fverify%2Fcheck-system-realms+TestIPA.testQualifiedUsers) :

![image](https://user-images.githubusercontent.com/200109/231094151-077aa40b-a9fa-4fb0-9bb2-6dc962f43eae.png)

[example log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18609-20230406-123116-211c14b3-fedora-37-devel/log.html#279)

