### PR TITLE
prometheus-stats: Add prune option

### DIFF
--- a/prometheus-stats
+++ b/prometheus-stats
@@ -36,6 +36,7 @@ def main():
     parser.add_argument("--s3", metavar="URL", type=urllib.parse.urlparse,
                         help="Upload generated file to given S3 URL")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument("--prune", type=int, metavar="DAYS", help="Remove entries older than DAYS")
     opts = parser.parse_args()
 
     if opts.verbose:
@@ -43,6 +44,19 @@ def main():
 
     db_conn = sqlite3.connect(opts.db)
     cursor = db_conn.cursor()
+
+    if opts.prune:
+        # this would be much more elegant with just "PRAGMA foreign_keys = ON", and letting SQLite
+        # auto-cleanup deleted foreign keys in the other tables; but that takes unbearably long
+        cursor.execute(f"CREATE TEMP TABLE to_delete AS SELECT id FROM TestRuns "
+                       f"WHERE time < unixepoch('now', '-{opts.prune} days')")
+        cursor.execute("DELETE FROM Tests WHERE run IN to_delete")
+        cursor.execute("DELETE FROM TestCoverage WHERE run IN to_delete")
+        cursor.execute("DELETE FROM TestRuns WHERE id IN to_delete")
+        db_conn.commit()
+        cursor.execute("VACUUM")
+        db_conn.commit()
+        return
 
     # Output in prometheus format, see:
     # https://prometheus.io/docs/instrumenting/exposition_formats/


### PR DESCRIPTION
Our test database has grown too large; it takes too long to process, even causes networking errors during download, and we don't actually care much about ancient results.

Add a `prometheus-stats --prune DAYS` option that deletes all test runs older than the given number of days.

----

This was causing our [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html) to not work at all, and even curl fails:
```
$ curl -vv -O https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/test-results.db
 19  754M   19  147M    0     0  9194k      0  0:01:23  0:00:16  0:01:07 7326k
* Closing connection 0
} [5 bytes data]
* TLSv1.3 (OUT), TLS alert, close notify (256):
} [2 bytes data]
curl: (18) transfer closed with 636579840 bytes remaining to read
```

So in the OpenShift tasks container, I did a backup and pruned:
```
cp /cache/images/test-results{,-20230912}.db
./prometheus-stats --prune 30 --db /cache/images/test-results.db
```

which reduced the database size from 755 MB to 24 MB. Now the weather report works again, with reasonable performance.

Once this  lands, I'll think about how to do this regularly/automatically.