### PR TITLE
naughty: Bring back #4318

### DIFF
--- a/naughty/rhel-8/4318-insights-client-gpg-signull
+++ b/naughty/rhel-8/4318-insights-client-gpg-signull
@@ -1,0 +1,1 @@
+audit: type=1400 audit*: avc:  denied  { signull } for * comm="gpg" scontext=system_u:system_r:gpg_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:* tclass=process permissive=0


### PR DESCRIPTION
We still occasionally observe this on RHEL 8.10.

This reverts commit 4a0cc12b93352da630905bbdfc9edc711d63ec4c.

----

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-19585-20231108-091335-a3cbfcf3-rhel-8-10-other/log.html#102 . I reopened the downstream report https://issues.redhat.com/browse/RHELPLAN-146583 and the known issue #4318 