### PR TITLE
prometheus-stats: Make test failures context specific

### DIFF
--- a/prometheus-stats
+++ b/prometheus-stats
@@ -121,18 +121,18 @@ test_run_seconds_count {test_runs}
 
     # top failures of last 7 days
     top_failures = cursor.execute("""
-            SELECT TestRuns.project, t1.testname, (t2.failed * 100.0) / COUNT(run) AS percent
-            FROM Tests AS t1
-            JOIN TestRuns ON t1.run = TestRuns.id
+            SELECT project, allruns.testname, failruns.context, (failruns.failed * 100.0) / COUNT(run) AS percent
+            FROM Tests AS allruns
+            JOIN TestRuns ON allruns.run = TestRuns.id
             JOIN (
-                SELECT testname, COUNT(run) as failed
-                FROM Tests
-                JOIN TestRuns ON Tests.run = TestRuns.id
-                WHERE TestRuns.time > strftime('%s', 'now', '-7 days') AND Tests.failed = 1
-                GROUP BY testname
-            ) AS t2 ON t1.testname = t2.testname
-            WHERE TestRuns.time > strftime('%s', 'now', '-7 days') AND t2.failed > 1
-            GROUP BY t1.testname
+                    SELECT testname, context, COUNT(run) as failed
+                    FROM Tests
+                    JOIN TestRuns ON Tests.run = TestRuns.id
+                    WHERE TestRuns.time > strftime('%s', 'now', '-7 days') AND Tests.failed = 1
+                    GROUP BY testname, context
+            ) AS failruns ON allruns.testname = failruns.testname AND TestRuns.context = failruns.context
+            WHERE TestRuns.time > strftime('%s', 'now', '-7 days') AND failruns.failed > 1
+            GROUP BY allruns.testname, failruns.context
             ORDER BY percent DESC
             LIMIT 50""").fetchall()
 
@@ -140,9 +140,9 @@ test_run_seconds_count {test_runs}
 # HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
 # TYPE top_failures_pct gauge
 """
-    for (project, test, fail_pct) in top_failures:
+    for (project, test, context, fail_pct) in top_failures:
         if fail_pct > 10:
-            output += f'top_failures_pct{{project="{project}",test="{test}"}} {fail_pct}\n'
+            output += f'top_failures_pct{{project="{project}",test="{test}",context="{context}"}} {fail_pct}\n'
 
     # PR retries
     pr_retries = cursor.execute("""


### PR DESCRIPTION
Same change as commit ee90db7fcc489d0f did to the weather report. This will allow us to fix our Grafana to give more realistic SLIs and error budget.

---

Output with current [test-results.db](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/test-results.db):
```
 HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
# TYPE top_failures_pct gauge
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-reauthorize TestReauthorize.testSudo",context="fedora-coreos/other"} 47.05882352941177
top_failures_pct{project="cockpit-project/cockpit-machines",test="/test/check-machines-hostdevs TestMachinesHostDevs.testHostDevAddSingleDevice",context="arch"} 36.8421052631579
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-sosreport TestSOS.testBasic",context="fedora-38/other"} 33.333333333333336
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-reauthorize TestReauthorize.testSudo",context="rhel4edge/other"} 30.434782608695652
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-realms TestIPA.testClientCertAuthentication",context="rhel-9-4/networking"} 30.434782608695652
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-packagekit TestUpdates.testTracer",context="fedora-39/firefox-expensive"} 30.0
top_failures_pct{project="cockpit-project/cockpit-certificates",test="/test/check-application TestApplication.testRemoveCert",context="fedora-38"} 28.571428571428573
top_failures_pct{project="cockpit-project/cockpit-machines",test="/test/check-machines-hostdevs TestMachinesHostDevs.testHostDevAddSessionConnection",context="arch"} 27.77777777777778
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-realms TestIPA.testClientCertAuthentication",context="fedora-39/networking"} 21.05263157894737
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-realms TestIPA.testClientCertAuthentication",context="ubuntu-2204/networking"} 21.05263157894737
top_failures_pct{project="cockpit-project/cockpit-machines",test="/test/check-machines-nics TestMachinesNICs.testNICDelete",context="rhel-9-4"} 20.0
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-users TestAccounts.testUserPasswords",context="rhel-9-4/other"} 20.0
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-info TestSystemInfo.testCPUSecurityMitigationsEnable",context="fedora-coreos/other"} 18.51851851851852
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-realms TestIPA.testQualifiedUsers",context="fedora-39/firefox-networking"} 17.647058823529413
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-used TestStorageUsed.testUsed",context="fedora-39/firefox-storage"} 17.391304347826086
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-vdo TestStorageVDO.testVdo",context="centos-8-stream/storage"} 16.666666666666668
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-metrics TestMetricsPackages.testBasic",context="ubuntu-stable/other"} 15.789473684210526
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-mdraid TestStorageMdRaid.testNotRemovingDisks",context="centos-8-stream/storage"} 15.789473684210526
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-mdraid TestStorageMdRaid.testNotRemovingDisks",context="fedora-39/storage"} 15.789473684210526
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-mdraid TestStorageMdRaid.testRaid",context="rhel-9-4/storage"} 15.789473684210526
top_failures_pct{project="cockpit-project/cockpit-machines",test="/test/check-machines-lifecycle TestMachinesLifecycle.testBasic",context="fedora-39/devel"} 15.384615384615385
top_failures_pct{project="cockpit-project/cockpit-machines",test="/test/check-machines-nics TestMachinesNICs.testVmNICs",context="rhel-9-4"} 15.384615384615385
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-stratis TestStorageStratis.testCli",context="rhel-8-10-distropkg/storage"} 14.285714285714286
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-used TestStorageUsed.testUsedAsPV",context="rhel-8-10-distropkg/storage"} 12.5
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-metrics TestMetricsPackages.testBasic",context="ubuntu-2204/other"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-networkmanager-basic TestNetworkingBasic.testNoService",context="debian-testing/networking"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-static-login TestLogin.testUnsupportedBrowser",context="fedora-39/firefox-other"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-lvm2 TestStorageLvm2.testSnapshots",context="ubuntu-stable/storage"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-storage-mdraid TestStorageMdRaid.testNotRemovingDisks",context="fedora-38/storage"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-info TestSystemInfoTime.testTimeServersTimesyncd",context="fedora-39/other"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-journal TestJournal.testBasic",context="debian-stable/other"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-journal TestJournal.testBasic",context="debian-testing/other"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-realms TestIPA.testQualifiedUsers",context="debian-stable/networking"} 11.764705882352942
top_failures_pct{project="cockpit-project/cockpit",test="test/verify/check-system-services TestServices.testLogs",context="debian-stable/other"} 10.526315789473685
```