### PR TITLE
naughty: Add libvirt dbus GetStats timeout naughty for Rawhide

### DIFF
--- a/naughty/fedora-39/4915-libvirt-getstats-timeout
+++ b/naughty/fedora-39/4915-libvirt-getstats-timeout
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*", line *, in testVsock
+*
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Shut off")): actual text: Failedview more...


### PR DESCRIPTION
We can't test naughties before landing, so I gathered evidence :)

```
[jelle@t14s][~/projects/cockpit-bots]%wget https://artifacts.dev.testing-farm.io/1e1f71e7-6e3a-4ddc-b778-45b35111f8dd/work-networkqwu6joos/plans/all/network/execute/data/guest/default-0/test/browser/network-1/output.txt
--2023-06-23 10:56:30--  https://artifacts.dev.testing-farm.io/1e1f71e7-6e3a-4ddc-b778-45b35111f8dd/work-networkqwu6joos/plans/all/network/execute/data/guest/default-0/test/browser/network-1/output.txt
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving artifacts.dev.testing-farm.io (artifacts.dev.testing-farm.io)... 52.14.131.2
Connecting to artifacts.dev.testing-farm.io (artifacts.dev.testing-farm.io)|52.14.131.2|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 72219 (71K) [text/plain]
Saving to: ‘output.txt’

output.txt                                 100%[========================================================================================>]  70.53K  --.-KB/s    in 0.1s

2023-06-23 10:56:31 (631 KB/s) - ‘output.txt’ saved [72219/72219]

[jelle@t14s][~/projects/cockpit-bots]%cat output.txt
[jelle@t14s][~/projects/cockpit-bots]%cat -p output.txt
[jelle@t14s][~/projects/cockpit-bots]%cat output.txt
[jelle@t14s][~/projects/cockpit-bots]%./test/common/pixel-tests pull
[jelle@t14s][~/projects/cockpit-bots]%./test-failure-policy -o fedora-rawhide < output.txt
Known issue #4915
```