### PR TITLE
naughty: Add more pattern for podman pod creation hang

### DIFF
--- a/naughty/rhel4edge/4829-podman-hang-4
+++ b/naughty/rhel4edge/4829-podman-hang-4
@@ -1,0 +1,4 @@
+# testPruneUnusedContainers*
+*
+----- user containers -----
+timeout: sending signal TERM to command*

--- a/naughty/rhel4edge/4829-podman-hang-5
+++ b/naughty/rhel4edge/4829-podman-hang-5
@@ -1,0 +1,9 @@
+  File "test/check-application", line *
+    self.waitPodContainer(*
+*
+testlib.Error: timeout
+*
+  File "test/check-application", line *, in tearDown
+    self.execute(auth, "podman ps -a >&2")
+*
+RuntimeError: Timed out on 'podman ps -a >&2'

--- a/naughty/ubuntu-2204/4829-podman-hang-4
+++ b/naughty/ubuntu-2204/4829-podman-hang-4
@@ -1,0 +1,4 @@
+# testPruneUnusedContainers*
+*
+----- user containers -----
+timeout: sending signal TERM to command*

--- a/naughty/ubuntu-2204/4829-podman-hang-5
+++ b/naughty/ubuntu-2204/4829-podman-hang-5
@@ -1,0 +1,9 @@
+  File "test/check-application", line *
+    self.waitPodContainer(*
+*
+testlib.Error: timeout
+*
+  File "test/check-application", line *, in tearDown
+    self.execute(auth, "podman ps -a >&2")
+*
+RuntimeError: Timed out on 'podman ps -a >&2'


### PR DESCRIPTION
command completely locks up any podman operation, it also causes the cleanup handlers to hang (such as `podman ps -a` debug output, or the `podman rm --all`).

In some cases this takes long enough to trigger the hard 10-minute timeout, in which case we just get the global "timeout:" output. Restrict these to testPruneUnusedContainers.

---

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230713-122539-298112db-rhel4edge/log.html and https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230713-122539-298112db-ubuntu-2204/log.html and https://cockpit-logs.us-east-1.linodeobjects.com/pull-1353-20230713-121517-c10a8aa0-ubuntu-2204/log.html