### PR TITLE
testmap: Retire cockpit rhel-9.3 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -59,9 +59,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-7-9',
             'centos-7',
         ],
-        'rhel-9.3': [
-            *contexts('rhel-9-3', COCKPIT_SCENARIOS),
-        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-rawhide',


### PR DESCRIPTION
This was a vehicle to deliver some z-stream updates, but it served its purpose now.