### PR TITLE
naughty: handle fnmatch regex behaviour on Python 3.9

### DIFF
--- a/naughty/arch/5106-journalctl-since-until-behaviour-change-2
+++ b/naughty/arch/5106-journalctl-since-until-behaviour-change-2
@@ -1,4 +1,4 @@
 Traceback (most recent call last):
   File "*", line *, in testRebootAndTime
 *
-        })(["January 1, 2037", ["check-journal", "AFTER BOOT", ""], ["", "Reboot", ""], ["check-journal", "BEFORE BOOT", ""]])): Uncaught (in promise) Error: condition did not become true
+        *"January 1, 2037"*"check-journal"*"BEFORE BOOT"* condition did not become true

--- a/naughty/debian-testing/5106-journalctl-since-until-behaviour-change-2
+++ b/naughty/debian-testing/5106-journalctl-since-until-behaviour-change-2
@@ -1,4 +1,4 @@
 Traceback (most recent call last):
   File "*", line *, in testRebootAndTime
 *
-        })(["January 1, 2037", ["check-journal", "AFTER BOOT", ""], ["", "Reboot", ""], ["check-journal", "BEFORE BOOT", ""]])): Uncaught (in promise) Error: condition did not become true
+        *"January 1, 2037"*"check-journal"*"BEFORE BOOT"* condition did not become true

--- a/naughty/fedora-39/5106-journalctl-since-until-behaviour-change-2
+++ b/naughty/fedora-39/5106-journalctl-since-until-behaviour-change-2
@@ -1,4 +1,4 @@
 Traceback (most recent call last):
   File "*", line *, in testRebootAndTime
 *
-        })(["January 1, 2037", ["check-journal", "AFTER BOOT", ""], ["", "Reboot", ""], ["check-journal", "BEFORE BOOT", ""]])):* condition did not become true
+        *"January 1, 2037"*"check-journal"*"BEFORE BOOT"* condition did not become true


### PR DESCRIPTION
On Python 3.9 fnmatch cannot handle ["check-foo"] and gives an exception.

See https://github.com/cockpit-project/cockpit/pull/17226