### PR TITLE
weather: Show absolute test failure rates

### DIFF
--- a/tests.html
+++ b/tests.html
@@ -145,28 +145,35 @@
 
             if (test) {
                 const top10 = [];
-                const rows = db.exec(`
-                        SELECT context, COUNT(*) AS failed
+                const runs_by_context_table = db.exec(`
+                        SELECT context, COUNT(*)
+                        FROM TestRuns
+                        JOIN Tests ON Tests.run = TestRuns.id
+                        WHERE time > ${since} AND Tests.testname = '${test}' AND project LIKE '${repo}'
+                        GROUP BY context`);
+                const runs_by_context = {};
+                runs_by_context_table[0].values.forEach(row => {
+                    runs_by_context[row[0]] = row[1];
+                });
+
+                const fails_by_context = db.exec(`
+                        SELECT context, COUNT(*)
                         FROM TestRuns
                         JOIN Tests ON Tests.run = TestRuns.id
                         WHERE time > ${since} AND Tests.failed = 1 AND Tests.testname = '${test}' AND project LIKE '${repo}'
                         GROUP BY context
-                        ORDER BY COUNT(*) DESC`);
-                const failed = db.exec(`
-                        SELECT COUNT(*) AS failed
-                        FROM TestRuns
-                        JOIN Tests ON Tests.run = TestRuns.id
-                        WHERE time > ${since} AND Tests.failed = 1 AND Tests.testname = '${test}' AND project LIKE '${repo}'`)[0].values[0][0];
+                        ORDER BY COUNT(*) DESC`)[0].values;
+                let total_failures = fails_by_context.reduce((acc, row) => acc + row[1], 0);
 
-                rows[0].values.forEach(row => {
+                fails_by_context.forEach(([context, failcount]) => {
                     const urls = db.exec(`
                         SELECT DISTINCT TestRuns.url
                         FROM TestRuns JOIN Tests ON TestRuns.id = Tests.run
-                        WHERE testname = '${test}' AND TestRuns.context = '${row[0]}' AND failed = 1 AND project LIKE '${repo}'
+                        WHERE testname = '${test}' AND TestRuns.context = '${context}' AND failed = 1 AND project LIKE '${repo}'
                         ORDER BY run DESC
                         LIMIT 2`);
                     const links = urls[0].values.map(u => u[0]);
-                    top10.push([row[0], ((row[1] * 100) / failed).toFixed(2), links]);
+                    top10.push([context, ((failcount * 100) / runs_by_context[context]).toFixed(2), links]);
                 });
                 if (!top10.length)
                     top10.push([`No failures in the last ${days} days`, 0, []]);
@@ -218,7 +225,7 @@
                         FROM TestRuns
                         JOIN Tests ON Tests.run = TestRuns.id
                         WHERE time > ${since} AND Tests.testname = '${test}' AND project LIKE '${repo}'`)[0].values[0][0];
-                document.getElementById("description").innerHTML = `Showing results from ${all} tests (${failed} failed).`;
+                document.getElementById("description").innerHTML = `Showing results from ${all} test runs (${total_failures} failed).`;
             } else {
                 const prs_count = db.exec(`
                     SELECT COUNT(DISTINCT(revision))


### PR DESCRIPTION
The test detail page previously showed relative failure rates for all failures, i.e. the distribution of failures amongst the contexts. While this is useful to know in which context the failure is most likely, the number is highly misleading, though: This is *not* a "fail rate" in the sense of "which percentage of test runs on that context fail". I.e. it could be that a test fails 10% of the time, and 90% of them happen on fedora-38, and 10% on c8s; then fedora-38 should have a fail rate of 9%, and c8s 1%.

So compute the total number of runs by context first, so that we can compute a proper per-context failure rate. This maintains the relative order of "which context is the worst", but gives useful numbers how bad a test actually is.

Rename the generic `rows` variable to `fails_by_context` and use some destructuring to make the code more readable.

----

Status quo on the [deployed weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?days=7&repo=cockpit-project%2Fcockpit-machines&test=%2Ftest%2Fcheck-machines-disks+TestMachinesDisks.testAddDiskSCSI) for the current top machines flake:

![image](https://github.com/cockpit-project/bots/assets/200109/3e9c42b4-9c8c-4769-9b91-7a9a743abd40)

But this is misleading -- the test is highly broken, but not as bad as failing in 90% of all runs. It "only" fails in [6.85% of all runs](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?days=7&repo=cockpit-project%2Fcockpit-machines):

![image](https://github.com/cockpit-project/bots/assets/200109/94b6ec93-5427-49e8-adf7-d8eef3bb6530)

This is misleading on the overview page as well (not "red" enough), I'm going to send a PR for that as well.

With this PR, which I [copied to my server](https://piware.de/tmp/tests.html?repo=cockpit-project%2Fcockpit-machines&days=7&test=%2Ftest%2Fcheck-machines-disks+TestMachinesDisks.testAddDiskSCSI), it now gives more useful numbers:

![image](https://github.com/cockpit-project/bots/assets/200109/6bee8f6e-182f-4a9d-ae6e-b855d9f857c7)

So that tells me that I can expect the test to fail in about half of the runs on rhel-8-10 (see https://github.com/cockpit-project/cockpit-machines/pull/1286)