### PR TITLE
naughty: Copy 5040 vsock failure to fedora-40

### DIFF
--- a/naughty/fedora-40/5040-vm-vsock-hotplug-shutdown-timeout
+++ b/naughty/fedora-40/5040-vm-vsock-hotplug-shutdown-timeout
@@ -1,0 +1,9 @@
+Traceback (most recent call last):
+  File "*test/check-machines-settings", line *, in testVsock
+    setVsockLive(new_auto=True, previous_auto=False, previous_address="5", reboot_machine=True)
+  File "*test/check-machines-settings", line *, in setVsockLive
+    self.performAction("subVmTest1", "forceOff")
+*
+    raise Error("%s(%s): %s" % (func, arg, msg))
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Shut off"))* actual text: Running


### PR DESCRIPTION
Naughty for a failing test which is now present also on fedora-rawhide (e.g. [here](https://artifacts.dev.testing-farm.io/ae8d0515-1303-45b9-904b-407c202f98ed/))

TestMachinesSettings.testVsock:
`wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Shut off")): actual text: Running`

At first, libvirt team thought that the issues will be fixed in systemd 253.6. But now, we are seeing this issue also with systemd 254., so perhaps the issue is somewhere in libvirt. Anyway I [wrote a comment](https://bugzilla.redhat.com/show_bug.cgi?id=2224994#c2) about that on bugzilla and now copying the naughty which is paired with that bugzilla.