### PR TITLE
testmap: Run cockpit scenario in centos-7 refreshes

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -240,7 +240,7 @@ OSTREE_BUILD_IMAGE = {
 IMAGE_REFRESH_TRIGGERS = {
     # some tests run against centos-7's cockpit-ws for backwards compat testing
     "centos-7": [
-        TEST_OS_DEFAULT + "@cockpit-project/cockpit",
+        f"{TEST_OS_DEFAULT}/expensive@cockpit-project/cockpit",
     ],
     "openshift": [
         "rhel-7-9@cockpit-project/cockpit/rhel-7.9",


### PR DESCRIPTION
The only scenario where centos-7 gets provisioned in cockpit is "expensive" (by definition).

This makes tracking flakes by context more regular, as flakes in this test run would previously appear as a "fedora-N" context in image refreshes, but as "fedora-N/expensive" in cockpit PRs.

---

See PR #5496 for details.