### PR TITLE
Add fedora-39-boot for Anaconda testing

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -41,6 +41,7 @@ REFRESH = {
     "fedora-37": {},
     "fedora-38": {},
     "fedora-39": {},
+    "fedora-39-boot": {},
     "fedora-testing": {"refresh-days": 3},
     "fedora-coreos": {},
     "fedora-rawhide": {},

--- a/images/fedora-39-boot
+++ b/images/fedora-39-boot
@@ -1,0 +1,1 @@
+fedora-39-boot-8422ef5efd2418400fc600b1cd529e83e6bf46aa08c5a3ff1bfd54c82f51959e.iso

--- a/images/scripts/fedora-39-boot.bootstrap
+++ b/images/scripts/fedora-39-boot.bootstrap
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eux
+
+OUTPUT="$1"
+
+URL='https://download.fedoraproject.org/pub/fedora/linux/development/39/Server/x86_64/os/images/boot.iso'
+
+curl -L "$URL" -o "$OUTPUT"

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -211,6 +211,9 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'fedora-rawhide-boot',
         ],
+        'fedora-39': [
+            'fedora-39-boot',
+        ]
     },
 }
 
@@ -248,6 +251,9 @@ IMAGE_REFRESH_TRIGGERS = {
     # Anaconda builds in fedora-37 and runs tests in fedora-rawhide-boot
     "fedora-rawhide": [
         "fedora-rawhide-boot@rhinstaller/anaconda"
+    ],
+    "fedora-39": [
+        "fedora-39-boot@rhinstaller/anaconda"
     ],
 }
 


### PR DESCRIPTION
We need ISO to test against on new Anaconda branch for Fedora 39.

 * [x] image-refresh fedora-39-boot