### PR TITLE
naughty: Add pattern for rawhide's sssd losing files provider

### DIFF
--- a/naughty/fedora-40/5838-sssd-files-provider
+++ b/naughty/fedora-40/5838-sssd-files-provider
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-static-login", line *, in testClientCertAuthentication
+    m.execute("systemctl restart sssd")
+*
+subprocess.CalledProcessError: * returned non-zero exit status 1.


### PR DESCRIPTION
The purported "proxy" provider replacement does not work, so we don't know how to adjust our tests.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2260445 Known issue #5838

----

This will unbreak revdeps gating in e.g. https://github.com/fedora-selinux/selinux-policy/pull/2009 for the time being.