### PR TITLE
lib: add new anaconda-webui repository in the testmap

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -222,6 +222,11 @@ REPO_BRANCH_CONTEXT = {
             'fedora-rawhide-boot',
         ],
     },
+    'rhinstaller/anaconda-webui': {
+        'main': [
+            'fedora-rawhide-boot',
+        ],
+    },
 }
 
 # The OSTree variants can't build their own packages, so we build in


### PR DESCRIPTION
This will take the subdirectory of the webui out of the rhinstaller/anaconda project.
When the move finalizes we need to replace the image updates to run also against the new repository.