### PR TITLE
machine_core: Reduce journal sync sleep to 1s

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -144,7 +144,7 @@ class Machine(ssh_connection.SSHConnection):
         # give the OS some time to write pending log messages, to make
         # unexpected message detection more reliable; RHEL/CentOS 7 does not
         # yet know about --sync, so ignore failures
-        self.execute("journalctl --sync 2>/dev/null || true; sleep 3; journalctl --sync 2>/dev/null || true")
+        self.execute("journalctl --sync 2>/dev/null || true; sleep 1; journalctl --sync 2>/dev/null || true")
 
         # Prepend "SYSLOG_IDENTIFIER=" as a default field, for backwards compatibility
         matches = map(lambda m: m if re.match("[a-zA-Z0-9_]+=", m) else "SYSLOG_IDENTIFIER=" + m, matches)


### PR DESCRIPTION
This wait time is quite expensive, as it adds 3s to each single test run time. This happens after the actual test is done, so the machine ought to be quiet. 1s should be enough time for services to catch up on log writing.

----

See https://issues.redhat.com/browse/COCKPIT-979 for the baseline numbers. I'll run the tests several times here to get some reliable data, as our test runtimes vary a lot: Chromium ø 5634s, σ 381s; Firefox: ø 5929s, σ 525s