### PR TITLE
images: RHEL 8.8 and 9.2 are still nightly

### DIFF
--- a/images/rhel-8-8
+++ b/images/rhel-8-8
@@ -1,1 +1,1 @@
-rhel-8-8-5dce9082ba49fecfd31ca0809ea7cc36cfde1b295ddba0267a09a3ce56e35690.qcow2
+rhel-8-8-0b86b87ab88aacd237743f84e1e4d24cbea7a8d292f7c92bbd406e494bff41be.qcow2

--- a/images/rhel-9-2
+++ b/images/rhel-9-2
@@ -1,1 +1,1 @@
-rhel-9-2-f80bfefbce4d07ceecfb1932ba50bff9214015cb046d8b4160a05443aeae712c.qcow2
+rhel-9-2-1e182ec74baddc1d164611d1408f1aabfbaeb4bc4ee8d2cafbfde4a4c6ed6a73.qcow2

--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -55,13 +55,14 @@ EOF
         MAJOR=${VERSION%%-*}
         VERSION=${VERSION/-/.}
         # current development version uses /nightly, released ones /rel-eng + updates
-        if [ "$VERSION" = "9.3" ] || [ "$VERSION" = "8.9" ]; then
-            TREE=nightly
-            UPDATES=""
-        else
-            TREE=rel-eng
-            UPDATES="rhel-${MAJOR}/${TREE}/updates/RHEL-${MAJOR}/latest-RHEL-${VERSION}.0/compose"
-        fi
+        case "$VERSION" in
+            8.8 | 8.9 | 9.2 | 9.3)
+                TREE=nightly;
+                UPDATES="" ;;
+            *)
+                TREE=rel-eng
+                UPDATES="rhel-${MAJOR}/${TREE}/updates/RHEL-${MAJOR}/latest-RHEL-${VERSION}.0/compose" ;;
+        esac
 
         REPO="rhel-${MAJOR}/${TREE}/RHEL-${MAJOR}/latest-RHEL-${VERSION}.0/compose"
 


### PR DESCRIPTION
Fixes #4667

----

I missed that in #4647 as I wasn't refreshing all images at the same time.

 * [x] image-refresh rhel-8-8
 * [x] image-refresh rhel-9-2