### PR TITLE
testmap: Add cockpit/rhel-9.3 stable branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -59,6 +59,9 @@ REPO_BRANCH_CONTEXT = {
             'rhel-7-9',
             'centos-7',
         ],
+        'rhel-9.3': [
+            *contexts('rhel-9-3', COCKPIT_SCENARIOS),
+        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-rawhide',


### PR DESCRIPTION
I just created https://github.com/cockpit-project/cockpit/tree/rhel-9.3 straight from the https://github.com/cockpit-project/cockpit/releases/tag/300.1 tag. We need to do some backports for z-stream updates, let's test them properly.