### PR TITLE
testmap: Enable fedora-39 for cockpit, disable fedora-37

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -40,8 +40,8 @@ REPO_BRANCH_CONTEXT = {
             *contexts('debian-testing', COCKPIT_SCENARIOS),
             *contexts('ubuntu-2204', COCKPIT_SCENARIOS),
             *contexts('ubuntu-stable', COCKPIT_SCENARIOS),
-            *contexts('fedora-37', COCKPIT_SCENARIOS),
             *contexts('fedora-38', COCKPIT_SCENARIOS),
+            *contexts('fedora-39', COCKPIT_SCENARIOS),
             # this runs coverage, reports need the whole test suite
             *contexts(TEST_OS_DEFAULT, ['devel']),
             *contexts(TEST_OS_DEFAULT, ['firefox'], COCKPIT_SCENARIOS),
@@ -63,7 +63,6 @@ REPO_BRANCH_CONTEXT = {
         '_manual': [
             'fedora-testing',
             'fedora-rawhide',
-            'fedora-39',
         ],
     },
     'cockpit-project/starter-kit': {

--- a/naughty/fedora-39/4796-stratis-runs-clevis-too-early
+++ b/naughty/fedora-39/4796-stratis-runs-clevis-too-early
@@ -1,0 +1,2 @@
+  File "test/verify/check-storage-stratis", line *, in testBasic
+    self.wait_mounted(1, 1)  # should be mounted after boot

--- a/naughty/fedora-39/5020-selinux-nsupdate-sqpoll
+++ b/naughty/fedora-39/5020-selinux-nsupdate-sqpoll
@@ -1,0 +1,1 @@
+avc:  denied  { sqpoll } for * comm="nsupdate" scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:sssd_t:s0 tclass=io_uring permissive=0

--- a/naughty/fedora-39/5020-selinux-pmproxy-ipc_lock
+++ b/naughty/fedora-39/5020-selinux-pmproxy-ipc_lock
@@ -1,0 +1,1 @@
+avc:  denied  { ipc_lock } for * comm="pmproxy" capability=14  scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=capability permissive=0

--- a/naughty/fedora-39/5020-selinux-pmproxy-sqpoll
+++ b/naughty/fedora-39/5020-selinux-pmproxy-sqpoll
@@ -1,0 +1,1 @@
+avc:  denied  { sqpoll } for * comm="pmproxy" scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=io_uring permissive=0

--- a/naughty/fedora-39/5090-lvm2-resize-ntfs-unexpected-error
+++ b/naughty/fedora-39/5090-lvm2-resize-ntfs-unexpected-error
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*", line *, in testResizeNtfs
+    self.checkResize("ntfs", crypto=False,
+*
+testlib.Error: timeout

--- a/naughty/fedora-39/5090-lvresize-fails-with-stratis-signature
+++ b/naughty/fedora-39/5090-lvresize-fails-with-stratis-signature
@@ -1,0 +1,3 @@
+> warning: Error resizing logical volume: Process reported exit code 5:   File system device usage is not available from libblkid.
+*
+  File "check-storage-stratis", line *, in testPoolResize

--- a/naughty/fedora-39/5106-journalctl-since-until-behaviour-change
+++ b/naughty/fedora-39/5106-journalctl-since-until-behaviour-change
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*", line *, in testEvents
+*
+testlib.Error: timeout
+wait_js_cond(ph_is_present(".cockpit-log-message:contains('Created slice cockpittest.slice.')")): Uncaught (in promise) Error: condition did not become true

--- a/naughty/fedora-39/5106-journalctl-since-until-behaviour-change-2
+++ b/naughty/fedora-39/5106-journalctl-since-until-behaviour-change-2
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "*", line *, in testRebootAndTime
+*
+        })(["January 1, 2037", ["check-journal", "AFTER BOOT", ""], ["", "Reboot", ""], ["check-journal", "BEFORE BOOT", ""]])): Uncaught (in promise) Error: condition did not become true

--- a/naughty/fedora-39/5119-udisks-xfs-size-not-updated
+++ b/naughty/fedora-39/5119-udisks-xfs-size-not-updated
@@ -1,0 +1,6 @@
+  File "/work/bots/make-checkout-workdir/test/verify/check-storage-resize", line *, in testResizeXfs
+    self.checkResize("xfs", crypto=False,
+  File "/work/bots/make-checkout-workdir/test/verify/check-storage-resize", line *, in checkResize
+    self.content_tab_wait_in_info(1, 1, "Size", "398 MB")
+*
+testlib.Error: timed out waiting for predicate to become true

--- a/naughty/fedora-39/5173-tracer-rpm-fd-attribute-crash
+++ b/naughty/fedora-39/5173-tracer-rpm-fd-attribute-crash
@@ -1,0 +1,2 @@
+*TestUpdates*
+*error: Tracer failed: *AttributeError: module 'rpm' has no attribute 'fi'. Did you mean: 'fd'*

--- a/naughty/fedora-39/5174-gnutls-fips
+++ b/naughty/fedora-39/5174-gnutls-fips
@@ -1,0 +1,8 @@
+  File "test/verify/check-system-info", line *, in test*CryptoPolic*
+    self.login_and_go("/system")
+*
+testlib.Error: timeout
+*
+Process * (cockpit-certifi) of user 0 dumped core.
+*
+#*cockpit-certificate-ensure*


### PR DESCRIPTION
I initially thought that we need to do the usual "adjust test special cases", but it seems we replaced them all with globs now :muscle: So let's see how far they get!

 - [x] #5172
 - [x] [broken tracer](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5171-20230829-051341-98eab0de-fedora-39-expensive-cockpit-project-cockpit/log.html#7-2), 3 check-packagekit failures; filed known issue #5173
 - [x] [CPU mitigations failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5171-20230829-051347-98eab0de-fedora-39-other-cockpit-project-cockpit/log.html#107-2): fixed in https://github.com/cockpit-project/cockpit/pull/19254
 - [x] [gnutls breaks with FIPS](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5171-20230829-051347-98eab0de-fedora-39-other-cockpit-project-cockpit/log.html#110-2): #5174
 - [x] [kdump failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5171-20230829-063656-e518ac35-fedora-39-expensive-cockpit-project-cockpit/log.html#1-2): kernel now has `crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M` by default, so it runs; fixed by https://github.com/cockpit-project/cockpit/pull/19254
 - [x] `TestStorageNBDE.testRootReboot`: https://github.com/cockpit-project/cockpit/pull/19256
 - [x] [testResizeNtfs](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5171-20230829-115628-7ea001c7-fedora-39-storage-cockpit-project-cockpit/log.html#46): kernel does not support `ntfs` file system any more: PR #5178

Trigger command for iterating:
```sh
./tests-trigger 5171 fedora-39/{networking,storage,expensive,other}@cockpit-project/cockpit
```