### PR TITLE
naughty: podman container hang #4829 affects ubuntu-2204 as well

### DIFF
--- a/naughty/ubuntu-2204/4829-podman-hang
+++ b/naughty/ubuntu-2204/4829-podman-hang
@@ -1,0 +1,3 @@
+  File "*", line *, in testPruneUnusedContainersSystem
+*
+RuntimeError: Timed out on 'podman run --name inpod --pod pod -tid localhost/test-busybox sh -c 'exit 1''

--- a/naughty/ubuntu-2204/4829-podman-hang-2
+++ b/naughty/ubuntu-2204/4829-podman-hang-2
@@ -1,0 +1,3 @@
+  File "*", line *, in testPruneUnusedContainersUser
+*
+RuntimeError: Timed out on 'podman run --name inpod --pod pod -tid localhost/test-busybox sh -c 'exit 1''


### PR DESCRIPTION
See [log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1305-20230616-053112-d67bf2c7-ubuntu-2204/log.html#27), this happens all the time and is almost impossible to retry over.