### PR TITLE
testmap: Introduce cockpit/rhel-8 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -56,6 +56,12 @@ REPO_BRANCH_CONTEXT = {
             *contexts('rhel-9-4', COCKPIT_SCENARIOS),
             *contexts('rhel4edge', COCKPIT_SCENARIOS),
         ],
+        'rhel-8': [
+            *contexts('rhel-8-10', COCKPIT_SCENARIOS),
+            # all skipped
+            *contexts('rhel-8-10-distropkg', COCKPIT_SCENARIOS - {'networking'}),
+            *contexts('centos-8-stream', COCKPIT_SCENARIOS),
+        ],
         'rhel-7.9': [
             'rhel-7-9',
             'centos-7',


### PR DESCRIPTION
Only run CentOS/RHEL 8 tests on that.

----

I just created the [rhel-8 branch](https://github.com/cockpit-project/cockpit/tree/rhel-8). I'll send a first PR to adjust packit, workflows, etc. Then we can run that testmap there.