### PR TITLE
image-trigger: Restore fedora-coreos

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -41,6 +41,7 @@ REFRESH = {
     "fedora-37": {},
     "fedora-38": {},
     "fedora-39": {},
+    "fedora-coreos": {},
     "fedora-rawhide": {},
     "fedora-rawhide-boot": {},
     "fedora-rawhide-anaconda-payload": {"refresh-days": 30},


### PR DESCRIPTION
This got accidentally dropped in commit 28ef5b432cae0.

---

I noticed today that our last refresh is from September, oops!