### PR TITLE
machine: Add snapshot API

### DIFF
--- a/machine/machine_core/cli.py
+++ b/machine/machine_core/cli.py
@@ -23,7 +23,7 @@ from . import machine_virtual
 
 def cmd_cli():
     parser = argparse.ArgumentParser(description="Run a VM image until SIGTERM or SIGINT")
-    parser.add_argument("--memory", type=int, default=1024,
+    parser.add_argument("--memory", type=int, default=machine_virtual.MEMORY_MB,
                         help="Memory in MiB to allocate to the VM (default: %(default)s)")
     parser.add_argument("image", help="Image name")
     args = parser.parse_args()

--- a/machine/machine_core/cli.py
+++ b/machine/machine_core/cli.py
@@ -25,11 +25,13 @@ def cmd_cli():
     parser = argparse.ArgumentParser(description="Run a VM image until SIGTERM or SIGINT")
     parser.add_argument("--memory", type=int, default=machine_virtual.MEMORY_MB,
                         help="Memory in MiB to allocate to the VM (default: %(default)s)")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
     parser.add_argument("image", help="Image name")
     args = parser.parse_args()
 
     network = machine_virtual.VirtNetwork(0, image=args.image)
-    machine = machine_virtual.VirtMachine(image=args.image, networking=network.host(), memory_mb=args.memory)
+    machine = machine_virtual.VirtMachine(image=args.image, networking=network.host(), memory_mb=args.memory,
+                                          verbose=args.verbose)
     machine.start()
     machine.wait_boot()
 

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -245,7 +245,7 @@ class VirtMachine(Machine):
     cpus = None
 
     def __init__(self, image, networking=None, maintain=False, memory_mb=None, cpus=None,
-                 graphics=False, overlay_dir=None, **args):
+                 graphics=False, **args):
         self.maintain = maintain
 
         self.memory_mb = memory_mb or VirtMachine.memory_mb or MEMORY_MB
@@ -273,7 +273,7 @@ class VirtMachine(Machine):
 
         Machine.__init__(self, image=image, **args)
 
-        self.run_dir = overlay_dir or os.getenv("TEST_OVERLAY_DIR", "/var/tmp")
+        self.run_dir = os.getenv("TEST_OVERLAY_DIR", "/var/tmp")
 
         self.virt_connection = self._libvirt_connection(hypervisor="qemu:///session")
 

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -273,7 +273,8 @@ class VirtMachine(Machine):
 
         Machine.__init__(self, image=image, **args)
 
-        self.run_dir = os.getenv("TEST_OVERLAY_DIR", "/var/tmp")
+        self.run_dir = os.path.join(os.getenv("TEST_OVERLAY_DIR", "/var/tmp"), "bots-run")
+        os.makedirs(self.run_dir, 0o700, exist_ok=True)
 
         self.virt_connection = self._libvirt_connection(hypervisor="qemu:///session")
 


### PR DESCRIPTION
Add snapshot() and restore() methods machine: Add snapshot API around libvirt's save/restore [1]. Consumers like cockpit's run-tests can use this to more efficiently provide machines for destructive tests, and thus booting "standard" (no customized hardware) VMs just once.
    
https://issues.redhat.com/browse/COCKPIT-1011
    
[1] https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainSave

-----

A simple test for this is:

```diff
--- machine/machine_core/cli.py
+++ machine/machine_core/cli.py
@@ -46,6 +46,11 @@ def cmd_cli():
     # print marker that the VM is ready; tests can poll for this to wait for the VM
     print("RUNNING")
 
+    machine.snapshot()
+    input("Press enter to restore snapshot")
+    machine.restore()
+    input("Press ^C to stop")
+
     signal.signal(signal.SIGTERM, lambda sig, frame: machine.stop())
     try:
         signal.pause()

```