### PR TITLE
images: Fix mock config for CentOS stream

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -313,7 +313,7 @@ config_opts['macros']['%_rpmfilename'] = '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{AR
 EOF
     elif [ "${IMAGE#centos-*}" != "$IMAGE" ]; then
         # build mock for CentOS stream repo
-        ln -sf centos-stream-${version}-x86_64.cfg /etc/mock/default.cfg
+        ln -sf centos-stream-${major}-x86_64.cfg /etc/mock/default.cfg
     fi
 
     useradd -c Builder -G mock builder


### PR DESCRIPTION
Regression introduced in commit 27d39d40278cb.

Fixes #4670

 - [ ] image-refresh centos-9-stream