### PR TITLE
testmap: Unsplit Cockpit's /devel scenario

### DIFF
--- a/lib/test-testmap.py
+++ b/lib/test-testmap.py
@@ -92,8 +92,9 @@ class TestTestMap(unittest.TestCase):
         self.assertIn("arch/networking", main_tests)
         self.assertIn("debian-testing/other", main_tests)
         # scenario options
-        self.assertIn(f"{TEST_OS_DEFAULT}/devel-storage", main_tests)
         self.assertIn(f"{TEST_OS_DEFAULT}/firefox-expensive", main_tests)
+        # devel runs in one scenario due to coverage
+        self.assertIn(f"{TEST_OS_DEFAULT}/devel", main_tests)
 
 
 if __name__ == '__main__':

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -42,7 +42,8 @@ REPO_BRANCH_CONTEXT = {
             *contexts('ubuntu-stable', COCKPIT_SCENARIOS),
             *contexts('fedora-37', COCKPIT_SCENARIOS),
             *contexts('fedora-38', COCKPIT_SCENARIOS),
-            *contexts(TEST_OS_DEFAULT, ['devel'], COCKPIT_SCENARIOS),
+            # this runs coverage, reports need the whole test suite
+            *contexts(TEST_OS_DEFAULT, ['devel']),
             *contexts(TEST_OS_DEFAULT, ['firefox'], COCKPIT_SCENARIOS),
             *contexts(TEST_OS_DEFAULT, ['pybridge'], COCKPIT_SCENARIOS),
             *contexts('centos-8-stream', ['pybridge'], COCKPIT_SCENARIOS),


### PR DESCRIPTION
This produces coverage reports, which are much less useful when they get split into four parts.