### PR TITLE
images: Add grubby to anaconda-payload

### DIFF
--- a/create-anaconda-payload
+++ b/create-anaconda-payload
@@ -44,6 +44,7 @@ grub2-pc-modules
 grub2-tools-efi
 grub2-tools-extra
 grub2-efi-x64
+grubby
 shim-x64
 cryptsetup
 btrfs-progs

--- a/images/fedora-rawhide-anaconda-payload
+++ b/images/fedora-rawhide-anaconda-payload
@@ -1,1 +1,1 @@
-fedora-rawhide-anaconda-payload-b82e7eddd32b4faa15ddb5701ab3f3ebcbb05ea64f2108f1cb0f9d1e88d5b213.tar.gz
+fedora-rawhide-anaconda-payload-11cdf32d0ca69e0000fd8f17dfff3f641d70a6300db2c29ddb631d8b9024bda3.tar.gz


### PR DESCRIPTION
It is installed by default in Fedora Workstation and is the recommended way of working with grub.
It is also needed by some Anaconda WebUI tests: [anaconda-webui 64]( https://github.com/rhinstaller/anaconda-webui/pull/64)

 * [x] image-refresh fedora-rawhide-anaconda-payload