### PR TITLE
Store anaconda payload in the cockpit image server

### DIFF
--- a/create-anaconda-payload
+++ b/create-anaconda-payload
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# create-anaconda-payload  -- Create a payload to be used by anaconda installer tests.
+
+import argparse
+import os
+import subprocess
+
+from lib.constants import BOTS_DIR
+from machine import testvm
+
+KICKSTART = """\
+cmdline
+timezone Europe/Prague --utc
+keyboard --vckeymap=us --xlayouts='us'
+lang en_US.UTF-8
+url --url https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/
+rootpw test # root gets locked anyway
+%packages --excludedocs --exclude-weakdeps --inst-langs en
+openssh
+xfsprogs
+exfatprogs
+e2fsprogs
+efibootmgr
+grub2-tools
+grub2-pc
+grub2-pc-modules
+grub2-tools-efi
+grub2-tools-extra
+grub2-efi-x64
+shim-x64
+cryptsetup
+btrfs-progs
+mdadm
+lvm2
+%end
+"""
+
+KICKSTART_PATH = "/tmp/payload.ks"
+
+
+def build_payload(image, output):
+    subprocess.check_call([os.path.join(BOTS_DIR, "image-download"), image])
+    machine = testvm.VirtMachine(image=image, memory_mb=4096)
+    try:
+        machine.start()
+        machine.wait_boot()
+        machine.execute("dnf install -y anaconda", timeout=300)
+
+        # Create directory /mnt/sysimage and start installation
+        machine.write(KICKSTART_PATH, KICKSTART)
+        machine.execute(
+            f"mkdir -p /mnt/sysimage && anaconda --kickstart {KICKSTART_PATH} --dirinstall /mnt/sysimage",
+            timeout=600
+        )
+
+        # Change directory to /mnt/sysimage/ and create archive
+        machine.execute("cd /mnt/sysimage && tar --selinux --acls --xattrs -zcvf /root/payload.tar.gz *", timeout=100)
+
+        machine.download("/root/payload.tar.gz", output)
+    finally:
+        machine.stop()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--image', default='fedora-rawhide')
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args()
+
+    if not args.output:
+        raise RuntimeError("Output path not specified")
+
+    build_payload(args.image, args.output)
+
+
+main()

--- a/image-create
+++ b/image-create
@@ -56,7 +56,13 @@ class MachineBuilder:
     def __init__(self, machine):
         self.machine = machine
         self.iso = self.machine.image.endswith("boot")
-        self.suffix = ".iso" if self.iso else ".qcow2"
+        self.payload = self.machine.image.endswith("payload")
+        if self.iso:
+            self.suffix = ".iso"
+        elif self.payload:
+            self.suffix = ".tar.gz"
+        else:
+            self.suffix = ".qcow2"
 
         # Use /var/tmp/ as this is going to be a huge file; /tmp/ is commonly tmpfs
         self.target_file = self.machine.image_file
@@ -163,7 +169,7 @@ class MachineBuilder:
         if not os.path.exists(self.machine.image_file):
             raise testvm.Failure("Nothing to save.")
 
-        if not self.iso:
+        if not self.iso and not self.payload:
             rebuild = os.path.join(data_dir, self.machine.image + ".rebuild")
 
             # Copy image via convert, to make it sparse again
@@ -171,16 +177,16 @@ class MachineBuilder:
 
         # Hash the image here
         (sha, x1, x2) = subprocess.check_output(
-            ["sha256sum", self.machine.image_file if self.iso else rebuild], universal_newlines=True
+            ["sha256sum", self.machine.image_file if (self.iso or self.payload) else rebuild], universal_newlines=True
         ).partition(" ")
         if not sha:
             raise testvm.Failure("sha256sum returned invalid output")
 
         name = self.machine.image + "-" + sha + self.suffix
         data_file = os.path.join(data_dir, name)
-        shutil.move(self.machine.image_file if self.iso else rebuild, data_file)
+        shutil.move(self.machine.image_file if (self.iso or self.payload) else rebuild, data_file)
 
-        if not self.iso:
+        if not self.iso and not self.payload:
             # Remove temp image file
             os.unlink(self.machine.image_file)
 

--- a/image-trigger
+++ b/image-trigger
@@ -44,6 +44,7 @@ REFRESH = {
     "fedora-coreos": {},
     "fedora-rawhide": {},
     "fedora-rawhide-boot": {},
+    "fedora-rawhide-anaconda-payload": {"refresh-days": 30},
     "ubuntu-2204": {},
     "ubuntu-stable": {},
     "rhel-7-9": {},

--- a/images/fedora-rawhide-anaconda-payload
+++ b/images/fedora-rawhide-anaconda-payload
@@ -1,0 +1,1 @@
+fedora-rawhide-anaconda-payload-da9a1fa220015d8c75e76e5fb4340f1b9dd47982706340e334c7f81f63ce8531.tar.gz

--- a/images/scripts/fedora-rawhide-anaconda-payload.bootstrap
+++ b/images/scripts/fedora-rawhide-anaconda-payload.bootstrap
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eux
+
+OUTPUT="$1"
+
+python3 create-anaconda-payload --output=$OUTPUT


### PR DESCRIPTION
Image refresh for fedora-rawhide-anaconda-payload
 * [x] image-refresh fedora-rawhide-anaconda-payload

-------

This is the payload used for the anaconda tests for completing the installation.

Right now it is not gated and updating the images on the fedorapeople server is limited to specific people due to lack of permissions.

Additionally since there is not any caching happening, the tests that need the payload download it each time, making the whole concept very inefficient.

Lastly this will help to fix check-progress TestInstallationProgress.testBasic flake, which fails very often on timeout, because of the payload download.

Intructions on how to update it exist here: https://spaces.redhat.com/display/FRONTDOOR/Payload+creation

However, this does not need to change often, we can hardcode this for now.