### PR TITLE
images: Move rhel4edge to RHEL 9.2

### DIFF
--- a/images/scripts/rhel4edge.bootstrap
+++ b/images/scripts/rhel4edge.bootstrap
@@ -10,7 +10,7 @@ timestamp=$(date +%s)
 cat > edge-request.json <<EOF
 {
   "name": "rhel4edge-$timestamp",
-  "distribution": "rhel-91",
+  "distribution": "rhel-92",
   "imageType": "rhel-edge-installer",
   "packages": [
     { "name": "cockpit-system" },

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -219,7 +219,7 @@ REPO_BRANCH_CONTEXT = {
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
     "fedora-coreos": "fedora-38",
-    "rhel4edge": "rhel-9-0",
+    "rhel4edge": "rhel-9-2",
 }
 
 # only put auxiliary images here; triggers for primary OS images are computed from testmap


### PR DESCRIPTION
9.2 is a long-term supported release, 9.1 isn't.

 * [ ] FAIL: image-refresh rhel4edge