### PR TITLE
naughty: Allow pf-v5-c* CSS selectors

### DIFF
--- a/naughty/arch/4308-virt-edit-cdrom
+++ b/naughty/arch/4308-virt-edit-cdrom
@@ -2,7 +2,7 @@ Traceback (most recent call last):
   File "test/check-machines-disks", line *, in testInsertDiscCDROM
 *
   File "test/check-machines-disks", line *, in verify
-    b.wait_not_present(".pf-c-modal-box")
+    b.wait_not_present(".pf*-c-modal-box")
 *
 testlib.Error: timeout
-wait_js_cond(!ph_is_present(".pf-c-modal-box")): Uncaught (in promise) Error: condition did not become true
+wait_js_cond(!ph_is_present(".pf*-c-modal-box")): Uncaught (in promise) Error: condition did not become true

--- a/naughty/debian-stable/2220-libvirt-crashes-on-startup
+++ b/naughty/debian-stable/2220-libvirt-crashes-on-startup
@@ -1,4 +1,4 @@
 # testBasicWheelUserUnprivileged (__main__.TestMachinesLifecycle)
 *
   File "test/check-machines-lifecycle", line *, in _testBasic
-    b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")
+    b.wait_in_text("#virtual-machines-listing .pf*-c-empty-state", "No VM is running")

--- a/naughty/debian-testing/2463-no-pod-events
+++ b/naughty/debian-testing/2463-no-pod-events
@@ -1,1 +1,1 @@
-wait_js_cond(ph_is_present("#table-pod-1 .pf-c-empty-state")):
+wait_js_cond(ph_is_present("#table-pod-1 .pf*-c-empty-state")):

--- a/naughty/debian-testing/4308-virt-edit-cdrom
+++ b/naughty/debian-testing/4308-virt-edit-cdrom
@@ -2,7 +2,7 @@ Traceback (most recent call last):
   File "test/check-machines-disks", line *, in testInsertDiscCDROM
 *
   File "test/check-machines-disks", line *, in verify
-    b.wait_not_present(".pf-c-modal-box")
+    b.wait_not_present(".pf*-c-modal-box")
 *
 testlib.Error: timeout
-wait_js_cond(!ph_is_present(".pf-c-modal-box"))
+wait_js_cond(!ph_is_present(".pf*-c-modal-box"))

--- a/naughty/fedora-37/4672-setroubleshootd-timeout-2
+++ b/naughty/fedora-37/4672-setroubleshootd-timeout-2
@@ -1,6 +1,6 @@
 > warning: transport closed: disconnected*
 Traceback (most recent call last):
   File "test/verify/check-selinux", line *, in testTroubleshootAlerts
-    b.wait_in_text(row_selector + " .pf-c-alert__title", "Solution applied successfully")
+    b.wait_in_text(row_selector + " .pf*-c-alert__title", "Solution applied successfully")
 *
 testlib.Error: timeout

--- a/naughty/fedora-38/4308-virt-edit-cdrom
+++ b/naughty/fedora-38/4308-virt-edit-cdrom
@@ -2,7 +2,7 @@ Traceback (most recent call last):
   File "test/check-machines-disks", line *, in testInsertDiscCDROM
 *
   File "test/check-machines-disks", line *, in verify
-    b.wait_not_present(".pf-c-modal-box")
+    b.wait_not_present(".pf*-c-modal-box")
 *
 testlib.Error: timeout
-wait_js_cond(!ph_is_present(".pf-c-modal-box"))
+wait_js_cond(!ph_is_present(".pf*-c-modal-box"))

--- a/naughty/fedora-38/4672-setroubleshootd-timeout-2
+++ b/naughty/fedora-38/4672-setroubleshootd-timeout-2
@@ -1,6 +1,6 @@
 > warning: transport closed: disconnected*
 Traceback (most recent call last):
   File "test/verify/check-selinux", line *, in testTroubleshootAlerts
-    b.wait_in_text(row_selector + " .pf-c-alert__title", "Solution applied successfully")
+    b.wait_in_text(row_selector + " .pf*-c-alert__title", "Solution applied successfully")
 *
 testlib.Error: timeout

--- a/naughty/fedora-39/4308-virt-edit-cdrom
+++ b/naughty/fedora-39/4308-virt-edit-cdrom
@@ -2,7 +2,7 @@ Traceback (most recent call last):
   File "test/check-machines-disks", line *, in testInsertDiscCDROM
 *
   File "test/check-machines-disks", line *, in verify
-    b.wait_not_present(".pf-c-modal-box")
+    b.wait_not_present(".pf*-c-modal-box")
 *
 testlib.Error: timeout
-wait_js_cond(!ph_is_present(".pf-c-modal-box"))
+wait_js_cond(!ph_is_present(".pf*-c-modal-box"))

--- a/naughty/fedora-39/4672-setroubleshootd-timeout-2
+++ b/naughty/fedora-39/4672-setroubleshootd-timeout-2
@@ -1,6 +1,6 @@
 > warning: transport closed: disconnected*
 Traceback (most recent call last):
   File "test/verify/check-selinux", line *, in testTroubleshootAlerts
