### PR TITLE
naughty: Add yet another pattern for podman pod run hang

### DIFF
--- a/naughty/rhel4edge/4829-podman-hang-5
+++ b/naughty/rhel4edge/4829-podman-hang-5
@@ -1,9 +1,4 @@
-  File "test/check-application", line *
-    self.waitPodContainer(*
+# testCreatePod*
 *
-testlib.Error: timeout
-*
-  File "test/check-application", line *, in tearDown
-    self.execute(auth, "podman ps -a >&2")
-*
-RuntimeError: Timed out on 'podman ps -a >&2'
+----- user containers -----
+timeout: sending signal TERM to command*

--- a/naughty/rhel4edge/4829-podman-hang-6
+++ b/naughty/rhel4edge/4829-podman-hang-6
@@ -1,0 +1,9 @@
+  File "test/check-application", line *
+    self.waitPodContainer(*
+*
+testlib.Error: timeout
+*
+  File "test/check-application", line *, in tearDown
+    self.execute(auth, "podman ps -a >&2")
+*
+RuntimeError: Timed out on 'podman ps -a >&2'

--- a/naughty/ubuntu-2204/4829-podman-hang-5
+++ b/naughty/ubuntu-2204/4829-podman-hang-5
@@ -1,9 +1,4 @@
-  File "test/check-application", line *
-    self.waitPodContainer(*
+# testCreatePod*
 *
-testlib.Error: timeout
-*
-  File "test/check-application", line *, in tearDown
-    self.execute(auth, "podman ps -a >&2")
-*
-RuntimeError: Timed out on 'podman ps -a >&2'
+----- user containers -----
+timeout: sending signal TERM to command*

--- a/naughty/ubuntu-2204/4829-podman-hang-6
+++ b/naughty/ubuntu-2204/4829-podman-hang-6
@@ -1,0 +1,9 @@
+  File "test/check-application", line *
+    self.waitPodContainer(*
+*
+testlib.Error: timeout
+*
+  File "test/check-application", line *, in tearDown
+    self.execute(auth, "podman ps -a >&2")
+*
+RuntimeError: Timed out on 'podman ps -a >&2'


### PR DESCRIPTION
Pattern -4 only applied to `testPruneUnusedContainers`, but the same can happen to `testCreatePod`. As -5 was a different pattern, move -5 to -6, and make the new -5 a copy of 4 that applies to the latter test.

---

Spotted here: https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230714-100146-0d0a164d-ubuntu-2204/log.html#19-1

The gift that keeps on giving! :gift_heart: 