### PR TITLE
naughty: Add patterns for F39 updates-testing regressions

### DIFF
--- a/naughty/fedora-39/5467-selinux-rpcbind-proc-search
+++ b/naughty/fedora-39/5467-selinux-rpcbind-proc-search
@@ -1,0 +1,1 @@
+avc:  denied  { search } for * comm="rpcbind" name="net" dev="proc" * scontext=system_u:system_r:rpcbind_t:s0 tcontext=system_u:object_r:sysctl_net_t:s0 tclass=dir permissive=0

--- a/naughty/fedora-39/5468-stratis-key-set
+++ b/naughty/fedora-39/5468-stratis-key-set
@@ -1,0 +1,7 @@
+termios.error: (25, 'Inappropriate ioctl for device')
+*
+Traceback (most recent call last):
+  File "test/verify/check-storage-stratis", line *, in testEncrypted
+    m.execute("echo not-the-passphrase | stratis key set --capture-key pool0")
+*
+subprocess.CalledProcessError

--- a/naughty/fedora-39/5469-stratis-no-tangd
+++ b/naughty/fedora-39/5469-stratis-no-tangd
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-stratis", line *, in testBasic
+    b.wait_in_text("#dialog", "Error communicating")
+*
+testlib.Error: timeout


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit/pull/19541 , should cover [these failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19541-20231028-061240-f17dc026-fedora-39-updates-testing/log.html)