### PR TITLE
make-checkout: Retry rebase target git fetch as well

### DIFF
--- a/make-checkout
+++ b/make-checkout
@@ -2,9 +2,20 @@
 
 set -eu
 
-usage()
-{
+usage() {
     echo "usage: make-checkout [-v] [--rebase BRANCH] --repo REPO REF [REVISION]" >&2
+}
+
+retry() {
+    for retry in $(seq 5); do
+        if "$@"; then
+            return
+        fi
+        echo "Retrying $@... (attempt $retry)" >&2
+        sleep $((retry * 5))
+    done
+    echo "Failed to run $@" >&2
+    exit 1
 }
 
 eval set -- "$(getopt -o vh -l repo:,rebase:,help,verbose -- "$@")"
@@ -36,29 +47,16 @@ if [ -e "$TARGET_DIR" ]; then
     rm -rf "$TARGET_DIR"
 fi
 
-for retry in $(seq 5); do
-    if git clone "https://github.com/$REPO" "$TARGET_DIR"; then
-        break
-    fi
-    echo "Retrying git clone..."
-    rm -rf "$TARGET_DIR"
-    sleep $((retry * 5))
-done
+retry git clone "https://github.com/$REPO" "$TARGET_DIR"
 
 cd "$TARGET_DIR"
 
-for retry in $(seq 5); do
-    if git fetch origin "$REF"; then
-        break
-    fi
-    echo "Retrying git fetch..."
-    sleep $((retry * 5))
-done
+retry git fetch origin "$REF"
 
 git checkout --detach "$REV"
 
 if [ -n "${REBASE:-}" ]; then
-    git fetch origin "$REBASE"
+    retry git fetch origin "$REBASE"
     SHA=`git rev-parse "origin/$REBASE"`
     echo "Rebasing onto origin/$REBASE $SHA ..."
     git rebase "origin/$REBASE"


### PR DESCRIPTION
Commit b366611cf1 missed a case. Provide a retry() helper function to factorize the logic.

We can drop the `rm -rf` of the target dir, as `git clone` automatically removes it on failure.

---

See [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19024-20230912-131855-e49ec197-rhel-9-3-storage/log.html)

Again, this PR is not self-testing. I tested it locally wiht the checkout command from that PR:
```
./make-checkout --verbose --repo=cockpit-project/cockpit --rebase=main e49ec1973ee271a0a2ab330ddc0ad3e24313a75f 
```
and while the initial git clone was running, I ran `pkill git`. That correctly retried it:
```
+ git clone https://github.com/cockpit-project/cockpit make-checkout-workdir
Cloning into 'make-checkout-workdir'...
remote: Enumerating objects: 155098, done.
remote: Counting objects: 100% (257/257), done.
remote: Compressing objects: 100% (111/111), done.
fetch-pack: unexpected disconnect while reading sideband packet/s
Terminated
+ echo 'Retrying git' clone https://github.com/cockpit-project/cockpit 'make-checkout-workdir... (attempt 1)'
Retrying git clone https://github.com/cockpit-project/cockpit make-checkout-workdir... (attempt 1)
+ sleep 5
+ for retry in $(seq 5)
+ git clone https://github.com/cockpit-project/cockpit make-checkout-workdir
Cloning into 'make-checkout-workdir'...
remote: Enumerating objects: 155098, done.
remote: Counting objects: 100% (257/257), done.
remote: Compressing objects: 100% (104/104), done.
remote: Total 155098 (delta 172), reused 196 (delta 153), pack-reused 154841
Receiving objects: 100% (155098/155098), 161.43 MiB | 16.73 MiB/s, done.
Resolving deltas: 100% (121608/121608), done.
+ return
+ cd make-checkout-workdir

```