### PR TITLE
cockpit-lib-update: automatically bump COCKPIT_REPO_COMMIT

### DIFF
--- a/cockpit-lib-update
+++ b/cockpit-lib-update
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Update COCKPIT_REPO_COMMIT to cockpit HEAD automatically, defaults to
+# Makefile as input optionally the full path can be provided. (For example
+# Anaconda uses ui/webui/Makefile.am).
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+
+import task
+from lib.constants import BASE_DIR
+
+GIT_URL_RE = r'COCKPIT_REPO_URL\s*=\s*(.*)'
+GIT_COMMIT_RE = r'COCKPIT_REPO_COMMIT\s*=\s*(.*)'
+
+
+def run(context, verbose=False, **kwargs):
+    cockpit_repo_url = 'https://github.com/cockpit-project/cockpit.git'
+    cockpit_repo_commit = 'HEAD'
+    makefile = context or 'Makefile'
+    makefile_path = os.path.join(BASE_DIR, makefile)
+
+    with open(makefile_path) as fp:
+        content = fp.read()
+
+    m = re.search(GIT_URL_RE, content)
+    if m:
+        cockpit_repo_url = m.group(1)
+
+    m = re.search(GIT_COMMIT_RE, content)
+    if m:
+        cockpit_repo_commit = m.group(1)
+
+    # Figure out latest cockpit tip commit
+    with tempfile.TemporaryDirectory('cockpit-repo') as tmpdir:
+        tmpdir = Path(tmpdir)
+        clone_dir = 'cockpit'
+        subprocess.check_call(['git', 'clone', cockpit_repo_url, clone_dir], cwd=tmpdir)
+        git_describe = subprocess.check_output(['git', 'describe'], cwd=tmpdir / clone_dir).decode().strip()
+        git_head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=tmpdir / clone_dir).decode().strip()
+
+    tag, commits, _ = git_describe.split('-')
+    comment = f'{git_head} # {tag} + {commits} commits'
+    content = content.replace(cockpit_repo_commit, comment)
+    with open(makefile_path, 'w') as fp:
+        fp.write(content)
+
+    if not kwargs['dry']:
+        title = f"Makefile: Update Cockpit lib to {git_head[:32]}"
+        branch = task.branch('cockpit-lib', title, pathspec=makefile, **kwargs)
+        kwargs["title"] = title
+        task.pull(branch, **kwargs)
+
+
+if __name__ == '__main__':
+    task.main(function=run, title="Update COCKPIT_REPO_COMMIT for cockpit projects")


### PR DESCRIPTION
This scripts bumps COCKPIT_REPO_COMMIT to the latest cockpit HEAD with a comment of what tag + how many commits there are since the last tag. This should be called periodically, for example bi-weekly from a Github workflow.

```
This scripts bumps COCKPIT_REPO_COMMIT to the latest cockpit HEAD with a comment of what tag + how many commits there are since the last tag. This should be called periodically, for example bi-weekly from a Github workflow.

[jelle@t14s][~/projects/starter-kit]%./bots/cockpit-lib-update
Cloning into 'cockpit'...
remote: Enumerating objects: 149319, done.
remote: Counting objects: 100% (330/330), done.
remote: Compressing objects: 100% (153/153), done.
remote: Total 149319 (delta 195), reused 247 (delta 177), pack-reused 148989
Receiving objects: 100% (149319/149319), 149.70 MiB | 1.46 MiB/s, done.
Resolving deltas: 100% (116711/116711), done.

# Completed (no log available)
# Duration: 106.6257734298706s
[jelle@t14s][~/projects/starter-kit]%git diff
diff --git a/Makefile b/Makefile
index abaa718..35f0554 100644
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ COCKPIT_REPO_FILES = \
        $(NULL)

 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 6073b2703acd68e216bd9dbc116c30d2d7a9701c # 288.1 + esbuild plugin updates
+COCKPIT_REPO_COMMIT = 1ab407db87ad307432bc593dfa9eecd99391ca81 # 289 + 17 commits

 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
[jelle@t14s][~/projects/starter-kit]%
```