### PR TITLE
Refactor mock server

### DIFF
--- a/task/test-github
+++ b/task/test-github
@@ -19,7 +19,6 @@
 
 import fnmatch
 import json
-import multiprocessing
 import shutil
 import tempfile
 import time
@@ -27,84 +26,52 @@ import unittest
 import urllib.parse
 
 from task import cache, github
+from task.test_mock_server import MockHandler, MockServer
 
 ADDRESS = ("127.0.0.8", 9898)
+GITHUB_ISSUES = [{"number": "5", "state": "open", "created_at": "2011-04-22T13:33:48Z"},
+                 {"number": "6", "state": "closed", "closed_at": "2011-04-21T13:33:48Z"},
+                 {"number": "7", "state": "open"}]
 
 
-def mockServer():
-    # Data used by the above handler
-    reply_count = 0
-
-    issues = [{"number": "5", "state": "open", "created_at": "2011-04-22T13:33:48Z"},
-              {"number": "6", "state": "closed", "closed_at": "2011-04-21T13:33:48Z"},
-              {"number": "7", "state": "open"}]
-
-    import http.server
-
-    class Handler(http.server.BaseHTTPRequestHandler):
-
-        def replyData(self, value, headers={}, status=200):
-            self.send_response(status)
-            for name, content in headers.items():
-                self.send_header(name, content)
-            self.end_headers()
-            self.wfile.write(value.encode('utf-8'))
-            self.wfile.flush()
-
-        def replyJson(self, value, headers=None, status=200):
-            self.server.reply_count += 1
-            all_headers = {"Content-type": "application/json"}
-            all_headers.update(headers or {})
-            self.replyData(json.dumps(value), headers=all_headers, status=status)
-
-        def do_GET(self):
-            parsed = urllib.parse.urlparse(self.path)
-            if parsed.path == "/count":
-                self.replyJson(self.server.reply_count)
-            elif parsed.path == "/issues":
-                issues_ = issues
-                if "state=open" in self.path:
-                    issues_ = [i for i in issues_ if i["state"] == "open"]
-                if "since=" in self.path:
-                    issues_ = [i for i in issues_ if "created_at" not in i.keys() and "closed_at" not in i.keys()]
-                self.replyJson(issues_)
-            elif parsed.path == "/test/user":
-                if self.headers.get("If-None-Match") == "blah":
-                    self.replyData("", status=304)
-                else:
-                    self.replyJson({"user": "blah"}, headers={"ETag": "blah"})
-            elif parsed.path == "/test/user/modified":
-                if self.headers.get("If-Modified-Since") == "Thu, 05 Jul 2012 15:31:30 GMT":
-                    self.replyData("", status=304)
-                else:
-                    self.replyJson({"user": "blah"}, headers={"Last-Modified": "Thu, 05 Jul 2012 15:31:30 GMT"})
-            elif parsed.path == "/orgs/cockpit-project/teams/contributors/members":
-                self.replyJson([
-                    {"login": "one"},
-                    {"login": "two"},
-                    {"login": "three"}
-                ])
+class Handler(MockHandler):
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == "/count":
+            self.replyJson(self.server.reply_count)
+        elif parsed.path == "/issues":
+            issues_ = self.server.data
+            if "state=open" in self.path:
+                issues_ = [i for i in issues_ if i["state"] == "open"]
+            if "since=" in self.path:
+                issues_ = [i for i in issues_ if "created_at" not in i.keys() and "closed_at" not in i.keys()]
+            self.replyJson(issues_)
+        elif parsed.path == "/test/user":
+            if self.headers.get("If-None-Match") == "blah":
+                self.replyData("", status=304)
             else:
-                self.send_error(404, 'Mock Not Found: ' + parsed.path)
-
-        def do_DELETE(self):
-            parsed = urllib.parse.urlparse(self.path)
-            if parsed.path == '/issues/7':
-                del issues[-1]
-                self.replyJson({})
+                self.replyJson({"user": "blah"}, headers={"ETag": "blah"})
+        elif parsed.path == "/test/user/modified":
+            if self.headers.get("If-Modified-Since") == "Thu, 05 Jul 2012 15:31:30 GMT":
+                self.replyData("", status=304)
             else:
-                self.send_error(404, 'Mock Not Found: ' + parsed.path)
+                self.replyJson({"user": "blah"}, headers={"Last-Modified": "Thu, 05 Jul 2012 15:31:30 GMT"})
+        elif parsed.path == "/orgs/cockpit-project/teams/contributors/members":
+            self.replyJson([
+                {"login": "one"},
+                {"login": "two"},
+                {"login": "three"}
+            ])
+        else:
+            self.send_error(404, 'Mock Not Found: ' + parsed.path)
 
