### PR TITLE
testmap: reflect on the testmap the anaconda repository split

### DIFF
--- a/images/scripts/lib/build-deps.sh
+++ b/images/scripts/lib/build-deps.sh
@@ -25,17 +25,6 @@ esac
 
 echo "$spec" | rpmspec -D "$OS_VER" -D 'version 0' -D 'enable_old_bridge 0' --buildrequires --query /dev/stdin | sed 's/.*/"&"/' | tr '\n' ' '
 
-# We build anaconda rpms
-case "$OS_VER" in
-    fedora*) # let's try if Anaconda have branch for the given fedora, if not, use master (rawhide)
-        SPEC=$($GET "https://raw.githubusercontent.com/rhinstaller/anaconda/fedora-${OS_VER#fedora }/anaconda.spec.in") || \
-            SPEC=$($GET "https://raw.githubusercontent.com/rhinstaller/anaconda/master/anaconda.spec.in")
-        echo "$SPEC" | \
-            sed 's/@PACKAGE.*@/0/' | rpmspec --buildrequires --query /dev/stdin | \
-            sed 's/.*/"&"/' | tr '\n' ' '
-    ;;
-esac
-
 # some extra build dependencies:
 # - libappstream-glib for validating appstream metadata in starter-kit and derivatives
 # - rpmlint for validating built RPMs

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -217,11 +217,6 @@ REPO_BRANCH_CONTEXT = {
             'fedora-39',
         ]
     },
-    'rhinstaller/anaconda': {
-        'master': [
-            'fedora-rawhide-boot',
-        ],
-    },
     'rhinstaller/anaconda-webui': {
         'main': [
             'fedora-rawhide-boot',
@@ -256,11 +251,11 @@ IMAGE_REFRESH_TRIGGERS = {
     ],
     # Anaconda builds in fedora-rawhide and runs tests in fedora-rawhide-boot
     "fedora-rawhide": [
-        "fedora-rawhide-boot@rhinstaller/anaconda"
+        "fedora-rawhide-boot@rhinstaller/anaconda-webui"
     ],
     # Anaconda payload updates can affect tests
     "fedora-rawhide-anaconda-payload": [
-        "fedora-rawhide-boot@rhinstaller/anaconda"
+        "fedora-rawhide-boot@rhinstaller/anaconda-webui"
     ],
 }
 


### PR DESCRIPTION
Also drop anaconda conditional for previous fedora versions in the build-deps.sh script. The anaconda-webui will be maintaining one branch for all active fedora versions.