### PR TITLE
machine: Drop virt domain collision retry

### DIFF
--- a/machine/machine_core/exceptions.py
+++ b/machine/machine_core/exceptions.py
@@ -22,7 +22,3 @@ class Failure(Exception):
 
     def __str__(self):
         return self.msg
-
-
-class RepeatableFailure(Failure):
-    pass

--- a/machine/machine_core/testvm.py
+++ b/machine/machine_core/testvm.py
@@ -17,12 +17,12 @@
 
 from lib.constants import BOTS_DIR, DEFAULT_IMAGE, TEST_DIR, TEST_OS_DEFAULT
 
-from .exceptions import Failure, RepeatableFailure
+from .exceptions import Failure
 from .machine import Machine
 from .machine_virtual import VirtMachine, VirtNetwork
 from .timeout import Timeout
 
 __all__ = (
-    "Timeout", "Machine", "Failure", "RepeatableFailure", "VirtMachine", "VirtNetwork",
+    "Timeout", "Machine", "Failure", "VirtMachine", "VirtNetwork",
     "BOTS_DIR", "TEST_DIR", "DEFAULT_IMAGE", "TEST_OS_DEFAULT"
 )

--- a/machine/testvm.py
+++ b/machine/testvm.py
@@ -29,7 +29,7 @@ if bots_dir not in sys.path:
     sys.path.insert(1, bots_dir)
 
 from machine_core.cli import cmd_cli  # noqa: E402
-from machine_core.exceptions import Failure, RepeatableFailure  # noqa: E402
+from machine_core.exceptions import Failure  # noqa: E402
 from machine_core.machine import Machine  # noqa: E402
 from machine_core.machine_virtual import VirtMachine, VirtNetwork  # noqa: E402
 from machine_core.timeout import Timeout  # noqa: E402
@@ -39,7 +39,7 @@ from lib.directories import get_images_data_dir  # noqa: E402
 from lib.testmap import get_build_image, get_test_image  # noqa: E402
 
 __all__ = (
-    "Timeout", "Machine", "Failure", "RepeatableFailure", "VirtMachine",
+    "Timeout", "Machine", "Failure", "VirtMachine",
     "VirtNetwork", "get_build_image", "get_test_image", "get_images_data_dir",
     "BOTS_DIR", "TEST_DIR", "IMAGES_DIR", "SCRIPTS_DIR",
     "DEFAULT_IMAGE", "TEST_OS_DEFAULT"


### PR DESCRIPTION
Collisions Should Not Happen™, as we flock() the assigned ports to the VMs, and the name includes these. This was introduced in https://github.com/cockpit-project/cockpit/pull/3141 without much detail nor justification, and I have never seen such a retry in the wild.

---

I noticed that while staring at the qemu code for integrating snapshot/restore, for https://issues.redhat.com/browse/COCKPIT-1011 . This retry loop would interfere too much with that, so let's get rid of it. I trigger a bunch of expensive tests to make sure this works.