### PR TITLE
lib: Enable cockpit-navigator testing

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -123,6 +123,16 @@ REPO_BRANCH_CONTEXT = {
             'fedora-rawhide',
         ],
     },
+    'cockpit-project/cockpit-navigator': {
+        '_manual': [
+            TEST_OS_DEFAULT,
+            'arch',
+            'rhel-9-4',
+            'fedora-39',
+            'debian-testing',
+            'fedora-rawhide',
+        ],
+    },
     'weldr/lorax': {
         'master': [
         ],


### PR DESCRIPTION
Needs PR to enable CI on the cockpit-navigator repo.