### PR TITLE
cockpit-lib-update: Fix ValueError crash when cockpit main is tagged

### DIFF
--- a/cockpit-lib-update
+++ b/cockpit-lib-update
@@ -62,8 +62,14 @@ def run(context, verbose=False, **kwargs):
         git_describe = subprocess.check_output(['git', 'describe'], cwd=tmpdir / clone_dir).decode().strip()
         git_head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=tmpdir / clone_dir).decode().strip()
 
-    tag, commits, _ = git_describe.split('-')
-    comment = f'{git_head} # {tag} + {commits} commits'
+    try:
+        # when HEAD is not tagged, this looks like "290-9-g4a6d86f5b"
+        tag, commits, _ = git_describe.split('-')
+        comment = f'{git_head} # {tag} + {commits} commits'
+    except ValueError:
+        # when HEAD is tagged, use that name
+        comment = f'{git_head} # {git_describe}'
+
     content = content.replace(cockpit_repo_commit, comment)
     with open(makefile_path, 'w') as fp:
         fp.write(content)


### PR DESCRIPTION
Then `git describe` is a single value (the tag name), and splitting doesn't unpack to three values.

---

Seen in [last night's failed job runs](https://github.com/cockpit-project/starter-kit/actions/runs/4749856958/jobs/8437504993) for all our projects. 

I [was already suspicious about this](https://github.com/cockpit-project/bots/pull/4651#discussion_r1167062363), but then missed that you manually tested this with `git describe --long`, but cockpit-lib-update doesn't use `--long`. I think this is nicer now, though. I tested this locally on starter-kit, it reproduced the error, and with the fix it generates this commit:

```diff
commit 061892fd800402f449f3d3bed5b1b74499e8b8a8
Author: Martin Pitt <martin@piware.de>
Date:   Thu Apr 20 08:01:24 2023 +0200

    Makefile: Update Cockpit lib to a2a1f34d567de5fc512801018e15e6b6
    
    Closes #642

diff --git Makefile Makefile
index abaa718..1c15f68 100644
--- Makefile
+++ Makefile
@@ -34,7 +34,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 6073b2703acd68e216bd9dbc116c30d2d7a9701c # 288.1 + esbuild plugin updates
+COCKPIT_REPO_COMMIT = a2a1f34d567de5fc512801018e15e6b6810cf261 # 290
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
```

It also produced https://github.com/cockpit-project/starter-kit/pull/642 with that diff.