### PR TITLE
Add script to download fedora rawhide live ISO

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -45,6 +45,7 @@ REFRESH = {
     "fedora-rawhide": {},
     "fedora-rawhide-boot": {},
     "fedora-rawhide-anaconda-payload": {"refresh-days": 30},
+    "fedora-rawhide-live-boot": {"refresh-days": 30},
     "ubuntu-2204": {},
     "ubuntu-stable": {},
     "rhel-7-9": {},

--- a/images/fedora-rawhide-live-boot
+++ b/images/fedora-rawhide-live-boot
@@ -1,0 +1,1 @@
+fedora-rawhide-live-boot-bbda56362ea214f7666396443a233a05e43f67bcc51d50729cf91bbba56de6b7.iso

--- a/images/scripts/fedora-rawhide-live-boot.bootstrap
+++ b/images/scripts/fedora-rawhide-live-boot.bootstrap
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eux
+
+OUTPUT="$1"
+
+ISO_FOLDER='https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Workstation/x86_64/iso'
+ISO=$(curl -L --silent https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Workstation/x86_64/iso/ |  grep -oP 'href="\K[^"]+' | grep -E '\.iso' | head -n1 | tr -d '\n')
+URL="$ISO_FOLDER/$ISO"
+
+curl -L "$URL" -o "$OUTPUT"


### PR DESCRIPTION
Image refresh for fedora-rawhide-live-boot
 * [x] image-refresh fedora-rawhide-live-boot

This ISO is for now used for manual testing only.

The reason for introducing this here is to allow anaconda devs to reuse the existing scripts for spawning the test VMs.

In the future this should be ideally replaced by building a custom Live ISO with `sshd` enabled so that we can use this image in the test automation as well.