### PR TITLE
debian.setup: remove netdev hack

### DIFF
--- a/images/debian-stable
+++ b/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-b3ad4e4032c33c2f4d1e98804e64db3ba2a0f626949bcd0b893004eaea96ccf4.qcow2
+debian-stable-eca25d9c8982d5d3cb5fb8e49d3b211a0030390d2e0d615be858e9ed6eff8775.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -104,10 +104,6 @@ systemd-timesyncd
 # wait until cloud-init finishes, so that it doesn't clobber sources.list
 until systemctl list-jobs | grep -q "No jobs"; do sleep 1; done
 
-# HACK: bookworm cloud images have broken netdev group
-# https://lists.debian.org/debian-cloud/2023/06/msg00029.html and https://bugs.debian.org/1038691
-delgroup netdev
-
 RELEASE=$(. /etc/os-release; echo $VERSION_CODENAME)
 
 # debian-testing image gets bootstrapped from debian stable; upgrade


### PR DESCRIPTION
b51ce28add added a workaround for the broken netdev group, but that's fixed now.  Drop it again.

Fixes #4963

 * [x] image-refresh debian-stable