### PR TITLE
naughty: Add variation for #4829 podman hang

### DIFF
--- a/naughty/rhel4edge/4829-podman-hang-2
+++ b/naughty/rhel4edge/4829-podman-hang-2
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in testPruneUnusedContainers*
+*
+RuntimeError: Timed out on '
+            podman run --name inpodrunning --pod pod -tid localhost/test-busybox sh -c 'sleep infinity''

--- a/naughty/ubuntu-2204/4829-podman-hang-2
+++ b/naughty/ubuntu-2204/4829-podman-hang-2
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in testPruneUnusedContainers*
+*
+RuntimeError: Timed out on '
+            podman run --name inpodrunning --pod pod -tid localhost/test-busybox sh -c 'sleep infinity''


### PR DESCRIPTION
This can also happen for the "inpodrunning" part of the test, where the pod name and the executed command are different.

----

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-1322-20230703-061631-7cc9e4bf-rhel4edge/log.html#28-1 or https://cockpit-logs.us-east-1.linodeobjects.com/pull-1322-20230703-063358-7cc9e4bf-ubuntu-2204/log.html#28-2