### PR TITLE
npm-update: Drop alpha versions for @patternfly

### DIFF
--- a/npm-update
+++ b/npm-update
@@ -58,8 +58,6 @@ def write_package_json(package_json_path, data):
 def prefix(name, version):
     if not version[0].isdigit():
         return version
-    if name.startswith("@patternfly"):
-        return "alpha"
     return "~" + version
 
 


### PR DESCRIPTION
The "alpha" and "prerelease" tags are currently very inconsistent in the various @patternfly projects, and even go backwards. Stay at the stable releases for the time being.

----

See https://github.com/cockpit-project/starter-kit/pull/686 and https://github.com/cockpit-project/cockpit/pull/19181 , they both went backwards. E.g. [@p/patternfly](https://www.npmjs.com/package/@patternfly/patternfly?activeTab=versions)'s "alpha" points to a 5.0 prerelease (older than "latest"), and [@p/react-core](https://www.npmjs.com/package/@patternfly/react-core?activeTab=versions)'s "prerelease" points to a 5.0 prerelease (older than "latest").

Also, we've had enough churn on PF5 to take a breath for a while.