### PR TITLE
image-prune: Fix prune URL

### DIFF
--- a/image-prune
+++ b/image-prune
@@ -177,7 +177,7 @@ class S3ImageStore(ImageCache):
 
     def delete_file(self, filename):
         try:
-            with s3.urlopen(self.url._replace(path='/' + filename), method='DELETE'):
+            with s3.urlopen(self.url._replace(path=os.path.join(self.url.path, filename)), method='DELETE'):
                 pass
         except urllib.error.HTTPError as e:
             # 404 → already gone? *shrug* eventual consistency or parallel image-prune run


### PR DESCRIPTION
Don't assume that the S3 objects live in the root path, but keep the path given by the store S3 URL. The path is `/images/` for our minio store on rhos-01-1, and trying to delete an image in / will cause a HTTP error 400.

Fixes https://github.com/cockpit-project/cockpituous/issues/563

---

 - [x] I have a test for this: https://github.com/cockpit-project/cockpituous/pull/564
 - [x] Test this with our actual Linode S3 store
