### PR TITLE
naughty: Add pattern for SELinux ABRT failure

### DIFF
--- a/naughty/fedora-40/5905-abrt-varrun
+++ b/naughty/fedora-40/5905-abrt-varrun
@@ -1,0 +1,7 @@
+Job for abrtd.service failed because the control process exited with error code.
+*
+Traceback (most recent call last):
+  File "test/verify/check-system-journal", line *, in testAbrt*
+    m.execute("systemctl restart systemd-sysctl; systemctl start abrtd abrt-journal-core")
+*
+subprocess.CalledProcessError: Command *systemctl restart systemd-sysctl; systemctl start abrtd abrt-journal-core* returned non-zero exit status 1.


### PR DESCRIPTION
Knownn issue #5905
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2264094

---

Fixes [these two recent rawhide failures](https://artifacts.dev.testing-farm.io/d60c6277-5d0c-44ee-8d7c-c45928364fee/)