### PR TITLE
naughty: Make patterns for #5090 less specific

### DIFF
--- a/naughty/arch/5090-lvresize-fails-with-stratis-signature
+++ b/naughty/arch/5090-lvresize-fails-with-stratis-signature
@@ -1,5 +1,3 @@
 > warning: Error resizing logical volume: Process reported exit code 5:   File system device usage is not available from libblkid.
 *
-Traceback (most recent call last):
   File "check-storage-stratis", line *, in testPoolResize
-    b.wait_not_present(vol_tab + " button:contains(Shrink volume)")

--- a/naughty/rhel-9/5090-lvresize-fails-with-stratis-signature
+++ b/naughty/rhel-9/5090-lvresize-fails-with-stratis-signature
@@ -1,5 +1,3 @@
 > warning: Error resizing logical volume: Process reported exit code 5:   File system device usage is not available from libblkid.
 *
-Traceback (most recent call last):
   File "check-storage-stratis", line *, in testPoolResize
-    b.wait_not_present(vol_tab + " button:contains(Shrink volume)")


### PR DESCRIPTION
The message is not triggered by the function in the backtrace, but sometime earlier.

The tests in https://github.com/cockpit-project/cockpit/pull/19079 have changed and now we need to update these naughties.
