### PR TITLE
testmap: Run firefox tests for validating services image

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -239,6 +239,7 @@ IMAGE_REFRESH_TRIGGERS = {
     ],
     "services": [
         *contexts(TEST_OS_DEFAULT, COCKPIT_SCENARIOS, repo='cockpit-project/cockpit'),
+        *contexts(TEST_OS_DEFAULT, ['firefox'], COCKPIT_SCENARIOS, repo='cockpit-project/cockpit'),
         *contexts('ubuntu-stable', COCKPIT_SCENARIOS, repo='cockpit-project/cockpit'),
         *contexts('debian-stable', COCKPIT_SCENARIOS, repo='cockpit-project/cockpit'),
         *contexts('rhel-9-4', COCKPIT_SCENARIOS, repo='cockpit-project/cockpit'),


### PR DESCRIPTION
As we have seen in https://github.com/cockpit-project/cockpit/pull/19794 there can be Firefox specific failures for a services image refresh. Thus run the Fedora tests with Firefox to cover these.