### PR TITLE
weather: Make top 10 failures context specific

### DIFF
--- a/tests.html
+++ b/tests.html
@@ -275,8 +275,8 @@
                     createTable("t2", "Unexpected messages", ["Message", "Count", "Logs"], data);
 
                 // Get all failures sorted by descending fail rate
-                const top10 = [];
-                const rows = db.exec(`
+                const top_failures = [];
+                const result = db.exec(`
                         SELECT allruns.testname, project, failruns.context, (failruns.failed * 100.0) / COUNT(run) AS percent
                         FROM Tests AS allruns
                         JOIN TestRuns ON allruns.run = TestRuns.id
@@ -289,11 +289,21 @@
                         ) AS failruns ON allruns.testname = failruns.testname AND TestRuns.context = failruns.context
                         WHERE TestRuns.time > ${since} AND failruns.failed > 1 AND project LIKE '${repo}'
                         GROUP BY allruns.testname, failruns.context
-                        ORDER BY percent DESC
-                        LIMIT 10`);
+                        ORDER BY percent DESC`);
 
-                if (rows.length)
-                    rows[0].values.forEach(row => {
+                if (result.length) {
+                    const rows = result[0].values;
+                    // If we have more than 10 results, truncate below 10% failure rate
+                    if (rows.length > 10) {
+                        for (let i = 0; i < rows.length; i++) {
+                            if (rows[i][3] < 10) {
+                                rows.splice(i);
+                                break;
+                            }
+                        }
+                    }
+
+                    rows.forEach(row => {
                         const urls = db.exec(`
                             SELECT DISTINCT TestRuns.url
                             FROM TestRuns JOIN Tests ON TestRuns.id = Tests.run
@@ -301,12 +311,12 @@
                             ORDER BY run DESC
                             LIMIT 2`);
                         const links = urls[0].values.map(u => u[0]);
-                        top10.push([{name: normalize(row[0], row[1]), key_name: row[0], key: "test"}, row[2], row[3].toFixed(2), links]);
+                        top_failures.push([{name: normalize(row[0], row[1]), key_name: row[0], key: "test"}, row[2], row[3].toFixed(2), links]);
                     });
-                else
-                    top10.push([`No failures in the last ${days} days`, "", 0, []]);
+                } else
+                    top_failures.push([`No failures in the last ${days} days`, "", 0, []]);
 
-                createTable("t1", "Top failures", ["Test name", "Context", "Fail rate (%)", "Logs"], top10);
+                createTable("t1", "Top failures", ["Test name", "Context", "Fail rate (%)", "Logs"], top_failures);
 
                 // Show average waiting time in queue per day
                 const time_points = [];

--- a/tests.html
+++ b/tests.html
@@ -274,21 +274,21 @@
                 if (data.length > 0)
                     createTable("t2", "Unexpected messages", ["Message", "Count", "Logs"], data);
 
-                // Get all failures sorted by number of occurrences
+                // Get all failures sorted by descending fail rate
                 const top10 = [];
                 const rows = db.exec(`
-                        SELECT t1.testname, TestRuns.project, (t2.failed * 100.0) / COUNT(run) AS percent
-                        FROM Tests AS t1
-                        JOIN TestRuns ON t1.run = TestRuns.id
+                        SELECT allruns.testname, project, failruns.context, (failruns.failed * 100.0) / COUNT(run) AS percent
+                        FROM Tests AS allruns
+                        JOIN TestRuns ON allruns.run = TestRuns.id
                         JOIN (
-                            SELECT testname, COUNT(run) as failed
-                            FROM Tests
-                            JOIN TestRuns ON Tests.run = TestRuns.id
-                            WHERE TestRuns.time > ${since} AND Tests.failed = 1 AND project LIKE '${repo}'
-                            GROUP BY testname
-                        ) AS t2 ON t1.testname = t2.testname
-                        WHERE TestRuns.time > ${since} AND t2.failed > 1 AND project LIKE '${repo}'
-                        GROUP BY t1.testname
+                                SELECT testname, context, COUNT(run) as failed
+                                FROM Tests
+                                JOIN TestRuns ON Tests.run = TestRuns.id
+                                WHERE TestRuns.time > ${since} AND Tests.failed = 1 AND project LIKE '${repo}'
+                                GROUP BY testname, context
+                        ) AS failruns ON allruns.testname = failruns.testname AND TestRuns.context = failruns.context
+                        WHERE TestRuns.time > ${since} AND failruns.failed > 1 AND project LIKE '${repo}'
+                        GROUP BY allruns.testname, failruns.context
                         ORDER BY percent DESC
                         LIMIT 10`);
 
@@ -297,16 +297,16 @@
                         const urls = db.exec(`
                             SELECT DISTINCT TestRuns.url
                             FROM TestRuns JOIN Tests ON TestRuns.id = Tests.run
-                            WHERE testname = '${row[0]}' AND failed = 1 AND project LIKE '${repo}'
+                            WHERE testname = '${row[0]}' AND failed = 1 AND project LIKE '${repo}' AND context = '${row[2]}'
                             ORDER BY run DESC
                             LIMIT 2`);
                         const links = urls[0].values.map(u => u[0]);
-                        top10.push([{name: normalize(row[0], row[1]), key_name: row[0], key: "test"}, row[2].toFixed(2), links]);
+                        top10.push([{name: normalize(row[0], row[1]), key_name: row[0], key: "test"}, row[2], row[3].toFixed(2), links]);
                     });
                 else
