### PR TITLE
testmap: Accept arbitrary scenarios in test triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ obtained by talking to Allison.
 
 For describing tests which we want to run we use __contexts__. A context has the form:
 
-    os_image[/scenario][@bots#bots_pr][@owner/project/ref]
+    image[/scenario][@bots#bots_pr][@owner/project/ref]
 
 where items have the following meaning:
-- os_image: Name of the image on which tests should run (e.g. 'fedora-testing').
+- image: Name of the image on which tests should run (e.g. 'fedora-testing').
 - scenario: Name of a specific test. This is specific for each separate project and
   is passed verbatim to 'test/run' in `$TEST_SCENARIO`.
 - bots_pr: Number of pull request that exists in bots repository. When specified,

--- a/lib/test-testmap.py
+++ b/lib/test-testmap.py
@@ -51,22 +51,28 @@ class TestTestMap(unittest.TestCase):
         # not known in this branch
         bad("debian-testing", "cockpit-project/cockpit/rhel-7.9")
 
-        # unknown scenarios/projects/branches
+        # unknown image/projects/branches
         bad("wrongos", "cockpit-project/cockpit")
-        bad("debian-testing/wrongscen", "cockpit-project/cockpit")
+        bad("wrongos/somescen", "cockpit-project/cockpit")
         bad("debian-testing", "cockpit-project/wrongproject")
         bad("debian-testing", "cockpit-project/cockpit/wrongbranch")
+
+        # accepts any scenario
+        good("debian-testing/newscen", "cockpit-project/cockpit")  # automatic
+        good("fedora-testing/newscen", "cockpit-project/cockpit")  # _manual
 
         # bots has no integration tests for itself
         bad("debian-testing", "cockpit-project/bots")
         # but can refer to foreign projects
         good("debian-testing@cockpit-project/cockpit", "cockpit-project/bots")
         good("debian-testing@cockpit-project/cockpit/main", "cockpit-project/bots")
+        good("debian-testing/somescen@cockpit-project/cockpit", "cockpit-project/bots")
         # can refer to _manual contexts of foreign projects
         good("fedora-testing@cockpit-project/cockpit", "cockpit-project/bots")
         good("fedora-testing@cockpit-project/cockpit/main", "cockpit-project/bots")
+        good("fedora-testing/somescen@cockpit-project/cockpit/main", "cockpit-project/bots")
 
-        # unknown scenarios/project/branches with foreign project
+        # unknown image/project/branches with foreign project
         bad("wrongos@cockpit-project/cockpit", "cockpit-project/bots")
         bad("debian-testing@cockpit-project/wrongproject", "cockpit-project/bots")
         bad("debian-testing@cockpit-project/cockpit/wrongbranch", "cockpit-project/bots")

--- a/lib/test-testmap.py
+++ b/lib/test-testmap.py
@@ -49,7 +49,7 @@ class TestTestMap(unittest.TestCase):
         # context from _manual pseudo-branch
         good("fedora-testing", "cockpit-project/cockpit")
         # not known in this branch
-        bad("debian-testing", "cockpit-project/cockpit/rhel-8.5")
+        bad("debian-testing", "cockpit-project/cockpit/rhel-7.9")
 
         # unknown scenarios/projects/branches
         bad("wrongos", "cockpit-project/cockpit")

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -290,24 +290,25 @@ def split_context(context):
 
 def is_valid_context(context, repo):
     image_scenario, _bots_pr, context_repo, branch = split_context(context)
+    image = image_scenario.split('/')[0]
     # if the context specifies a repo, use that one instead
     branch_contexts = tests_for_project(context_repo or repo)
     if context_repo:
         # if the context specifies a repo, only look at that particular branch
         try:
-            repo_contexts = branch_contexts[branch or get_default_branch(context_repo)].copy()
+            repo_images = [c.split('/')[0] for c in branch_contexts[branch or get_default_branch(context_repo)]]
         except KeyError:
             # unknown project
             return False
         # also allow _manual tests
-        repo_contexts.extend(branch_contexts.get('_manual', []))
+        repo_images.extend([c.split('/')[0] for c in branch_contexts.get('_manual', [])])
     else:
         # FIXME: if context is just a simple OS/scenario, we don't know which branch
         # is meant by the caller; accept known contexts from all branches for now
-        repo_contexts = set(itertools.chain(*branch_contexts.values()))
+        repo_images = set([c.split('/')[0] for c in itertools.chain(*branch_contexts.values())])
 
     # Valid contexts are the ones that exist in the given/current repo
-    return image_scenario in repo_contexts
+    return image in repo_images
 
 
 def projects():

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -52,7 +52,6 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-testing',
-            'fedora-testing/daily',
             'fedora-rawhide',
         ],
     },
