### PR TITLE
testmap: Enable rhel-9-4 for cockpit-machines

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -116,11 +116,11 @@ REPO_BRANCH_CONTEXT = {
             f'{TEST_OS_DEFAULT}/firefox',
             'rhel-8-9',
             'rhel-9-3',
+            'rhel-9-4',
             'centos-8-stream',
         ],
         '_manual': [
             'fedora-rawhide',
-            'rhel-9-4',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
Tests got adjusted in https://github.com/cockpit-project/cockpit-machines/pull/1218