### PR TITLE
Revert "testmap: Retire cockpit rhel-9.3 branch"

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -60,6 +60,9 @@ REPO_BRANCH_CONTEXT = {
             'rhel-7-9',
             'centos-7',
         ],
+        'rhel-9.3': [
+            *contexts('rhel-9-3', COCKPIT_SCENARIOS),
+        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-rawhide',

--- a/naughty/rhel-9/4796-stratis-runs-clevis-too-early-old
+++ b/naughty/rhel-9/4796-stratis-runs-clevis-too-early-old
@@ -1,0 +1,2 @@
+  File "test/verify/check-storage-stratis", line *, in testBasic
+    self.wait_mounted(1, 1)  # should be mounted after boot


### PR DESCRIPTION
We have some more RHEL 9.3 z-stream updates to do.

This reverts commit 1dce72d793af3659bc49dd1165b567fefdb3c9de.

---

Not running tests here. The branch needs some test adjustments, this needs to land together with https://github.com/cockpit-project/cockpit/pull/19734