### PR TITLE
Fedora nightly scenario

### DIFF
--- a/task/test-tests-scan
+++ b/task/test-tests-scan
@@ -25,6 +25,7 @@ import tempfile
 import unittest
 
 from lib.constants import BOTS_DIR
+from task import github
 from task.test_mock_server import MockHandler, MockServer
 
 ADDRESS = ("127.0.0.7", 9898)
@@ -69,11 +70,20 @@ class Handler(MockHandler):
             self.replyJson([])
         elif self.path.startswith('/repos/project/repo/pulls'):
             self.replyJson([self.server.data['/repos/project/repo/pulls/1']])
+        elif self.path.endswith("/issues"):
+            issues = self.server.data['issues']
+            self.replyJson(issues)
         else:
             self.send_error(404, 'Mock Not Found: ' + self.path)
 
     def do_POST(self):
-        self.send_error(405, 'Method not allowed: ' + self.path)
+        if self.path.startswith("/repos/cockpit-project/cockpit/issues"):
+            content_len = int(self.headers.get('content-length'))
+            data = json.loads(self.rfile.read(content_len).decode('utf-8'))
+            self.server.data['issues'] = [data]
+            self.replyJson(data)
+        else:
+            self.send_error(405, 'Method not allowed: ' + self.path)
 
 
 class TestTestsScan(unittest.TestCase):
@@ -205,6 +215,31 @@ class TestTestsScan(unittest.TestCase):
         self.assertEqual(proc.returncode, 0)
         self.assertEqual(output.strip(), expected_output)
         self.assertIsNone(stderr)
+
+    def test_tests_invoke(self):
+        repo = "cockpit-project/cockpit"
+        args = ["--revision", self.revision, "--repo", repo]
+        script = os.path.join(BOTS_DIR, "tests-invoke")
+        with tempfile.TemporaryDirectory() as tempdir:
+            testdir = f"{tempdir}/.cockpit-ci"
+            os.makedirs(testdir)
+            with open(f"{testdir}/run", "w") as fp:
+                fp.write("#!/bin/bash\nexit 1")
+            os.system(f"chmod +x {testdir}/run")
+            proc = subprocess.Popen([script, *args], stdout=subprocess.PIPE, universal_newlines=True,
+                                    env={"GITHUB_API": f"http://{ADDRESS[0]}:{ADDRESS[1]}", "TEST_INVOKE_SLEEP": "1"},
+                                    cwd=tempdir)
+            output, stderr = proc.communicate()
+            api = github.GitHub(f"http://{ADDRESS[0]}:{ADDRESS[1]}/")
+            issues = api.get("issues")
+
+            self.assertEqual(output, "")
+            self.assertEqual(proc.returncode, 1)
+            self.assertEqual(len(issues), 1)
+            self.assertEqual(issues[0]['title'], "Nightly tests did not succeed")
+            self.assertEqual(issues[0]['body'], f"Tests failed on {self.revision}")
+            self.assertEqual(issues[0]['labels'], ["nightly"])
+            self.assertIsNone(stderr)
 
 
 if __name__ == '__main__':

--- a/task/test-tests-scan
+++ b/task/test-tests-scan
@@ -51,6 +51,12 @@ GITHUB_DATA = {
         "statuses": [],
         "sha": "abcdef",
     },
+    # HACK: we can't change the test map dynamically when invoked via test-scan
+    "/repos/cockpit-project/cockpit/commits/abcdef/status?page=1&per_page=100": {
+        "state": "pending",
+        "statuses": [],
+        "sha": "abcdef",
+    },
     "/users/user/repos": [{"full_name": "project/repo"}]
 }
 
@@ -169,6 +175,34 @@ class TestTestsScan(unittest.TestCase):
 
         self.assertEqual(proc.returncode, 0)
         expected_output = self.expected_human_output()
+        self.assertEqual(output.strip(), expected_output)
+        self.assertIsNone(stderr)
+
+    def test_no_pull_request(self):
+        repo = "cockpit-project/cockpit"
+        args = ["--dry", "--sha", self.revision, "--repo", repo,
+                "--context", self.context]
+        proc, output, stderr = self.run_tests_scan(args)
+        expected_output = (f"./s3-streamer --repo {repo} --test-name pull-\\d+-\\d+-\\d+"
+                           f" --github-context {self.context} --revision {self.revision} -- /bin/sh -c"
+                           f" \"PRIORITY=0006 ./make-checkout --verbose --repo={repo} --rebase=main {self.revision}"
+                           f" && cd make-checkout-workdir && TEST_OS=fedora BASE_BRANCH=main"
+                           " COCKPIT_BOTS_REF=main TEST_SCENARIO=nightly ../tests-invoke"
+                           f" --revision {self.revision} --repo {repo}\"")
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertRegex(output.strip(), expected_output)
+        self.assertIsNone(stderr)
+
+    def test_no_pull_request_human(self):
+        repo = "cockpit-project/cockpit"
+        args = ["--dry", "--sha", self.revision, "--repo", repo,
+                "--context", self.context, "-v"]
+        proc, output, stderr = self.run_tests_scan(args)
+        expected_output = (f"pull-0      {self.context}            {self.revision}"
+                           f"     6.0  ({repo}) [bots@main]   {{main}}")
+
+        self.assertEqual(proc.returncode, 0)
         self.assertEqual(output.strip(), expected_output)
         self.assertIsNone(stderr)
 

