### PR TITLE
naughty: Add pattern for arch PackageKit crash

### DIFF
--- a/naughty/arch/5229-packagekit-emitted_finished
+++ b/naughty/arch/5229-packagekit-emitted_finished
@@ -1,0 +1,4 @@
+Process * (packagekitd) of user 0 dumped core.
+*g_assertion_message_expr*
+*alpm_db_update*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:


### PR DESCRIPTION
Upstream report: https://github.com/PackageKit/PackageKit/issues/656 Known issue #5229

Examples:
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-19286-20230907-154333-3e7ba9e2-arch-other/log.html#173
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-19246-20230908-090032-b82c60f7-arch-other/log.html#128