### PR TITLE
naughty: Add pattern for Fedora rawhide sos crash

### DIFF
--- a/naughty/fedora-39/5016-sosreport-readfp
+++ b/naughty/fedora-39/5016-sosreport-readfp
@@ -1,0 +1,4 @@
+  File "tests/test/verify/check-sosreport", line *
+    b.wait_not_present("#sos-dialog")
+*
+testlib.Error: timeout


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2223526 Known issue #5016

----

Fedora Rawhide works again in TF in principle since yesterday evening. It now fails "properly" on this sos regression, see https://artifacts.dev.testing-farm.io/382d0430-4269-4e71-8fca-2f874a491f91/