### PR TITLE
tests-scan: Add --match option for triggered contexts

### DIFF
--- a/tests-scan
+++ b/tests-scan
@@ -20,6 +20,7 @@
 import argparse
 import json
 import logging
+import re
 import shlex
 import sys
 import time
@@ -69,6 +70,8 @@ def main():
                         help='Test contexts to use.')
     parser.add_argument('-p', '--pull-number', default=None,
                         help='Single pull request to scan for tasks')
+    parser.add_argument('-m', '--match', default=None,
+                        help='Filter triggered contexts from testmap (regular expression)')
     parser.add_argument('--pull-data', default=None,
                         help='pull_request event GitHub JSON data to evaluate; mutualy exclusive with -p and -s')
     parser.add_argument('-s', '--sha', default=None,
@@ -274,9 +277,11 @@ def update_status(api, revision, context, last, changes):
     return True
 
 
-def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp):
+def cockpit_tasks(api, update, contexts, context_filter, repo, pull_data, pull_number, sha, amqp):
     results = []
     pulls = []
+
+    filter_re = re.compile(context_filter) if context_filter else None
 
     if pull_data:
         pulls.append(json.loads(pull_data)['pull_request'])
@@ -324,6 +329,9 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
                 todos[status] = statuses[status]
         if not statuses:  # If none defined in github add basic set of contexts
             for context in build_policy(repo, contexts).get(base, []):
+                if filter_re and not filter_re.search(context):
+                    logging.debug("skipping %s because it does not match %s", context, context_filter)
+                    continue
                 todos[context] = {}
 
         # there are 3 different HEADs
@@ -390,7 +398,8 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
 
 
 def scan_for_pull_tasks(api, contexts, opts, repo):
-    results = cockpit_tasks(api, not opts.dry, contexts, repo, opts.pull_data, opts.pull_number, opts.sha, opts.amqp)
+    results = cockpit_tasks(api, not opts.dry, contexts, opts.match, repo,
+                            opts.pull_data, opts.pull_number, opts.sha, opts.amqp)
 
     if opts.human_readable:
         results.sort(reverse=True, key=str)


### PR DESCRIPTION
This allows developers to select a subset easily, especially with
cockpit's recent scenario split. One can e.g. only trigger all Debian
tests with `-m debian` or only all the /networking scenario with
`-m networking`.

---

 - [x] Rebase after PR #5026

I did that in https://github.com/cockpit-project/cockpit/pull/19104 . Demo:

```
❱❱❱ bots/tests-scan -p 19104 -nv -m other 
INFO:root:Processing #19104 titled 'sosreport: Add fallback error message' on revision ece5d7d240b859a8a795f37ba10456399fbd314d
pull-19104  ubuntu-stable/other       ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  ubuntu-2204/other         ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  rhel4edge/other           ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  rhel-9-3/other            ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  rhel-8-9/other            ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  rhel-8-9-distropkg/other  ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  fedora-coreos/other       ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  fedora-38/pybridge-other  ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  fedora-38/other           ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  fedora-38/firefox-other   ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  fedora-37/other           ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  debian-testing/other      ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  debian-stable/other       ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  centos-8-stream/pybridge-other ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  centos-8-stream/other     ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
pull-19104  arch/other                ece5d7d    5.80896  (cockpit-project/cockpit) [bots@main]   {main}
```