### PR TITLE
testmap: Run cockpit with split scenarios

### DIFF
--- a/lib/test-testmap.py
+++ b/lib/test-testmap.py
@@ -21,6 +21,8 @@ import unittest
 
 import testmap
 
+from lib.constants import TEST_OS_DEFAULT
+
 
 class TestTestMap(unittest.TestCase):
     def test_split_context(self):
@@ -76,6 +78,22 @@ class TestTestMap(unittest.TestCase):
         bad("wrongos@cockpit-project/cockpit", "cockpit-project/bots")
         bad("debian-testing@cockpit-project/wrongproject", "cockpit-project/bots")
         bad("debian-testing@cockpit-project/cockpit/wrongbranch", "cockpit-project/bots")
+
+    # cockpit uses a dynamic multi-scenario testmap
+    # this makes some assumptions about the concrete test map, only use scenarios which don't change often
+    def test_cockpit_contexts(self):
+        main_tests = testmap.REPO_BRANCH_CONTEXT["cockpit-project/cockpit"]["main"]
+        # no three-part scenarios, no scenario-less contexts
+        for context in main_tests:
+            self.assertEqual(context.count("/"), 1, f"malformed context {context}")
+            self.assertIn(context.split("/")[1].count("-"), [0, 1],
+                          f"context {context} has unexpected number of scenarios")
+        # standard image with standard scenarios
+        self.assertIn("arch/networking", main_tests)
+        self.assertIn("debian-testing/other", main_tests)
+        # scenario options
+        self.assertIn(f"{TEST_OS_DEFAULT}/devel-storage", main_tests)
+        self.assertIn(f"{TEST_OS_DEFAULT}/firefox-expensive", main_tests)
 
 
 if __name__ == '__main__':

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -17,8 +17,16 @@
 
 import itertools
 import os.path
+from typing import List
 
 from lib.constants import TEST_OS_DEFAULT
+
+COCKPIT_SCENARIOS = {'networking', 'storage', 'expensive', 'other'}
+
+
+def contexts(image, *scenarios: List[str]):
+    return [image + '/' + '-'.join(i) for i in itertools.product(*scenarios)]
+
 
 REPO_BRANCH_CONTEXT = {
     'cockpit-project/bots': {
@@ -27,23 +35,24 @@ REPO_BRANCH_CONTEXT = {
     },
     'cockpit-project/cockpit': {
         'main': [
-            'arch',
-            'debian-stable',
-            'debian-testing',
-            'ubuntu-2204',
-            'ubuntu-stable',
-            'fedora-37',
-            'fedora-38',
-            f'{TEST_OS_DEFAULT}/devel',
-            f'{TEST_OS_DEFAULT}/firefox',
-            f'{TEST_OS_DEFAULT}/pybridge',
-            'centos-8-stream/pybridge',
-            'fedora-coreos',
-            'rhel-8-9',
-            'rhel-8-9-distropkg',
-            'centos-8-stream',
-            'rhel-9-3',
-            'rhel4edge',
+            *contexts('arch', COCKPIT_SCENARIOS),
+            *contexts('debian-stable', COCKPIT_SCENARIOS),
+            *contexts('debian-testing', COCKPIT_SCENARIOS),
+            *contexts('ubuntu-2204', COCKPIT_SCENARIOS),
+            *contexts('ubuntu-stable', COCKPIT_SCENARIOS),
+            *contexts('fedora-37', COCKPIT_SCENARIOS),
+            *contexts('fedora-38', COCKPIT_SCENARIOS),
+            *contexts(TEST_OS_DEFAULT, ['devel'], COCKPIT_SCENARIOS),
+            *contexts(TEST_OS_DEFAULT, ['firefox'], COCKPIT_SCENARIOS),
+            *contexts(TEST_OS_DEFAULT, ['pybridge'], COCKPIT_SCENARIOS),
+            *contexts('centos-8-stream', ['pybridge'], COCKPIT_SCENARIOS),
+            # no udisks on CoreOS → skip storage
+            *contexts('fedora-coreos', COCKPIT_SCENARIOS - {'storage'}),
+            *contexts('rhel-8-9', COCKPIT_SCENARIOS),
+            *contexts('rhel-8-9-distropkg', COCKPIT_SCENARIOS),
+            *contexts('centos-8-stream', COCKPIT_SCENARIOS),
+            *contexts('rhel-9-3', COCKPIT_SCENARIOS),
+            *contexts('rhel4edge', COCKPIT_SCENARIOS),
         ],
         'rhel-7.9': [
             'rhel-7-9',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,6 @@ exclude = [
 ]
 ignore = [
     "E731",  # Do not assign a `lambda` expression, use a `def`
+    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 line-length = 118


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/commit/55539de0 introduced four scenarios, which allow us to run Cockpit tests much faster in parallel.

Compute the full product map of all scenarios. As this is not entirely trivial, add a unit test which verifies the expected syntactic form and makes some spot checks.

---

The expanded list now looks like this:

> ['arch/networking', 'arch/storage', 'arch/expensive', 'arch/other', 'debian-stable/networking', 'debian-stable/storage', 'debian-stable/expensive', 'debian-stable/other', 'debian-testing/networking', 'debian-testing/storage', 'debian-testing/expensive', 'debian-testing/other', 'ubuntu-2204/networking', 'ubuntu-2204/storage', 'ubuntu-2204/expensive', 'ubuntu-2204/other', 'ubuntu-stable/networking', 'ubuntu-stable/storage', 'ubuntu-stable/expensive', 'ubuntu-stable/other', 'fedora-37/networking', 'fedora-37/storage', 'fedora-37/expensive', 'fedora-37/other', 'fedora-38/networking', 'fedora-38/storage', 'fedora-38/expensive', 'fedora-38/other', 'fedora-38/devel-networking', 'fedora-38/devel-storage', 'fedora-38/devel-expensive', 'fedora-38/devel-other', 'fedora-38/firefox-networking', 'fedora-38/firefox-storage', 'fedora-38/firefox-expensive', 'fedora-38/firefox-other', 'fedora-38/pybridge-networking', 'fedora-38/pybridge-storage', 'fedora-38/pybridge-expensive', 'fedora-38/pybridge-other', 'centos-8-stream/pybridge-networking', 'centos-8-stream/pybridge-storage', 'centos-8-stream/pybridge-expensive', 'centos-8-stream/pybridge-other', 'fedora-coreos/networking', 'fedora-coreos/expensive', 'fedora-coreos/other', 'rhel-8-9/networking', 'rhel-8-9/storage', 'rhel-8-9/expensive', 'rhel-8-9/other', 'rhel-8-9-distropkg/networking', 'rhel-8-9-distropkg/storage', 'rhel-8-9-distropkg/expensive', 'rhel-8-9-distropkg/other', 'centos-8-stream/networking', 'centos-8-stream/storage', 'centos-8-stream/expensive', 'centos-8-stream/other', 'rhel-9-3/networking', 'rhel-9-3/storage', 'rhel-9-3/expensive', 'rhel-9-3/other', 'rhel4edge/networking', 'rhel4edge/storage', 'rhel4edge/expensive', 'rhel4edge/other']

This looks reasonable and intended to me.

For testing, I created https://github.com/cockpit-project/cockpit/pull/18985 and ran `bots/tests-scan -p 18985` in cockpit against that branch. This gives a nice avalanche of triggered tests. ~Let's block this until that finished.~ **Update**: it works!