### PR TITLE
README: Document trigger permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
         id: changes
         run: |
           git log --exit-code --stat HEAD --not origin/${{ github.event.pull_request.base.ref }} -- \
+              ':!README.md' \
+              ':!HACKING.md' \
               ':!images' \
               ':!image-create' \
               ':!image-customize' \

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ When generating a new personal access token, the scopes should contain
 `repo:status` and `read:org`. Note in particular, that `repo` and
 `public_repo` scopes each grant full push access, and should not be used.
 
+You need at least "Write" access to the project for triggering statuses, either
+individually per repo (e.g. [cockpit](https://github.com/cockpit-project/cockpit/settings/access)
+or for [all cockpit-project repos](https://github.com/orgs/cockpit-project/teams/committers).
+
 If you'd like to download Red Hat-only internal images from S3, you'll
 need to create a key file in `~/.config/cockpit-dev/s3-keys/[domain]`.
 The `[domain]` can be any non-toplevel domain which contains the S3 URL


### PR DESCRIPTION
There is no way in GitHub to grant someone permissions to POST /statuses without giving full "Write" permissions to the repository. Document that, so that we know what to do for future contributors.

---

@subhoghoshX can now run `bots/tests-trigger` on cockpit, I added him to https://github.com/cockpit-project/cockpit/settings/access . There are still the branch protection rules, so it's not *that* bad.