### PR TITLE
tests-invoke: show logs url in nightly issue

### DIFF
--- a/task/test-tests-scan
+++ b/task/test-tests-scan
@@ -223,6 +223,7 @@ class TestTestsScan(unittest.TestCase):
     def test_tests_invoke(self):
         repo = "cockpit-project/cockpit"
         args = ["--revision", self.revision, "--repo", repo]
+        attachments_url = "https://example.org/dir"
         script = os.path.join(BOTS_DIR, "tests-invoke")
         with tempfile.TemporaryDirectory() as tempdir:
             testdir = f"{tempdir}/.cockpit-ci"
@@ -232,7 +233,8 @@ class TestTestsScan(unittest.TestCase):
             os.system(f"chmod +x {testdir}/run")
             proc = subprocess.Popen([script, *args], stdout=subprocess.PIPE, universal_newlines=True,
                                     env={"GITHUB_API": f"http://{ADDRESS[0]}:{ADDRESS[1]}",
-                                         "TEST_INVOKE_SLEEP": "1", "TEST_OS": "fedora-38"},
+                                         "TEST_INVOKE_SLEEP": "1", "TEST_OS": "fedora-38",
+                                         "TEST_ATTACHMENTS_URL": attachments_url},
                                     cwd=tempdir)
             output, stderr = proc.communicate()
             api = github.GitHub(f"http://{ADDRESS[0]}:{ADDRESS[1]}/")
@@ -242,7 +244,8 @@ class TestTestsScan(unittest.TestCase):
             self.assertEqual(proc.returncode, 1)
             self.assertEqual(len(issues), 1)
             self.assertEqual(issues[0]['title'], "Nightly tests did not succeed on fedora-38")
-            self.assertEqual(issues[0]['body'], f"Tests failed on {self.revision}")
+            self.assertEqual(issues[0]['body'],
+                             f"Tests failed on {self.revision}, [logs]({attachments_url}/log.html)")
             self.assertEqual(issues[0]['labels'], ["nightly"])
             self.assertIsNone(stderr)
 

--- a/tests-invoke
+++ b/tests-invoke
@@ -97,14 +97,19 @@ def main():
         return_code = p.returncode
         sys.stderr.write(f"Test run finished, return code: {return_code}\n")
         if not api.has_open_prs(opts.revision) and not collision_detected and return_code != 0:
+            logs_url = os.getenv("TEST_ATTACHMENTS_URL")
             test_scenario = os.getenv("TEST_SCENARIO", "")
             test_os = os.getenv("TEST_OS")
             title = f"Nightly tests did not succeed on {test_os}"
+            body = f"Tests failed on {opts.revision}"
+
+            if logs_url:
+                body += f", [logs]({logs_url}/log.html)"
             if test_scenario != "":
                 title += f"/{test_scenario}"
             data = {
                 "title": title,
-                "body": f"Tests failed on {opts.revision}",
+                "body": body,
                 "labels": ["nightly"]
             }
             api.post("issues", data)


### PR DESCRIPTION
s3-streamer sets a TEST_ATTACHMENTS_URL environment variable as http url to the S3 directory.

References: COCKPIT-1060

---

Turns out we already use the logs somewhere in Cockpit, so this should work as well.
```
test/common/lcov.py:            ta_url = os.environ.get("TEST_ATTACHMENTS_URL", None)
test/common/lcov.py:            if ta_url:
test/common/lcov.py:                body += f"  [Details]({ta_url}/Coverage/lcov/github-pr.diff.gcov.html)"
```