### PR TITLE
naughty: Add pattern for #5090 on rhel-9-3

### DIFF
--- a/naughty/rhel-9/5090-lvresize-fails-with-stratis-signature
+++ b/naughty/rhel-9/5090-lvresize-fails-with-stratis-signature
@@ -1,0 +1,5 @@
+> warning: Error resizing logical volume: Process reported exit code 5:   File system device usage is not available from libblkid.
+*
+Traceback (most recent call last):
+  File "check-storage-stratis", line *, in testPoolResize
+    b.wait_not_present(vol_tab + " button:contains(Shrink volume)")


### PR DESCRIPTION
lvresize has broken its "API" again and rhel-9-3 is also affected in addition to Arch. Other OSes don't seem to be affected because lvresize is compiled differently and uses different defaults for the `--fs` option.

rhel-9-3 didn't see the NTFS failure of Arch, since we don't test NTFS there.

This will be triggered in the existing rhel-9-3 image by the new tests in https://github.com/cockpit-project/cockpit/pull/19079