### PR TITLE
naughty: #5494 affects RHEL 9 now

### DIFF
--- a/naughty/rhel-9/5494-libvirt-snapshot-revert-crash
+++ b/naughty/rhel-9/5494-libvirt-snapshot-revert-crash
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/check-machines-snapshots", line *, in testSnapshotRevert
+    b.wait_visible("#vm-subVmTest1-snapshot-0-current")
+*
+testlib.Error: timeout

--- a/naughty/rhel-9/5494-libvirt-snapshot-revert-crash-2
+++ b/naughty/rhel-9/5494-libvirt-snapshot-revert-crash-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/check-machines-snapshots", line *, in testSnapshotRevert
+    b.wait_not_present("#vm-subVmTest1-snapshot-1-current")
+*
+testlib.Error: timeout


### PR DESCRIPTION
Reported to https://issues.redhat.com/browse/RHEL-18439

---

See e.g. https://artifacts.dev.testing-farm.io/4ed332de-dd62-4a49-9375-f863b0bfd4eb/ this happens on every c-machine PR now.