### PR TITLE
images: switch to "latest" symlinks for centos-stream cloud images

### DIFF
--- a/images/centos-8-stream
+++ b/images/centos-8-stream
@@ -1,1 +1,1 @@
-centos-8-stream-94768efcecaf77c50a7bab75e6bc690164f7fc6e105511c78b6a01f801aafabf.qcow2
+centos-8-stream-9ba58c984fbeefa06f8fdac0502a4b410cc478b02c4bbd5e5753591c22c156cb.qcow2

--- a/images/centos-9-stream
+++ b/images/centos-9-stream
@@ -1,1 +1,1 @@
-centos-9-stream-42939d27feeadb9ecb79972e45eae99bafee28ad53bcfc56ef38fd2184f4ae65.qcow2
+centos-9-stream-0fad9cc36e737486d1cd275365aa7f25edee638ea074d58c63dc943eb87b808e.qcow2

--- a/images/scripts/centos-8-stream.bootstrap
+++ b/images/scripts/centos-8-stream.bootstrap
@@ -1,8 +1,6 @@
 #! /bin/bash
 set -eux
 
-URL=https://cloud.centos.org/centos/8-stream/x86_64/images/
-DAILIES=$(curl -s "$URL" | sed -n '/<a href=.*GenericCloud.*qcow2"/ { s/^.*href="//; s_".*$__; p }')
-LATEST_DAILY=$(echo "$DAILIES" | sort -u | tail -n1)
+URL='https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2'
 
-exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$LATEST_DAILY"
+exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL"

--- a/images/scripts/centos-9-stream.bootstrap
+++ b/images/scripts/centos-9-stream.bootstrap
@@ -1,8 +1,6 @@
 #! /bin/bash
 set -eux
 
-URL=https://cloud.centos.org/centos/9-stream/x86_64/images/
-DAILIES=$(curl -s "$URL" | sed -n '/<a href=.*GenericCloud.*qcow2"/ { s/^.*href="//; s_".*$__; p }')
-LATEST_DAILY=$(echo "$DAILIES" | sort -u | tail -n1)
+URL='https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2'
 
-exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$LATEST_DAILY"
+exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL"


### PR DESCRIPTION
The CentOS project finally provides "latest" symlinks for all the cloud images, pointing to the latest version:
- https://lists.centos.org/pipermail/centos-devel/2023-June/142967.html

Hence, drop the scraping way to pick the latest qcow2 cloud image available, and use the direct URLs.

 * [x] image-refresh centos-8-stream
 * [x] image-refresh centos-9-stream