### PR TITLE
tests-invoke: Fix log URL

### DIFF
--- a/task/test-tests-scan
+++ b/task/test-tests-scan
@@ -220,10 +220,9 @@ class TestTestsScan(unittest.TestCase):
         self.assertEqual(output.strip(), expected_output)
         self.assertIsNone(stderr)
 
-    def test_tests_invoke(self):
+    def do_test_tests_invoke(self, attachments_url, expected_logs_url):
         repo = "cockpit-project/cockpit"
         args = ["--revision", self.revision, "--repo", repo]
-        attachments_url = "https://example.org/dir"
         script = os.path.join(BOTS_DIR, "tests-invoke")
         with tempfile.TemporaryDirectory() as tempdir:
             testdir = f"{tempdir}/.cockpit-ci"
@@ -245,9 +244,15 @@ class TestTestsScan(unittest.TestCase):
             self.assertEqual(len(issues), 1)
             self.assertEqual(issues[0]['title'], "Nightly tests did not succeed on fedora-38")
             self.assertEqual(issues[0]['body'],
-                             f"Tests failed on {self.revision}, [logs]({attachments_url}/log.html)")
+                             f"Tests failed on {self.revision}, [logs]({expected_logs_url})")
             self.assertEqual(issues[0]['labels'], ["nightly"])
             self.assertIsNone(stderr)
+
+    def test_tests_invoke_noslash(self):
+        self.do_test_tests_invoke("https://example.org/dir", "https://example.org/dir/log.html")
+
+    def test_tests_invoke_slash(self):
+        self.do_test_tests_invoke("https://example.org/dir/", "https://example.org/dir/log.html")
 
     def disabled_test_tests_invoke_no_issue(self):
         repo = "cockpit-project/cockpit"

--- a/task/test-tests-scan
+++ b/task/test-tests-scan
@@ -122,8 +122,8 @@ class TestTestsScan(unittest.TestCase):
     def expected_human_output(self, pull_number=None):
         if pull_number is None:
             pull_number = self.pull_number
-        return f"pull-{pull_number}      {self.context}            {self.revision}" \
-               + f"     5.99999  ({self.repo}) [bots@main]"
+        return (f"pull-{pull_number}      {self.context}            {self.revision}"
+                f"     5.99999  ({self.repo}) [bots@main]")
 
     def test_pull_number(self):
         args = ["--dry", "--repo", self.repo, "--pull-number", self.pull_number,

--- a/tests-invoke
+++ b/tests-invoke
@@ -104,7 +104,7 @@ def main():
             body = f"Tests failed on {opts.revision}"
 
             if logs_url:
-                body += f", [logs]({logs_url}/log.html)"
+                body += f", [logs]({os.path.join(logs_url, 'log.html')})"
             if test_scenario != "":
                 title += f"/{test_scenario}"
 


### PR DESCRIPTION
If `$TEST_ATTACHMENTS_URL` ends with a slash (which is the case for
s3-streamer), the generated URL had two slashes, which doesn't work with
S3. Use `os.path.join()` to intelligently join them.

----

See e.g. https://github.com/cockpit-project/cockpit/issues/19661 or the other recent nightly failures, they have a broken log URL.