### PR TITLE
images: Drop fedora-38-boot [was: Image refresh for fedora-38-boot]

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -29,7 +29,6 @@ REFRESH = {
     "fedora-36": {},
     "fedora-37": {},
     "fedora-38": {},
-    "fedora-38-boot": {},
     "fedora-testing": {"refresh-days": 3},
     "fedora-coreos": {},
     "fedora-rawhide": {},

--- a/images/fedora-38-boot
+++ b/images/fedora-38-boot
@@ -1,1 +1,0 @@
-fedora-38-boot-8268db8d64ecaedda312b63202cefe2461b1bcbc1917fcac9a4e72253f852147.iso

--- a/images/scripts/fedora-38-boot.bootstrap
+++ b/images/scripts/fedora-38-boot.bootstrap
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -eux
-
-OUTPUT="$1"
-
-URL='https://download.fedoraproject.org/pub/fedora/linux/development/38/Server/x86_64/os/images/boot.iso'
-
-curl -L "$URL" -o "$OUTPUT"

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -212,9 +212,6 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'fedora-rawhide-boot',
         ],
-        'fedora-38': [
-            'fedora-38-boot',
-        ],
         '_manual': [
             'fedora-rawhide-boot/devel',
         ]


### PR DESCRIPTION
Fedora 38 is released, so Anaconda's fedora-38 branch will not get changes any more.
