### PR TITLE
testmap: enable devel scenario for pull requests

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -77,6 +77,7 @@ REPO_BRANCH_CONTEXT = {
     'cockpit-project/cockpit-ostree': {
         'main': [
             'fedora-coreos',
+            'fedora-coreos/devel',
             'rhel4edge',
         ],
     },


### PR DESCRIPTION
This gives us coverage insights by default.

* [x] This test PR goes green https://github.com/cockpit-project/cockpit-ostree/pull/459