### PR TITLE
Revert "naughty: Add pattern for Fedora podman-next image push regression"

### DIFF
--- a/naughty/fedora-39/5515-podman-push-image-change
+++ b/naughty/fedora-39/5515-podman-push-image-change
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-  File "test/check-application", line *, in testDownloadImage
-    dialog1.deleteImage(True, another=IMG_BUSYBOX_LATEST)
-*
-testlib.Error: timeout
-wait_js_cond(ph_is_present(".pf-v5-c-check__input[aria-label='localhost/test-busybox:latest']:not([disabled]):not([aria-disabled=true])")): Uncaught (in promise) Error: condition did not become true

--- a/naughty/fedora-40/5515-podman-push-image-change
+++ b/naughty/fedora-40/5515-podman-push-image-change
@@ -1,6 +1,0 @@
-Traceback (most recent call last):
-  File "test/check-application", line *, in testDownloadImage
-    dialog1.deleteImage(True, another=IMG_BUSYBOX_LATEST)
-*
-testlib.Error: timeout
-wait_js_cond(ph_is_present(".pf-v5-c-check__input[aria-label='localhost/test-busybox:latest']:not([disabled]):not([aria-disabled=true])")): Uncaught (in promise) Error: condition did not become true


### PR DESCRIPTION
This was handled more properly in https://github.com/cockpit-project/cockpit-podman/pull/1477

This reverts commit 642433233e4d077f82a1c4638181c2ecc3d72143.

Fixes #5515