### PR TITLE
naughty: adding missing glob for pid= on Fedora-39 kdump naughty

### DIFF
--- a/naughty/fedora-39/5444-selinux-systemd-kdump-cleanup-2
+++ b/naughty/fedora-39/5444-selinux-systemd-kdump-cleanup-2
@@ -1,2 +1,2 @@
 testlib.Error: FAIL: Test completed, but found unexpected journal messages:
-*avc:  denied  { rmdir } for  comm="(sd-rmrf)" * scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0 tclass=dir permissive=0
+*avc:  denied  { rmdir } for * comm="(sd-rmrf)" * scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0 tclass=dir permissive=0


### PR DESCRIPTION
See https://cockpit-logs.us-east-1.linodeobjects.com/pull-19546-20231030-121229-9a64080b-fedora-39-updates-testing/log.html#43