### PR TITLE
naughty: Add pattern for udisks drive detection bug

### DIFF
--- a/naughty/arch/4942-udisks-missing-drives
+++ b/naughty/arch/4942-udisks-missing-drives
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-scaling", line *, in testScaling
+    b.click("#drives button:contains(Show all 202 drives)")
+*
+testlib.Error: timeout


### PR DESCRIPTION
udisks bug report: https://github.com/storaged-project/udisks/issues/1133 Known issue #4942

---

Takes care of the common flake in [TestStorageScaling.testScaling](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19040-20230628-152825-8c7822ee-arch-storage/log.html#47-2)