### PR TITLE
tests-invoke: show a bodhi link for the updates-testing scenario

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -107,6 +107,14 @@ def main():
                 body += f", [logs]({logs_url}/log.html)"
             if test_scenario != "":
                 title += f"/{test_scenario}"
+
+            if 'updates-testing' in test_scenario:
+                assert test_os is not None
+                if test_os.startswith("fedora-"):
+                    rel = test_os.split("-")[-1]
+                    base_url = "https://bodhi.fedoraproject.org"
+                    url = f"{base_url}/updates/?search=&status=testing&status=stable&releases=F{rel}"
+                    body += f"\n[bodhi updates]({url})"
             data = {
                 "title": title,
                 "body": body,


### PR DESCRIPTION
When the updates-testing scenario include a link to the bodhi updates page for convenience.

* [ ] Unbreak cockpituous CI `/bin/sh: line 2: update-ca-trust: command not found`