### PR TITLE
naughty: loosen the packagekitd stack trace for Arch

### DIFF
--- a/naughty/arch/5229-packagekit-emitted_finished
+++ b/naughty/arch/5229-packagekit-emitted_finished
@@ -1,4 +1,3 @@
 Process * (packagekitd) of user 0 dumped core.
 *g_assertion_message_expr*
-*alpm_db_update*
 testlib.Error: FAIL: Test completed, but found unexpected journal messages:


### PR DESCRIPTION
alpm_db_update is not always included in the backtrace.

Verified locally:

```
[jelle@t14s][~/projects/cockpit-bots]%wget https://cockpit-logs.us-east-1.linodeobjects.com/pull-19315-20230912-105951-93ad0f56-arch/log                            [58/126]
--2023-09-12 14:10:39--  https://cockpit-logs.us-east-1.linodeobjects.com/pull-19315-20230912-105951-93ad0f56-arch/log
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving cockpit-logs.us-east-1.linodeobjects.com (cockpit-logs.us-east-1.linodeobjects.com)... 2600:3c03::f03c:92ff:fe6e:ce1a, 2600:3c03::f03c:92ff:fe92:7931, 2600:3c03::
f03c:92ff:fe6e:7ea0, ...
Connecting to cockpit-logs.us-east-1.linodeobjects.com (cockpit-logs.us-east-1.linodeobjects.com)|2600:3c03::f03c:92ff:fe6e:ce1a|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 441971 (432K) [text/plain]
Saving to: ‘log’

log                                        100%[========================================================================================>] 431.61K   879KB/s    in 0.5s

2023-09-12 14:10:40 (879 KB/s) - ‘log’ saved [441971/441971]

[jelle@t14s][~/projects/cockpit-bots]%vim naughty/arch/5229-packagekit-emitted_finished
[jelle@t14s][~/projects/cockpit-bots]%./test-failure-policy arch < log
Known issue #5229
```