### PR TITLE
Revert "naughty: Close 5020: avc: denied { ipc_lock sqpoll } for comm="pmproxy|nsupdate""

### DIFF
--- a/naughty/fedora-37/5020-selinux-pmproxy-ipc_lock
+++ b/naughty/fedora-37/5020-selinux-pmproxy-ipc_lock
@@ -1,0 +1,1 @@
+avc:  denied  { ipc_lock } for * comm="pmproxy" capability=14  scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=capability permissive=0

--- a/naughty/fedora-37/5020-selinux-pmproxy-sqpoll
+++ b/naughty/fedora-37/5020-selinux-pmproxy-sqpoll
@@ -1,0 +1,1 @@
+avc:  denied  { sqpoll } for * comm="pmproxy" scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=io_uring permissive=0

--- a/naughty/fedora-38/5020-selinux-nsupdate-sqpoll
+++ b/naughty/fedora-38/5020-selinux-nsupdate-sqpoll
@@ -1,0 +1,1 @@
+avc:  denied  { sqpoll } for * comm="nsupdate" scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:sssd_t:s0 tclass=io_uring permissive=0

--- a/naughty/fedora-38/5020-selinux-pmproxy-ipc_lock
+++ b/naughty/fedora-38/5020-selinux-pmproxy-ipc_lock
@@ -1,0 +1,1 @@
+avc:  denied  { ipc_lock } for * comm="pmproxy" capability=14  scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=capability permissive=0

--- a/naughty/fedora-38/5020-selinux-pmproxy-sqpoll
+++ b/naughty/fedora-38/5020-selinux-pmproxy-sqpoll
@@ -1,0 +1,1 @@
+avc:  denied  { sqpoll } for * comm="pmproxy" scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=io_uring permissive=0

--- a/naughty/fedora-39/5020-selinux-nsupdate-sqpoll
+++ b/naughty/fedora-39/5020-selinux-nsupdate-sqpoll
@@ -1,0 +1,1 @@
+avc:  denied  { sqpoll } for * comm="nsupdate" scontext=system_u:system_r:sssd_t:s0 tcontext=system_u:system_r:sssd_t:s0 tclass=io_uring permissive=0

--- a/naughty/fedora-39/5020-selinux-pmproxy-ipc_lock
+++ b/naughty/fedora-39/5020-selinux-pmproxy-ipc_lock
@@ -1,0 +1,1 @@
+avc:  denied  { ipc_lock } for * comm="pmproxy" capability=14  scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=capability permissive=0

--- a/naughty/fedora-39/5020-selinux-pmproxy-sqpoll
+++ b/naughty/fedora-39/5020-selinux-pmproxy-sqpoll
@@ -1,0 +1,1 @@
+avc:  denied  { sqpoll } for * comm="pmproxy" scontext=system_u:system_r:pcp_pmproxy_t:s0 tcontext=system_u:system_r:pcp_pmproxy_t:s0 tclass=io_uring permissive=0


### PR DESCRIPTION
Reverts cockpit-project/bots#5392

---

This got spotted in the wild again in image refresh #5403 . I reopened the Fedora bugzilla, too.