### PR TITLE
machine_core: Drop obsolete SELinux message from fedora-coreos

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -196,10 +196,6 @@ class Machine(ssh_connection.SSHConnection):
             # Default PAM configuration logs motd for cockpit-session
             allowed.append(".*cockpit-session: pam: Web console: .*")
 
-        if self.image in ["fedora-coreos"]:
-            # https://bugzilla.redhat.com/show_bug.cgi?id=2122888
-            allowed.append('audit.*denied  { sys_admin } .* comm="mv" .*NetworkManager_dispatcher_console_t.*')
-
         if self.image in ["fedora-rawhide"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=2250930
             allowed.append('audit.*denied  { map_read map_write } for .* tclass=bpf.*')


### PR DESCRIPTION
That only applied to Fedora 37.