### PR TITLE
Remove ubuntu-2004 leftover scripts

### DIFF
--- a/images/scripts/ubuntu-2004.bootstrap
+++ b/images/scripts/ubuntu-2004.bootstrap
@@ -1,2 +1,0 @@
-#! /bin/sh -ex
-exec $(dirname $0)/lib/cloudimage.bootstrap "$1" https://cloud-images.ubuntu.com/daily/server/focal/current/focal-server-cloudimg-amd64.img

--- a/images/scripts/ubuntu-2004.setup
+++ b/images/scripts/ubuntu-2004.setup
@@ -1,1 +1,0 @@
-debian.setup


### PR DESCRIPTION
We no longer test anything on ubuntu-2004 since it was dropped at https://github.com/cockpit-project/bots/pull/3294, so remove its leftover setup scripts.