### PR TITLE
naughty: Add pattern for tracer crash on platform.linux_distribution

### DIFF
--- a/naughty/rhel-9/5414-tracer-crash-platform
+++ b/naughty/rhel-9/5414-tracer-crash-platform
@@ -1,0 +1,2 @@
+testlib.Error: FAIL: Test completed, but found unexpected browser errors:
+error: Tracer failed: *AttributeError: module 'platform' has no attribute 'linux_distribution'


### PR DESCRIPTION
Downstream report: https://issues.redhat.com/browse/RHEL-14094 Known issue #5414


----

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-19503-20231018-111152-5f9f5ce3-rhel-9-3-other/log.html#96 and https://cockpit-logs.us-east-1.linodeobjects.com/pull-19503-20231018-111150-5f9f5ce3-rhel-9-4-other/log.html#96 , spotted in https://github.com/cockpit-project/cockpit/pull/19503