### PR TITLE
naughty: Add pattern for tracer crash without os-release

### DIFF
--- a/naughty/rhel-8/5410-tracer-crash-no-osrelease
+++ b/naughty/rhel-8/5410-tracer-crash-no-osrelease
@@ -1,0 +1,4 @@
+*TestApps.testOsMap*
+*
+testlib.Error: FAIL: Test completed, but found unexpected browser errors:
+error: Tracer failed:*System.package_manager

--- a/naughty/rhel-9/5410-tracer-crash-no-osrelease
+++ b/naughty/rhel-9/5410-tracer-crash-no-osrelease
@@ -1,0 +1,4 @@
+*TestApps.testOsMap*
+*
+testlib.Error: FAIL: Test completed, but found unexpected browser errors:
+error: Tracer failed:*System.package_manager


### PR DESCRIPTION
This specifically happens in cockpit's TestApps.testOsMap() which removes /etc/os-release, so restrict the pattern to that test.

Known issue #5410
Downstream report: https://issues.redhat.com/browse/RHEL-14082

---

This blocks https://github.com/cockpit-project/cockpit/pull/19503