### PR TITLE
run-queue: Restrict issue-scan to bots PRs

### DIFF
--- a/run-queue
+++ b/run-queue
@@ -58,8 +58,9 @@ def consume_webhook_queue(channel, amqp):
         pull_request = request['pull_request']
         repo = pull_request['base']['repo']['full_name']
         action = request['action']
-        # scan for body changes (edited) and the bots label
-        if action == 'labeled' or (action == 'edited' and 'body' in request.get('changes', {})):
+        # scan for body changes (edited) and the bots label; we only use that for image refreshes in the bots repo
+        if repo.endswith('/bots') and (
+                action == 'labeled' or (action == 'edited' and 'body' in request.get('changes', {}))):
             cmd = ['./issue-scan', '--issues-data', json.dumps(request), '--amqp', amqp]
         elif action in ['opened', 'synchronize']:
             cmd = ['./tests-scan', '--pull-data', json.dumps(request), '--amqp', amqp, '--repo', repo]


### PR DESCRIPTION
Our projects like cockpit or cockpit-podman now get a lot of dependabot PRs, which have ginormous PR descriptions. They make the bots crash with

    OSError: [Errno 7] Argument list too long: './issue-scan'

as the JSON payload gets passed as a CLI string. This should be cleaned up more carefully soon, but as an immediate stopgap, restrict issue-scan to the bots repo -- we don't need it anywhere else any more, only for image refreshes.

----

This is urgent, as it makes both our webhook and all our tasks containers crash like crazy, and thus stalls tests.