--- a/tests-invoke
+++ b/tests-invoke
@@ -33,8 +33,7 @@ sys.dont_write_bytecode = True
 def main():
     parser = argparse.ArgumentParser(description='Run integration tests')
     parser.add_argument('--repo', help="The repository in which the tested PR is opened", default=None)
-    parser.add_argument('--pull-number', help="The number of the pull request to test",
-                        required=True)
+    parser.add_argument('--pull-number', help="The number of the pull request to test")
     parser.add_argument('--revision', help="Revision of the PR head", required=True)
     opts = parser.parse_args()
 
@@ -94,6 +93,14 @@ def main():
                 time.sleep(60)
         return_code = p.returncode
         sys.stderr.write("Test run finished, return code: {0}\n".format(return_code))
+        if not opts.pull_number and return_code != 0:
+            api = github.GitHub(repo=opts.repo)
+            data = {
+                "title": "Nightly tests did not succeed",
+                "body": f"Tests failed on {opts.revision}",
+                "labels": ["nightly"]
+            }
+            api.post("issues", data)
         return return_code
     except RuntimeError as ex:
         ret = str(ex)

--- a/tests-invoke
+++ b/tests-invoke
@@ -90,7 +90,7 @@ def main():
                 p.terminate()
                 p.wait(timeout=60)
             else:
-                time.sleep(60)
+                time.sleep(int(os.getenv("TEST_INVOKE_SLEEP", "60")))
         return_code = p.returncode
         sys.stderr.write("Test run finished, return code: {0}\n".format(return_code))
         if not opts.pull_number and return_code != 0:

--- a/tests-scan
+++ b/tests-scan
@@ -72,7 +72,7 @@ def main():
     parser.add_argument('--pull-data', default=None,
                         help='pull_request event GitHub JSON data to evaluate; mutualy exclusive with -p and -s')
     parser.add_argument('-s', '--sha', default=None,
-                        help='SHA belonging to pull request to scan for tasks')
+                        help='SHA to scan for tasks')
     parser.add_argument('--amqp', default=None,
                         help='The host:port of the AMQP server to publish to (format host:port)')
 
@@ -143,7 +143,11 @@ def tests_invoke(priority, name, number, revision, ref, context, base,
     (image, _, scenario) = context.partition("/")
 
     checkout = "PRIORITY={priority:04d} ./make-checkout --verbose --repo={repo}"
-    invoke = "../tests-invoke --pull-number {pull_number} --revision {revision} --repo {github_base}"
+    # Special case for when running tests without a PR
+    if number == 0:
+        invoke = "../tests-invoke --revision {revision} --repo {github_base}"
+    else:
+        invoke = "../tests-invoke --pull-number {pull_number} --revision {revision} --repo {github_base}"
     test_env = "TEST_OS={image} BASE_BRANCH={base}"
     wrapper = "./s3-streamer --repo {github_base} --test-name {name}-{current} " \
               "--github-context {github_context} --revision {revision}"
@@ -287,6 +291,21 @@ def cockpit_tasks(api, update, contexts, repo, pull_data, pull_number, sha, amqp
         else:
             logging.error("Can't find pull request %s", pull_number)
             return 1
+    elif sha:
+        pulls.append({
+            "title": f"{sha}",
+            "number": 0,
+            "head": {
+                "sha": sha,
+                "user": {
+                    "login": "cockpit-project"
+                }
+            },
+            "base": {
+                "ref": testmap.get_default_branch(repo)
+            },
+            "labels": [],
+        })
     else:
         pulls = api.pulls()
 


### PR DESCRIPTION
In general the idea is:

* Create a new Github workflow which runs nightly
* Github workflow invokes `./bots/tests-trigger --repo cockpit-project/cockpit-podman "-" $DEFAULT_OS/nightly`
* Commit status is posted, webhook runs and the we end up running: `/tests-scan -s $sha --context $DEFAULT_OS/nightly --repo cockpit-project/cockpit-podman`
* Issue is created if fails, otherwise :heavy_check_mark: should be shown on the commit.

Open discussion points:

* [ ] It seems we can't get the direct logs url from s3-streamer, we can either pol statuses or set an `env` variable so `s3-streamer`'s children know where to look @martinpitt what is your opinion here?
* [ ] Another discussion point, do we drop `--pull-number 0` and add a new argument to `tests-invoke`.

Testing ideas:

We could test the new `tests-invoke` option if we:
* [ ] Provide a mock Github issues endpoint where we can create an issue
* [ ] mock `BASE_DIR` so we can control the executed `test/run` and simply `exit 1` or `exit 0`
* [ ] mock / override `time.sleep(60)` or change the polling to be more aggressive as waiting 1 minute in a test is bonkers.

