### PR TITLE
images: Adjust ubuntu-stable for 22.10 mantic

### DIFF
--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -206,14 +206,15 @@ $APT --no-install-recommends install cockpit
 if grep -q 'ID=ubuntu' /etc/os-release; then
     # Extract scsi_debug and team modules from full kernel; let's not install linux-image-generic
     # just for that, it increases boot time by over 10s and image size by > 600 MB
-    EXTRA=$(apt-cache show linux-image-generic | grep Depends: | grep -o 'linux-modules-extra[^,]*' | sort -n | tail -n1)
+    EXTRAS=$(apt-cache show linux-image-generic | grep Depends: | grep -o 'linux-modules-extra[^,]*')
     (cd /tmp/
-     apt-get download "$EXTRA"
-     dpkg-deb --fsys-tarfile ${EXTRA}_*.deb | tar -C / --wildcards -xv '*/scsi_debug.ko' '*/team*.ko'
-     rm $EXTRA_*.deb
+     apt-get download $EXTRAS
+     for pkg in $EXTRAS; do
+        dpkg-deb --fsys-tarfile ${pkg}_*.deb | tar -C / --wildcards -xv '*/scsi_debug.ko' '*/team*.ko'
+        rm ${pkg}_*.deb
+        depmod "${pkg#linux-modules-extra-}"
+     done
     )
-    # call for the updated kernel, not the currently running one
-    depmod "${EXTRA#linux-modules-extra-}"
 fi
 
 # Prepare for building

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -47,7 +47,7 @@ udisks2-lvm2 \
 "
 
 # udisks >= 2.10 depends on libblockdev-mdraid, so add it manually only for older OSes
-if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] ; then
+if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] ; then
     COCKPIT_DEPS="$COCKPIT_DEPS libblockdev-mdraid2"
 fi
 
@@ -87,8 +87,14 @@ tcsh \
 clevis-luks \
 tang \
 libnss-myhostname \
+virtiofsd \
 wireguard-tools \
 "
+
+# older libvirt have this builtin
+if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] ; then
+    TEST_PACKAGES="${TEST_PACKAGES/virtiofsd/}"
+fi
 
 DEBUG_PACKAGES=''
 
@@ -219,7 +225,7 @@ if grep -q 'ID=ubuntu' /etc/os-release; then
     (cd /tmp/
      apt-get download $EXTRAS
      for pkg in $EXTRAS; do
-        dpkg-deb --fsys-tarfile ${pkg}_*.deb | tar -C / --wildcards -xv '*/scsi_debug.ko' '*/team*.ko'
+        dpkg-deb --fsys-tarfile ${pkg}_*.deb | tar -C / --wildcards -xv '*/scsi_debug.ko*' '*/team*.ko*'
         rm ${pkg}_*.deb
         depmod "${pkg#linux-modules-extra-}"
      done
@@ -254,7 +260,7 @@ $APT install dpkg-dev pbuilder
 pbuilder --create --extrapackages "fakeroot $PBUILDER_EXTRA"
 # our static build deps approach cannot resolve alternate build dependencies,
 # so hide systemd-dev on older releases which don't have it yet
-if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] ; then
+if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] ; then
     sed -i 's/systemd-dev |.*,/systemd,/' /tmp/out/tools/debian/control
 fi
 /usr/lib/pbuilder/pbuilder-satisfydepends-classic --control /tmp/out/tools/debian/control --force-version --echo|grep apt-get | pbuilder --login --save-after-login
@@ -324,6 +330,12 @@ fi
 # HACK: https://bugs.debian.org/1032990
 if [ "$RELEASE" = "testing" ]; then
     sed -i '/subid:.*sss/d' /etc/nsswitch.conf
+fi
+
+# HACK: https://launchpad.net/bugs/2040483
+if [ "$IMAGE" = "ubuntu-stable" ]; then
+    mkdir -p /etc/containers/containers.conf.d
+    printf '[CONTAINERS]\napparmor_profile=""\n' > /etc/containers/containers.conf.d/disable-apparmor.conf
 fi
 
 # reduce image size; don't keep old kernels

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -132,6 +132,15 @@ Pin-Priority: 10
 EOF
 fi
 
+if [ "${IMAGE#ubuntu}" != "$IMAGE" ]; then
+    echo "deb http://archive.ubuntu.com/ubuntu ${RELEASE}-proposed main restricted universe" > /etc/apt/sources.list.d/proposed.list
+    cat <<EOF > /etc/apt/preferences.d/all-proposed
+Package: *
+Pin: release a=*-proposed
+Pin-Priority: 600
+EOF
+fi
+
 # smaller and faster initrd; see https://launchpad.net/bugs/1592684
 echo 'MODULES=dep' > /etc/initramfs-tools/conf.d/modules-dep.conf
 

