### PR TITLE
testmap: enable debian-testing for navigator

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -122,6 +122,7 @@ REPO_BRANCH_CONTEXT = {
     },
     'cockpit-project/cockpit-navigator': {
         'main': [
+            'debian-testing',
             'fedora-38',
             'fedora-39',
             'fedora-rawhide',
@@ -130,7 +131,6 @@ REPO_BRANCH_CONTEXT = {
             TEST_OS_DEFAULT,
             'arch',
             'rhel-9-4',
-            'debian-testing',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
Test on debian-testing in pull requests now that we have packaging for it.