-                    top10.push([`No failures in the last ${days} days`, 0, []]);
+                    top10.push([`No failures in the last ${days} days`, "", 0, []]);
 
-                createTable("t1", "Top failures", ["Test name", "Fail rate (%)", "Logs"], top10);
+                createTable("t1", "Top failures", ["Test name", "Context", "Fail rate (%)", "Logs"], top10);
 
                 // Show average waiting time in queue per day
                 const time_points = [];

--- a/tests.html
+++ b/tests.html
@@ -275,8 +275,6 @@
                     createTable("t2", "Unexpected messages", ["Message", "Count", "Logs"], data);
 
                 // Get all failures sorted by number of occurrences
-                // Ignore selenium tests as they have a bug where skipped tests show up as failures.
-                // They are also deprecated and not very flaky, so not interesting to show.
                 const top10 = [];
                 const rows = db.exec(`
                         SELECT t1.testname, TestRuns.project, (t2.failed * 100.0) / COUNT(run) AS percent
@@ -286,7 +284,7 @@
                             SELECT testname, COUNT(run) as failed
                             FROM Tests
                             JOIN TestRuns ON Tests.run = TestRuns.id
-                            WHERE TestRuns.time > ${since} AND Tests.failed = 1 AND project LIKE '${repo}' AND testname NOT LIKE '%selenium%'
+                            WHERE TestRuns.time > ${since} AND Tests.failed = 1 AND project LIKE '${repo}'
                             GROUP BY testname
                         ) AS t2 ON t1.testname = t2.testname
                         WHERE TestRuns.time > ${since} AND t2.failed > 1 AND project LIKE '${repo}'


### PR DESCRIPTION
Many (or even most) flakes and failures are very specific to their
OS/context. These previously got drowned by averaging over all contexts:
e.g. a test that failed on a single OS 70% of the time ended up with a
global failure rate of < 7%, and thus would formally be within our SLO
even though it would still break most test runs, and never survive a "3x
affected" run.

Change the query and table to track the top ten failures separately for
each context, which is a lot more useful to identify current problems.

In the other direction, results were inflated by test runs which break
due to regressions in Fedora updates-testing -- these tend to get very
high failure rates quickly. We may decide to just hide them, but at
least it is now very clear where they actually fail.

----

[current main weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-machines&days=7) looks like all would be hunky-dory for machines:

![image](https://github.com/cockpit-project/bots/assets/200109/51f4b398-4325-4a55-b1d5-d6f214c36e16)

But when you e.g. drill down to [testAddDiskSCSI](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-machines&days=7&test=%2Ftest%2Fcheck-machines-disks+TestMachinesDisks.testAddDiskSCSI), it's clear that on RHEL 8 it is on fire:

![image](https://github.com/cockpit-project/bots/assets/200109/02c7f6a8-9ff7-4515-9b09-801b705865a2)

(Note: this very bug was fixed yesterday, so it'll go down from now on)

I deployed this PR to my server, and in [that overview](https://piware.de/tmp/tests.html?repo=cockpit-project%2Fcockpit-machines&days=7) it is now much more useful and realistic:

![image](https://github.com/cockpit-project/bots/assets/200109/fb93a534-bba9-48c9-aea6-dd49d965d65c)

I realize that this duplicates the test detail view somewhat, but due to the "drowning in average", many hot problems don't even appear on this table.