-    httpd = http.server.HTTPServer(ADDRESS, Handler)
-    httpd.reply_count = reply_count
-    process = multiprocessing.Process(target=httpd.serve_forever)
-    process.start()
-    return process
-
-
-def mockKill(child):
-    child.terminate()
-    child.join()
+    def do_DELETE(self):
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == '/issues/7':
+            del self.server.data[-1]
+            self.replyJson({})
+        else:
+            self.send_error(404, 'Mock Not Found: ' + parsed.path)
 
 
 class TestLogger(object):
@@ -118,12 +85,13 @@ class TestLogger(object):
 
 class TestGitHub(unittest.TestCase):
     def setUp(self):
-        self.child = mockServer()
+        self.server = MockServer(ADDRESS, Handler, GITHUB_ISSUES)
+        self.server.start()
         self.temp = tempfile.mkdtemp()
         self.api = github.GitHub(f"http://{ADDRESS[0]}:{ADDRESS[1]}/", cacher=cache.Cache(self.temp))
 
     def tearDown(self):
-        mockKill(self.child)
+        self.server.kill()
         shutil.rmtree(self.temp)
 
     def testCache(self):

--- a/task/test-task
+++ b/task/test-task
@@ -29,9 +29,6 @@ import task
 
 ADDRESS = ("127.0.0.9", 9898)
 
