### PR TITLE
images: Drop disabling of auditd on RHEL/CentOS

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -376,14 +376,6 @@ sed -i s/DefaultLimitCORE=.*/DefaultLimitCORE=infinity:infinity/ /etc/systemd/sy
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 
-# Audit events to the journal
-if [ ! -f /root/.keep-audit ]; then
-    rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
-    rm -rf /var/log/audit/
-else
-    echo "Keeping audit enabled as /root/.keep-audit exists"
-fi
-
 # clean up old kernels after upgrading
 dnf repoquery --installonly --latest-limit=-1 -q | xargs --no-run-if-empty rpm -e --verbose
 


### PR DESCRIPTION
Like commit fbe38679 did for Fedora. Drop the `.keep-audit` stamp handling, we haven't used that for many years.

 - [ ] image-refresh rhel-9-4
 - [ ] image-refresh rhel-8-10
 - [ ] image-refresh centos-8-stream