### PR TITLE
testmap: Drop Fedora pybridge scenario for Cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -45,7 +45,6 @@ REPO_BRANCH_CONTEXT = {
             # this runs coverage, reports need the whole test suite
             *contexts(TEST_OS_DEFAULT, ['devel']),
             *contexts(TEST_OS_DEFAULT, ['firefox'], COCKPIT_SCENARIOS),
-            *contexts(TEST_OS_DEFAULT, ['pybridge'], COCKPIT_SCENARIOS),
             *contexts('centos-8-stream', ['pybridge'], COCKPIT_SCENARIOS),
             # no udisks on CoreOS → skip storage
             *contexts('fedora-coreos', COCKPIT_SCENARIOS - {'storage'}),


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/19009 switched Fedora 38 to the pybridge for the "regular" build.

Still keep the pybridge scenario for the other projects, until cockpit with the above PR got released and the fedora-38 image refreshed with it.