### PR TITLE
naughty: Add pattern for Rawhide libvirt network SELinux regression

### DIFF
--- a/naughty/fedora-40/5408-selinux-virt-tc
+++ b/naughty/fedora-40/5408-selinux-virt-tc
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "tests/test/check-machines-networks", line *, in testNetworkState
+    wait(lambda: "yes" == m.execute("virsh net-info test_network2 | grep 'Active:' | awk '{print $2}'").strip(), tries=5)
+*
+testlib.Error: Condition did not become true.


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2244759
Known issue #5408

----

This will fix the current [rawhide machines failure](https://artifacts.dev.testing-farm.io/cc604426-d9b6-41ca-98bc-9860d57b46ec/)