### PR TITLE
machine_core: Fix race condition in dhcp_server()

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -300,7 +300,7 @@ class Machine(ssh_connection.SSHConnection):
         cmd = "dnsmasq --domain=cockpit.lan " \
               "--interface=\"$(grep -l '{mac}' /sys/class/net/*/address | cut -d / -f 5)\"" \
               " --bind-interfaces --dhcp-range=" + ','.join(range) + ",4h" + \
-              " && firewall-cmd --add-service=dhcp"
+              "; systemctl start firewalld; firewall-cmd --add-service=dhcp"
         self.execute(cmd.format(mac=mac))
 
     def dns_server(self, mac='52:54:01'):


### PR DESCRIPTION
This is usually called during VM provisioning, when sshd is already up, but firewalld isn't yet. This leads to the function failing with "FirewallD is not running" and the command exiting with code 252.

Fix this by explicitly starting firewalld, whose effect is to wait until the (usually already queued) startup finishes.

Also drop the obsolete `&&`, commands already run under `set -e`, and `&&` makes the command very brittle.

----

This fixes the failures seen e.g. [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19011-20230625-152237-f6471628-rhel-9-3-networking/log.html)