-    b.wait_in_text(row_selector + " .pf-c-alert__title", "Solution applied successfully")
+    b.wait_in_text(row_selector + " .pf*-c-alert__title", "Solution applied successfully")
 *
 testlib.Error: timeout

--- a/naughty/rhel-8/4517-systemd-missing-reload
+++ b/naughty/rhel-8/4517-systemd-missing-reload
@@ -1,6 +1,6 @@
   File "test/verify/check-system-services", line *, in _testBasic
     self.toggle_onoff()
   File "test/verify/check-system-services", line *, in toggle_onoff
-    self.browser.click(".service-top-panel .pf-c-switch__input")
+    self.browser.click(".service-top-panel .pf*-c-switch__input")
 *
 testlib.Error: *ph_mouse(".service-top-panel*:not*disabled*click*

--- a/naughty/rhel-8/4672-setroubleshootd-timeout-2
+++ b/naughty/rhel-8/4672-setroubleshootd-timeout-2
@@ -1,6 +1,6 @@
 > warning: transport closed: disconnected*
 Traceback (most recent call last):
   File "test/verify/check-selinux", line *, in testTroubleshootAlerts
-    b.wait_in_text(row_selector + " .pf-c-alert__title", "Solution applied successfully")
+    b.wait_in_text(row_selector + " .pf*-c-alert__title", "Solution applied successfully")
 *
 testlib.Error: timeout

--- a/naughty/rhel-9/4308-virt-edit-cdrom
+++ b/naughty/rhel-9/4308-virt-edit-cdrom
@@ -2,7 +2,7 @@ Traceback (most recent call last):
   File "test/check-machines-disks", line *, in testInsertDiscCDROM
 *
   File "test/check-machines-disks", line *, in verify
-    b.wait_not_present(".pf-c-modal-box")
+    b.wait_not_present(".pf*-c-modal-box")
 *
 testlib.Error: timeout
-wait_js_cond(!ph_is_present(".pf-c-modal-box"))
+wait_js_cond(!ph_is_present(".pf*-c-modal-box"))

--- a/naughty/rhel-9/4545-modprobe-kvdo
+++ b/naughty/rhel-9/4545-modprobe-kvdo
@@ -1,6 +1,6 @@
 File "/work/bots/make-checkout-workdir/test/verify/check-storage-vdo", line *, in testVdoMissingPackages
 *
 testlib.Error: timeout
-wait_js_cond(ph_in_text("#dialog .pf-c-alert.pf-m-danger","vdoformat")): Uncaught (in promise) Error: actual text: Danger alert:Error creating volume: Process reported exit code 3: modprobe: FATAL: Module kvdo not found in directory /lib/modules/5.14.*
+wait_js_cond(ph_in_text("#dialog .pf*-c-alert.pf-m-danger","vdoformat")): Uncaught (in promise) Error: actual text: Danger alert:Error creating volume: Process reported exit code 3: modprobe: FATAL: Module kvdo not found in directory /lib/modules/5.14.*
   /usr/sbin/modprobe failed: 1
   vdo: Required device-mapper target(s) not detected in your kernel.

--- a/naughty/rhel-9/4672-setroubleshootd-timeout-2
+++ b/naughty/rhel-9/4672-setroubleshootd-timeout-2
@@ -1,6 +1,6 @@
 > warning: transport closed: disconnected*
 Traceback (most recent call last):
   File "test/verify/check-selinux", line *, in testTroubleshootAlerts
-    b.wait_in_text(row_selector + " .pf-c-alert__title", "Solution applied successfully")
+    b.wait_in_text(row_selector + " .pf*-c-alert__title", "Solution applied successfully")
 *
 testlib.Error: timeout

--- a/naughty/ubuntu-2204/2463-no-pod-events
+++ b/naughty/ubuntu-2204/2463-no-pod-events
@@ -1,1 +1,1 @@
-wait_js_cond(ph_is_present("#table-pod-1 .pf-c-empty-state")):
+wait_js_cond(ph_is_present("#table-pod-1 .pf*-c-empty-state")):

--- a/naughty/ubuntu-stable/2463-no-pod-events
+++ b/naughty/ubuntu-stable/2463-no-pod-events
@@ -1,1 +1,1 @@
-wait_js_cond(ph_is_present("#table-pod-1 .pf-c-empty-state")):
+wait_js_cond(ph_is_present("#table-pod-1 .pf*-c-empty-state")):


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/18806 updated cockpit's PatternFly to the latest V5 alpha. That renamed all `pf-c-*` classes to `pf-v5-c*`. Adjust our naughties to get along with either, which will fix the current cockpit main runs, as well as the other projects that will get ported to the latest PF5 soon.

---

This unfortunately already broke main, e.g. [in this run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18829-20230522-075102-3f2d7470-rhel-9-3/log.html#244-2) of https://github.com/cockpit-project/cockpit/pull/18829