### PR TITLE
lib: testmap: update fedora-rawhide to trigger anaconda tests

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -246,7 +246,7 @@ IMAGE_REFRESH_TRIGGERS = {
         "rhel-9-3@candlepin/subscription-manager-cockpit",
     ],
     # Anaconda builds in fedora-37 and runs tests in fedora-rawhide-boot
-    "fedora-37": [
+    "fedora-rawhide": [
         "fedora-rawhide-boot@rhinstaller/anaconda"
     ],
 }


### PR DESCRIPTION
Anaconda test preparation builds the RPMs in the fedora-rawhide image which needs to be gated.