### PR TITLE
Add new rhel-9-4-boot images for enabling anaconda to test against RHEL

### DIFF
--- a/images/scripts/rhel-9-4-boot.bootstrap
+++ b/images/scripts/rhel-9-4-boot.bootstrap
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eux
+
+OUTPUT="$1"
+
+# Read the boot.iso file name from the MD5SUM file
+MD5SUM=http://download.devel.redhat.com/nightly/rhel-9/RHEL-9/latest-RHEL-9/compose/BaseOS/x86_64/iso/MD5SUM
+BOOTISO=$(curl -L --silent $MD5SUM | grep -Eo RHEL.*boot.iso | head -1)
+URL=http://download.devel.redhat.com/nightly/rhel-9/RHEL-9/latest-RHEL-9/compose/BaseOS/x86_64/iso/$BOOTISO
+
+curl -L "$URL" -o "$OUTPUT"

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -219,6 +219,9 @@ REPO_BRANCH_CONTEXT = {
         'main': [
             'fedora-rawhide-boot',
         ],
+        '_manual': [
+            'rhel-9-4-boot',
+        ],
     },
 }
 


### PR DESCRIPTION
Image refresh for rhel-9-4-boot
 * [x] image-refresh rhel-9-4-boot