### PR TITLE
testmap: Drop rhel-8-9 from cockpit-{podman,machines}

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -85,7 +85,6 @@ REPO_BRANCH_CONTEXT = {
     'cockpit-project/cockpit-podman': {
         'main': [
             'arch',
-            'rhel-8-9',
             'rhel-8-10',
             'rhel-9-4',
             'rhel4edge',
@@ -114,7 +113,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-39',
             f'{TEST_OS_DEFAULT}/devel',
             f'{TEST_OS_DEFAULT}/firefox',
-            'rhel-8-9',
             'rhel-8-10',
             'rhel-9-4',
             'centos-8-stream',


### PR DESCRIPTION
Similar to commit 1b63b252d5 for RHEL 9, 8.9 is done, and 8.10 is the current development target.

---

FYI, cockpit support is still missing, see https://github.com/cockpit-project/cockpit/pull/19533