### PR TITLE
testmap: a couple of subscription-manager updates

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -182,7 +182,6 @@ REPO_BRANCH_CONTEXT = {
     'candlepin/subscription-manager-cockpit': {
         'main': [
             'centos-9-stream',
-            'rhel-9-2',
             'rhel-9-3',
             'fedora-36',
             'fedora-37',

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -161,6 +161,7 @@ REPO_BRANCH_CONTEXT = {
             'rhel-8-4',
             'rhel-8-6',
             'rhel-8-8',
+            'rhel-8-9',
         ],
         'subscription-manager-1.28.29': [
             'rhel-8-6',
@@ -176,7 +177,6 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             f'{TEST_OS_DEFAULT}/pybridge',
-            'rhel-8-9',
         ],
     },
     'candlepin/subscription-manager-cockpit': {


### PR DESCRIPTION
- test `rhel-8-9` with `subscription-manager/subscription-manager-1.28`
- drop `rhel-9-2` from `subscription-manager-cockpit`