@@ -63,18 +62,11 @@ REPO_BRANCH_CONTEXT = {
             'centos-8-stream',
             'fedora-rawhide',
         ],
-        '_manual': [
-            f'{TEST_OS_DEFAULT}/firefox',
-            'fedora-38',
-        ],
     },
     'cockpit-project/cockpit-ostree': {
         'main': [
             'fedora-coreos',
             'rhel4edge',
-        ],
-        '_manual': [
-            'fedora-coreos/pybridge',
         ],
     },
     'cockpit-project/cockpit-podman': {
@@ -188,7 +180,6 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'centos-8-stream/subscription-manager-1.28',
             'rhel-8-9',
-            'rhel-8-9/subscription-manager-1.28',
         ],
     },
     'cockpit-project/cockpit-certificates': {
@@ -209,9 +200,6 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'fedora-rawhide-boot',
         ],
-        '_manual': [
-            'fedora-rawhide-boot/devel',
-        ]
     },
 }
 

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -272,7 +272,7 @@ def split_context(context):
     repo_branch = ""
 
     context_parts = context.split("@")
-    os_scenario = context_parts[0]
+    image_scenario = context_parts[0]
 
     # Second part can be be either `bots#<pr_number>` or repo specification
     if len(context_parts) > 1:
@@ -285,11 +285,11 @@ def split_context(context):
         repo_branch = context_parts[2]
 
     repo_branch = repo_branch.split('/', 2)
-    return (os_scenario, bots_pr, '/'.join(repo_branch[:2]), ''.join(repo_branch[2:]))
+    return (image_scenario, bots_pr, '/'.join(repo_branch[:2]), ''.join(repo_branch[2:]))
 
 
 def is_valid_context(context, repo):
-    os_scenario, _bots_pr, context_repo, branch = split_context(context)
+    image_scenario, _bots_pr, context_repo, branch = split_context(context)
     # if the context specifies a repo, use that one instead
     branch_contexts = tests_for_project(context_repo or repo)
     if context_repo:
@@ -307,7 +307,7 @@ def is_valid_context(context, repo):
         repo_contexts = set(itertools.chain(*branch_contexts.values()))
 
     # Valid contexts are the ones that exist in the given/current repo
-    return os_scenario in repo_contexts
+    return image_scenario in repo_contexts
 
 
 def projects():

--- a/tests-scan
+++ b/tests-scan
@@ -335,7 +335,7 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
             # Get correct project and branch. Ones from test name have priority
             project = repo
             branch = base
-            os_scenario, bots_pr, context_project, context_branch = testmap.split_context(context)
+            image_scenario, bots_pr, context_project, context_branch = testmap.split_context(context)
             if context_project:
                 project = context_project
                 branch = context_branch or testmap.get_default_branch(project)
@@ -379,7 +379,7 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
                                 number,
                                 revision,
                                 checkout_ref,
-                                os_scenario,
+                                image_scenario,
                                 branch,
                                 project,
                                 bots_ref,

--- a/tests-trigger
+++ b/tests-trigger
@@ -41,7 +41,7 @@ def trigger_pull(api, opts):
         for cntx in opts.context:
             if cntx.startswith("image:"):
                 contexts.update(testmap.tests_for_image(cntx.split(':', 1)[1]))
-            elif github.is_valid_context(cntx, api.repo):
+            elif testmap.is_valid_context(cntx, api.repo):
                 if opts.bots_pr:
                     cntx += "@bots#" + opts.bots_pr
                 contexts.add(cntx)


### PR DESCRIPTION
We want to use scenarios a lot more soon for parallelizing tests. Having to always pre-declare them as `_manual` context is annoying for development and experimentation.

Change `is_valid_context` to cut off and ignore the scenario when checking a context against the testmap.

----

Plus a few small cleanups.

I did a `bots/tests-trigger 18778 fedora-38/ohlook` in cockpit with this, and https://github.com/cockpit-project/cockpit/pull/18778 now has the /ohlook scenario pending. Of course that won't actually be considered by our CI until this PR lands. After that, it should be run and fail immediately with "unknown scenario", as cockpit checks that.

Other projects like c-machines don't check for unknown scenarios, and will just run the default one. We can/should fix that, but IMHO this is acceptable for now.