### PR TITLE
make-checkout: Retry git network operations

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -36,10 +36,25 @@ if [ -e "$TARGET_DIR" ]; then
     rm -rf "$TARGET_DIR"
 fi
 
-git clone "https://github.com/$REPO" "$TARGET_DIR"
+for retry in $(seq 5); do
+    if git clone "https://github.com/$REPO" "$TARGET_DIR"; then
+        break
+    fi
+    echo "Retrying git clone..."
+    rm -rf "$TARGET_DIR"
+    sleep $((retry * 5))
+done
+
 cd "$TARGET_DIR"
 
-git fetch origin "$REF"
+for retry in $(seq 5); do
+    if git fetch origin "$REF"; then
+        break
+    fi
+    echo "Retrying git fetch..."
+    sleep $((retry * 5))
+done
+
 git checkout --detach "$REV"
 
 if [ -n "${REBASE:-}" ]; then


### PR DESCRIPTION
clone or fetch sometimes fails on transient network problems. Retry both up to 5 times with increasing delays.

---

This should mitigate [errors like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19310-20230911-093427-96ab0112-fedora-coreos-networking/log.html)

`make-checkout` is not self-checking with our PR, it needs to come from main. So we can only rely on the "cockpitous" integration test.