### PR TITLE
naughty: Add #5494 alternate pattern to arch

### DIFF
--- a/naughty/arch/5494-libvirt-snapshot-revert-crash-2
+++ b/naughty/arch/5494-libvirt-snapshot-revert-crash-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/check-machines-snapshots", line *, in testSnapshotRevert
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#vm-subVmTest1-snapshot-1-current")): condition did not become true


### PR DESCRIPTION
See https://cockpit-logs.us-east-1.linodeobjects.com/pull-1317-20231120-134315-e2974bce-arch/log.html#68 . The -2 variant so far only exists on fedora-40 and debian-testing.