### PR TITLE
images: add linux-system-roles for kdump automation

### DIFF
--- a/images/fedora-38
+++ b/images/fedora-38
@@ -1,1 +1,1 @@
-fedora-38-e6d3defaeb4e04beb148725ce9edc4b570a3485e6d8e1784fd7d2df4082c9f6e.qcow2
+fedora-38-4061eaf7f1654018a42de300d5ab5db24d49d9d7ea4fb20f814fafc59f992eac.qcow2

--- a/images/scripts/fedora.setup
+++ b/images/scripts/fedora.setup
@@ -92,6 +92,7 @@ gettext \
 libvirt-daemon-driver-storage-iscsi \
 libvirt-daemon-driver-storage-iscsi-direct \
 libvirt-daemon-driver-storage-logical \
+linux-system-roles \
 ltrace \
 netcat \
 NetworkManager-openvpn \


### PR DESCRIPTION
The upcoming Ansible integration into the Kdump page will use the existing linux-system-roles (rhel-system-roles on RHEL) for configuring kdump using Ansible.

 * [x] image-refresh fedora-38

Just refreshing TEST_OS_DEFAULT now as that's required for kdump testing.