### PR TITLE
setup-deploy-keys: Add "self" environment for cockpit-podman

### DIFF
--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -65,7 +65,8 @@ deploy_to cockpit-project/cockpit-machines-weblate \
 # cockpit-podman
 deploy_to cockpit-project/cockpit-podman \
     --deploy-from \
-        cockpit-project/cockpit-podman/npm-update/SELF_DEPLOY_KEY
+        cockpit-project/cockpit-podman/npm-update/SELF_DEPLOY_KEY \
+        cockpit-project/cockpit-podman/self/DEPLOY_KEY
 
 deploy_to cockpit-project/cockpit-podman-weblate \
     --deploy-from \


### PR DESCRIPTION
We need that to properly run weblate-sync-po.yml.

----

This is the prerequisite for fixing [podman PO refreshes](https://github.com/cockpit-project/cockpit-podman/pull/1264) to actually be able to run "protection checks". That only works for SSH pushes, not for HTTP pushes with the github default tokoen (as these can't trigger workflows).

I ran this, and https://github.com/cockpit-project/cockpit-podman/settings/environments now has a "self" environment. It's also a good opportunity to rotate the keys, we last did that 4 months ago.