### PR TITLE
images/scripts: hard-code some extra build-deps

### DIFF
--- a/images/scripts/lib/build-deps.sh
+++ b/images/scripts/lib/build-deps.sh
@@ -19,7 +19,7 @@ case "$OS_VER" in
         ;;
 
     *)
-        spec=$($GET "$COCKPIT_GIT/main/tools/cockpit.spec")
+        spec=$($GET "$COCKPIT_GIT/procps-ng-buildrequire/tools/cockpit.spec")
         ;;
 esac
 


### PR DESCRIPTION
The cockpit repo is introducing dynamic BuildRequires[^1] in its spec   
file, which is not supported by our build-deps.sh script, and would not    
be easy to add.    
    
We avoid this issue by simply hard-coding the necessary dependencies    
directly here.    
    
It could be argued that it would be better to add those extra    
dependencies to the .spec file itself, but I chose this approach for two    
reasons:    
    
- having the redundant information in the .spec file is inelegant
    
- whenever we need to add extra dependencies, it's a bit of a
complicated lock-step dance between adding the new dependencies to
the spec file, landing it on main, then updating the images before
actually being able to use those dependencies.
    
Hard-coding the dependencies directly here, although also inelegant,
lets us skip the first step and remove the catch-22: we just update
the images via a PR to bots/ and then can proceed to hack on the
cockpit repo.
    
[^1]: https://fedoraproject.org/wiki/Changes/DynamicBuildRequires

<hr>

Note: this PR can't land in its current state.  It has a hacked up temporary commit to pull the `cockpit.spec` file from cockpit-project/cockpit#18730 (which in turn, can't land until we get new images).

 * [x] image-refresh fedora-37: succeeded as fedora-37-31d79577954d1e3c0e2d7d26db24e75588d29102814d0e904825dcc3839bfe17.qcow2 , but failed during image-prune
 * [x] image-refresh fedora-38