### PR TITLE
lib: Fix @functools.lru_cache() decorator

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -70,7 +70,7 @@ def host_ssl_context(hostname: str) -> Optional[ssl.SSLContext]:
     return ssl.create_default_context(cafile=cafile) if cafile else None
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def redhat_network() -> bool:
     """Check if we can access the Red Hat network
 


### PR DESCRIPTION
In Python 3.6 it still couldn't be called with a function as an argument [1], so it fails with an "invalid value of maxsize".

https://docs.python.org/3.6/library/functools.html#functools.lru_cache

----

This broke today's RHEL gating tests.