### PR TITLE
naughty: Add another pattern for #5444

### DIFF
--- a/naughty/fedora-39/5444-selinux-systemd-kdump-cleanup-4
+++ b/naughty/fedora-39/5444-selinux-systemd-kdump-cleanup-4
@@ -1,0 +1,2 @@
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+*avc:  denied  { unlink } for * comm="(sd-rmrf)" * scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0

--- a/naughty/fedora-40/5444-selinux-systemd-kdump-cleanup-4
+++ b/naughty/fedora-40/5444-selinux-systemd-kdump-cleanup-4
@@ -1,0 +1,2 @@
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+*avc:  denied  { unlink } for * comm="(sd-rmrf)" * scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:kdumpctl_tmp_t:s0


### PR DESCRIPTION
With latest systemd this can now also happen straight from pid 1 instead of systemd-tmpfile.

---

This started happening recently, e.g. [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18614-20231130-141040-88c30181-fedora-39-expensive/log.html) or [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18614-20231130-174158-a87c3dbc-fedora-39-devel/log.html).