### PR TITLE
naughty: add naughty for Fedora-38 NFS kdump issue

### DIFF
--- a/naughty/fedora-38/5263-kernel-nfs-kdump
+++ b/naughty/fedora-38/5263-kernel-nfs-kdump
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "*check-kdump", line *, in testBasic
+    self.assertIn("Kdump compressed dump",
+AssertionError: 'Kdump compressed dump' not found in "/srv/kdump/var/crash/10.111.113.1*/vmcore: cannot open `/srv/kdump/var/crash/10.111.113.1*/vmcore' (No such file or directory)\n"


### PR DESCRIPTION
This only occurs in updates-testing, see https://github.com/cockpit-project/cockpit/issues/19331