-os.environ["GITHUB_API"] = "http://127.0.0.9:9898"
-os.environ["GITHUB_BASE"] = "project/repo"
-
 
 DATA = {
     "/repos/project/repo": {
@@ -136,10 +133,14 @@ class TestTask(unittest.TestCase):
     def setUp(self):
         self.child = mockServer()
         self.temp = tempfile.mkdtemp()
+        os.environ["GITHUB_API"] = "http://127.0.0.9:9898"
+        os.environ["GITHUB_BASE"] = "project/repo"
 
     def tearDown(self):
         mockKill(self.child)
         shutil.rmtree(self.temp)
+        os.unsetenv("GITHUB_API")
+        os.unsetenv("GITHUB_BASE")
 
     def testRunArguments(self):
         status = {"ran": False}

--- a/task/test-task
+++ b/task/test-task
@@ -18,7 +18,6 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import multiprocessing
 import os
 import shutil
 import tempfile
@@ -26,11 +25,12 @@ import unittest
 from unittest.mock import patch
 
 import task
+from task.test_mock_server import MockHandler, MockServer
 
 ADDRESS = ("127.0.0.9", 9898)
 
 
-DATA = {
+GITHUB_DATA = {
     "/repos/project/repo": {
         "default_branch": "main"
     },
@@ -48,65 +48,39 @@ DATA = {
 }
 
 
-def mockServer():
-    # Data used by below handler
-    data = {}
+class Handler(MockHandler):
+    def do_GET(self):
+        if self.path in self.server.data:
+            self.replyJson(self.server.data[self.path])
+        else:
+            self.send_error(404, 'Mock Not Found: ' + self.path)
 
-    import http.server
-
-    class Handler(http.server.BaseHTTPRequestHandler):
-
-        def replyData(self, value, headers={}, status=200):
-            self.send_response(status)
-            for name, content in headers.items():
-                self.send_header(name, content)
-            self.end_headers()
-            self.wfile.write(value)
-            self.wfile.flush()
-
-        def replyJson(self, value, headers=None, status=200):
-            all_headers = {"Content-type": "application/json"}
-            all_headers.update(headers or {})
-            self.replyData(json.dumps(value).encode('utf-8'), headers=all_headers, status=status)
-
-        def do_GET(self):
-            if self.path in DATA:
-                self.replyJson(DATA[self.path])
-            else:
-                self.send_error(404, 'Mock Not Found: ' + self.path)
-
-        def do_POST(self):
-            if self.path == "/repos/project/repo/pulls":
-                content_len = int(self.headers.get('content-length'))
-                data = json.loads(self.rfile.read(content_len).decode('utf-8'))
-                assert data['title'] == "[no-test] Task title"
-                data["number"] = 1234
-                self.replyJson(data)
-            elif self.path == "/repos/project/repo/pulls/1234":
-                content_len = int(self.headers.get('content-length'))
-                data = json.loads(self.rfile.read(content_len).decode('utf-8'))
-                data["number"] = 1234
-                data["body"] = "This is the body"
-                data["head"] = {"sha": "abcde"}
-                self.replyJson(data)
-            elif self.path == "/repos/project/repo/issues/1234/comments":
-                content_len = int(self.headers.get('content-length'))
-                data = json.loads(self.rfile.read(content_len).decode('utf-8'))
-                self.replyJson(data)
-            elif self.path == "/repos/project/repo/issues/1234/labels":
-                content_len = int(self.headers.get('content-length'))
-                data = json.loads(self.rfile.read(content_len).decode('utf-8'))
-                self.replyJson(data)
-            elif self.path.startswith("/repos/project/repo/issues/3333"):
-                self.replyJson({})
-            else:
-                self.send_error(405, 'Method not allowed: ' + self.path)
-
-    httpd = http.server.HTTPServer(ADDRESS, Handler)
-    httpd.data = data
-    process = multiprocessing.Process(target=httpd.serve_forever)
-    process.start()
-    return process
+    def do_POST(self):
+        if self.path == "/repos/project/repo/pulls":
+            content_len = int(self.headers.get('content-length'))
+            data = json.loads(self.rfile.read(content_len).decode('utf-8'))
+            assert data['title'] == "[no-test] Task title"
+            data["number"] = 1234
+            self.replyJson(data)
+        elif self.path == "/repos/project/repo/pulls/1234":
+            content_len = int(self.headers.get('content-length'))
+            data = json.loads(self.rfile.read(content_len).decode('utf-8'))
+            data["number"] = 1234
+            data["body"] = "This is the body"
+            data["head"] = {"sha": "abcde"}
+            self.replyJson(data)
+        elif self.path == "/repos/project/repo/issues/1234/comments":
+            content_len = int(self.headers.get('content-length'))
+            data = json.loads(self.rfile.read(content_len).decode('utf-8'))
+            self.replyJson(data)
+        elif self.path == "/repos/project/repo/issues/1234/labels":
+            content_len = int(self.headers.get('content-length'))
+            data = json.loads(self.rfile.read(content_len).decode('utf-8'))
+            self.replyJson(data)
+        elif self.path.startswith("/repos/project/repo/issues/3333"):
+            self.replyJson({})
+        else:
+            self.send_error(405, 'Method not allowed: ' + self.path)
 
 
 def mock_execute(*args):
@@ -124,20 +98,16 @@ def mock_execute(*args):
         raise Exception("Mocking unsupported git command")
 
 
-def mockKill(child):
-    child.terminate()
-    child.join()
-
-
 class TestTask(unittest.TestCase):
     def setUp(self):
-        self.child = mockServer()
+        self.server = MockServer(ADDRESS, Handler, GITHUB_DATA)
+        self.server.start()
         self.temp = tempfile.mkdtemp()
         os.environ["GITHUB_API"] = "http://127.0.0.9:9898"
         os.environ["GITHUB_BASE"] = "project/repo"
 
     def tearDown(self):
-        mockKill(self.child)
+        self.server.kill()
         shutil.rmtree(self.temp)
         os.unsetenv("GITHUB_API")
         os.unsetenv("GITHUB_BASE")

--- a/task/test_mock_server.py
+++ b/task/test_mock_server.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import http.server
+import json
+import multiprocessing
+
+
+class MockServer(http.server.HTTPServer):
+    def __init__(self, address, handler, data=None):
+        self.address = address
+        self.handler = handler
+        self.data = data
+        self.reply_count: int = 0
+        super(MockServer, self).__init__(address, handler)
+
+    def start(self):
+        self.process = multiprocessing.Process(target=self.serve_forever)
+        self.process.start()
+
+    def kill(self):
+        self.process.terminate()
+        self.process.join()
+
+
+class MockHandler(http.server.BaseHTTPRequestHandler):
+    server: MockServer
+
+    def replyData(self, value, headers={}, status=200):
+        self.send_response(status)
+        for name, content in headers.items():
+            self.send_header(name, content)
+        self.end_headers()
+        self.wfile.write(value.encode('utf-8'))
+        self.wfile.flush()
+
+    def replyJson(self, value, headers=None, status=200):
+        self.server.reply_count += 1
+        all_headers = {"Content-type": "application/json"}
+        all_headers.update(headers or {})
+        self.replyData(json.dumps(value), headers=all_headers, status=status)


### PR DESCRIPTION
Follow up idea, get rid of the hardcoded ports, just pick a random unused port by binding on `0` and use that.

Personally dislike the location of `test_mock_server` but I am not sure yet how I feel about having `test/__init__.py` and it's consequences.