--- a/images/scripts/ubuntu-stable.bootstrap
+++ b/images/scripts/ubuntu-stable.bootstrap
@@ -15,11 +15,4 @@ fi
 # release name is the last part of the URL
 rel=${rel##*/}
 
-# mantic has several dealbreakers which make cockpit unsupportable:
-# https://launchpad.net/bugs/2040488 https://launchpad.net/bugs/2040082 https://launchpad.net/bugs/2040483
-# until at least the first one is fixed, keep lunar aka 22.04
-if [ "$rel" = "mantic" ]; then
-    rel="lunar"
-fi
-
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "https://cloud-images.ubuntu.com/daily/server/$rel/current/$rel-server-cloudimg-amd64.img"

--- a/images/ubuntu-stable
+++ b/images/ubuntu-stable
@@ -1,1 +1,1 @@
-ubuntu-stable-5355e5aec6b660cc62e25e44a834ca7eb389e738a13b4c651b551fe66d9f2b86.qcow2
+ubuntu-stable-e12469ee415da548598a8721f2f833cbf6eae8265e8284dcfaadc10c70b777e8.qcow2

--- a/naughty/ubuntu-stable/2463-no-pod-events
+++ b/naughty/ubuntu-stable/2463-no-pod-events
@@ -1,1 +1,0 @@
-wait_js_cond(ph_is_present("#table-pod-1 .pf*-c-empty-state")):

--- a/naughty/ubuntu-stable/2463-no-pod-events-1
+++ b/naughty/ubuntu-stable/2463-no-pod-events-1
@@ -1,1 +1,0 @@
-wait_js_cond(ph_is_present("#containers-containers .pod-name:contains('pod_user')"))

--- a/naughty/ubuntu-stable/2463-no-pod-events-2
+++ b/naughty/ubuntu-stable/2463-no-pod-events-2
@@ -1,3 +1,0 @@
-testCreateContainerInPodSystem
-*
-wait_js_cond(ph_is_present("#table-system_pod .create-container-in-pod

--- a/naughty/ubuntu-stable/4468-curl-https-unix-socket-issue
+++ b/naughty/ubuntu-stable/4468-curl-https-unix-socket-issue
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-connection", line *, in testSocket
-    self.assertIn('Loading...', output)

--- a/naughty/ubuntu-stable/4915-libvirt-getstats-timeout
+++ b/naughty/ubuntu-stable/4915-libvirt-getstats-timeout
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*", line *, in testVsock
+*
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Shut off"))*

--- a/naughty/ubuntu-stable/5434-udisks2-lvm2-on-luks-broken
+++ b/naughty/ubuntu-stable/5434-udisks2-lvm2-on-luks-broken
@@ -1,0 +1,2 @@
+  File "check-storage-lvm2", line *, in testLvmOnLuks
+    b.wait_in_text(self.card_desc("LVM2 logical volume", "Physical volumes"), bn(disk))

--- a/naughty/ubuntu-stable/5661-nm-netplan-allowed-ips-mask
+++ b/naughty/ubuntu-stable/5661-nm-netplan-allowed-ips-mask
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-networkmanager-wireguard", line *, in testVPN
+    m2.execute(f"until wg show wg0 | grep -q 'allowed ips.*{m1_ip6}/128'; do sleep 1; done")
+*
+RuntimeError: Timed out on 'until wg show wg0 | grep -q 'allowed ips.*2001::1/128'; do sleep 1; done'


### PR DESCRIPTION
Fixes #5431

 * [x] Fix udisks crash when loading lvm2 module: https://launchpad.net/bugs/2040488; fixed in devel series (noble), and mantic-proposed
 * [x] Fix podman AppArmor version parsing crash: https://launchpad.net/bugs/2040082 (could work around with a painful hack)
 * [x] podman AppArmor denial for container signals: https://launchpad.net/bugs/2040483: work around by disabling apparmor container profile
 * [x] image-refresh ubuntu-stable
 * [x] [TestWireGuard.testVPN regression](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5432-20231210-095415-5680c888-ubuntu-stable-networking-cockpit-project-cockpit/log.html#32-2): first part is relatively easy (fixed in https://github.com/cockpit-project/cockpit/pull/19724), but it fails later on missing IPv6 address: https://github.com/cockpit-project/bots/issues/5661
 * [x] [TestMetrics regressions](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5432-20231210-095419-5680c888-ubuntu-stable-other-cockpit-project-cockpit/log.html): CPU and memory work locally, fallout from AppArmor above? DiskIO is real, it's shown as constant 0. Fixed in https://github.com/cockpit-project/cockpit/pull/19724