### PR TITLE
setup-deploy-keys: Rename cockpit's npm-update key

### DIFF
--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -48,10 +48,6 @@ deploy_to cockpit-project/cockpit-project.github.io \
     --deploy-from \
         cockpit-project/cockpit/website/DEPLOY_KEY
 
-deploy_to cockpit-project/cockpit-container \
-    --deploy-from \
-        cockpit-project/cockpit/container-release/DEPLOY_KEY
-
 # cockpit-machines
 deploy_to cockpit-project/cockpit-machines \
     --deploy-from \

--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -37,7 +37,7 @@ deploy_to cockpit-project/bots \
 # cockpit
 deploy_to cockpit-project/cockpit \
     --deploy-from \
-        cockpit-project/cockpit/npm-update/COCKPIT_DEPLOY_KEY \
+        cockpit-project/cockpit/npm-update/SELF_DEPLOY_KEY \
         cockpit-project/cockpit/self/DEPLOY_KEY
 
 deploy_to cockpit-project/cockpit-weblate \


### PR DESCRIPTION
Rename to`SELF_DEPLOY_KEY` like in our other projects, to keep the dependabot workflows in sync. See
https://github.com/cockpit-project/cockpit/pull/19420