### PR TITLE
testmap: Retire cockpit rhel-9.3 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -60,9 +60,6 @@ REPO_BRANCH_CONTEXT = {
             'rhel-7-9',
             'centos-7',
         ],
-        'rhel-9.3': [
-            *contexts('rhel-9-3', COCKPIT_SCENARIOS),
-        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-rawhide',


### PR DESCRIPTION
We have not received any further regression reports in RHEL 9.3, and can now stop maintaining this branch.