### PR TITLE
naughty: Add pattern for RHEL 8 libsystemd inotify assertion

### DIFF
--- a/naughty/rhel-8/4826-libsystemd-buffer_filled
+++ b/naughty/rhel-8/4826-libsystemd-buffer_filled
@@ -1,0 +1,1 @@
+Assertion 'sz <= d->buffer_filled' failed at ../src/libsystemd/sd-event/sd-event.c:3229, function event_inotify_data_drop(). Aborting.


### PR DESCRIPTION
Known issue #4826
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2211358

---

This often [breaks like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18860-20230531-072427-a3d937fe-centos-8-stream-pybridge/log.html#264)