### PR TITLE
naughty: Add pattern for libvirt 9.9.0 snapshot revert crash

### DIFF
--- a/naughty/fedora-40/5494-libvirt-snapshot-revert-crash
+++ b/naughty/fedora-40/5494-libvirt-snapshot-revert-crash
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/check-machines-snapshots", line *, in testSnapshotRevert
+    b.wait_visible("#vm-subVmTest1-snapshot-0-current")
+*
+testlib.Error: timeout


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2247754
Known issue #5494

----

See [this](https://artifacts.dev.testing-farm.io/ed12c1f9-16bb-42dc-ab24-164ef18790bf/) or [this failure](https://artifacts.dev.testing-farm.io/39826913-575c-45cf-9ba6-82923426aaa6/), this has broken c-machine's rawhide runs since yesterday. Including bodhi gating for [yesterday's 301 release](https://bodhi.fedoraproject.org/updates/FEDORA-2023-0d6db24042)