### PR TITLE
Revert "images: Force nodejs 18 on Rawhide"

### DIFF
--- a/images/fedora-rawhide
+++ b/images/fedora-rawhide
@@ -1,1 +1,1 @@
-fedora-rawhide-41ddfc2bd0d88e979690e2547011abc37e63ffff25d6a60f9f079746ba53fda0.qcow2
+fedora-rawhide-d7bb7e6dd17ad738985e48a0afe628cabafd7a4915a05bf784b02070b869c2b6.qcow2

--- a/images/scripts/fedora.setup
+++ b/images/scripts/fedora.setup
@@ -186,11 +186,6 @@ fi
 echo "config_opts['use_bootstrap'] = False" >>/etc/mock/site-defaults.cfg
 su builder -c "/usr/bin/mock --no-bootstrap-chroot --verbose -i $(/var/lib/testvm/build-deps.sh "${ID} ${VERSION_ID}")"
 
-# HACK: nodejs 20 crashes left and right in rawhide
-if [ "$VERSION_ID" = "39" ]; then
-    su builder -c "mock --install nodejs18; mock --shell -- ln -sfn node-18 /usr/bin/node"
-fi
-
 # we need to ensure that mock's selinux-policy is older than the host:
 # disabling the updates repository will surely get us a very old version
 mkdir /tmp/selinux-policy-rpms


### PR DESCRIPTION
This reverts commit 87c3af1aea1091f83012c0e12f26c8d6fb7ac056. Our TF tests no longer use nodejs 18 but switched back to nodejs 20.

 * [x] image-refresh fedora-rawhide