### PR TITLE
naughty: Add pattern for podman missing health check events

### DIFF
--- a/naughty/debian-stable/5003-podman-health-log
+++ b/naughty/debian-stable/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/debian-testing/5003-podman-health-log
+++ b/naughty/debian-testing/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/fedora-37/5003-podman-health-log
+++ b/naughty/fedora-37/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/fedora-38/5003-podman-health-log
+++ b/naughty/fedora-38/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/fedora-39/5003-podman-health-log
+++ b/naughty/fedora-39/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/rhel-8/5003-podman-health-log
+++ b/naughty/rhel-8/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/rhel-9/5003-podman-health-log
+++ b/naughty/rhel-9/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/rhel4edge/5003-podman-health-log
+++ b/naughty/rhel4edge/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/ubuntu-2204/5003-podman-health-log
+++ b/naughty/ubuntu-2204/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout

--- a/naughty/ubuntu-stable/5003-podman-health-log
+++ b/naughty/ubuntu-stable/5003-podman-health-log
@@ -1,0 +1,4 @@
+  File "test/check-application", line *, in _testHealthcheck
+    b.wait_visible(".ct-listing-panel-body tbody tr:nth-child(2)")
+*
+testlib.Error: timeout


### PR DESCRIPTION
podman upstream report: https://github.com/containers/podman/issues/19237

Known issue #5003

----

[example log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230714-100146-0d0a164d-fedora-38/log.html#25) (that is with extra debug information)

This is unfortunately broken everywhere, and I don't see a good workaround.