### PR TITLE
Disable automatic trigger anaconda webui test suite against ELN

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -216,8 +216,10 @@ REPO_BRANCH_CONTEXT = {
     'rhinstaller/anaconda-webui': {
         'main': [
             'fedora-rawhide-boot',
-            'fedora-eln-boot',
         ],
+        '_manual': [
+            'fedora-eln-boot',
+        ]
     },
 }
 


### PR DESCRIPTION
These tests are heavily flaky lately [1] and there is not capacity to debug these.

[1] https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=rhinstaller%2Fanaconda-webui&days=5