### PR TITLE
images: Add pkgconf and systemd-dev to Debian pbuilders

### DIFF
--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -227,6 +227,9 @@ EOF
 
 $APT install dpkg-dev pbuilder
 
+# TEMP: until https://github.com/cockpit-project/cockpit/pull/19407 lands
+PBUILDER_EXTRA="${PBUILDER_EXTRA} pkgconf systemd-dev"
+
 pbuilder --create --extrapackages "fakeroot $PBUILDER_EXTRA"
 /usr/lib/pbuilder/pbuilder-satisfydepends-classic --control /tmp/out/tools/debian/control --force-version --echo|grep apt-get | pbuilder --login --save-after-login
 rm -rf /tmp/out


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/19407 will add them to debian/control proper, but for that to land it first needs to be in our current images.

 - [ ] image-refresh debian-stable
 - [ ] image-refresh ubuntu-stable
 - [ ] image-refresh ubuntu-2204

Skipping debian-testing for now due to #5295 . I'll work around that separately.