### PR TITLE
testmap: Declare debian-stable context for cockpit-podman

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -86,6 +86,7 @@ REPO_BRANCH_CONTEXT = {
         ],
         '_manual': [
             'centos-8-stream',
+            'debian-stable',
             'fedora-rawhide',
             'fedora-testing',
         ],


### PR DESCRIPTION
Debian stable is now 12, which includes podman.

---

Manual for now, as c-podman still needs a little test adjustment.