### PR TITLE
naughty: RAID repair kernel hang now affects Fedora

### DIFF
--- a/naughty/fedora-38/5874-lvconvert-hangs-in-kernel
+++ b/naughty/fedora-38/5874-lvconvert-hangs-in-kernel
@@ -1,0 +1,6 @@
+[<0>] md_stop+*
+*
+[<0>] dev_suspend+*
+*
+  File "check-storage-lvm2", line *, in testRaidRepair
+    self.dialog_wait_close()  # wait for repair to finish

--- a/naughty/fedora-39/5874-lvconvert-hangs-in-kernel
+++ b/naughty/fedora-39/5874-lvconvert-hangs-in-kernel
@@ -1,0 +1,6 @@
+[<0>] md_stop+*
+*
+[<0>] dev_suspend+*
+*
+  File "check-storage-lvm2", line *, in testRaidRepair
+    self.dialog_wait_close()  # wait for repair to finish

--- a/naughty/fedora-40/5874-lvconvert-hangs-in-kernel
+++ b/naughty/fedora-40/5874-lvconvert-hangs-in-kernel
@@ -1,0 +1,6 @@
+[<0>] md_stop+*
+*
+[<0>] dev_suspend+*
+*
+  File "check-storage-lvm2", line *, in testRaidRepair
+    self.dialog_wait_close()  # wait for repair to finish


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit/issues/19967

---

Tested locally against the failure output in https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-20240208-012335-d2a0a971-fedora-39-daily/log.html

I had to modify the pattern slightly as on Fedora the "[dm-mod]" prefix doesn't appear.