### PR TITLE
run-queue: Add loop mode and wrapper script

### DIFF
--- a/run-queue
+++ b/run-queue
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import random
+import signal
 import smtplib
 import socket
 import subprocess
@@ -142,49 +143,70 @@ Subject: cockpituous: run-queue crash on %s
 # Consume from the webhook queue and republish to the task queue via *-scan
 # Consume from the task queue (endpoint)
 def main():
-    parser = argparse.ArgumentParser(description='Bot: read a single test command from the queue and execute it')
+    parser = argparse.ArgumentParser(description='Bot: read and execute task command(s) from the queue')
     parser.add_argument('--amqp', default=distributed_queue.DEFAULT_AMQP_SERVER,
                         help='The host:port of the AMQP server to consume from (default: %(default)s)')
+    parser.add_argument('--loop', action='store_true',
+                        help='Run forever until SIGTERM; by default, run a single task or exit '
+                             'immediately if queue is empty')
     opts = parser.parse_args()
 
-    with distributed_queue.DistributedQueue(opts.amqp, ['webhook', 'rhel', 'public', 'statistics']) as q:
-        channel = q.channel
+    # gracefully handle SIGTERM -- don't interrupt a running task, but stop the main loop
+    pending_stop = False
+    if opts.loop:
+        def handle_term(_sig, _frame):
+            nonlocal pending_stop
+            logging.info("Received SIGTERM, stopping after the current task")
+            pending_stop = True
 
-        cmd, delivery_tag = consume_webhook_queue(channel, opts.amqp)
-        if not cmd and delivery_tag:
-            logging.info("Webhook message interpretation generated no command")
+        signal.signal(signal.SIGTERM, handle_term)
+
+        loop_sleep = int(os.getenv('LOOP_SLEEP', '60'))
+
+    while not pending_stop:
+        with distributed_queue.DistributedQueue(opts.amqp, ['webhook', 'rhel', 'public', 'statistics']) as q:
+            channel = q.channel
+
+            cmd, delivery_tag = consume_webhook_queue(channel, opts.amqp)
+            if not cmd and delivery_tag:
+                logging.info("Webhook message interpretation generated no command")
+                channel.basic_ack(delivery_tag)
+                continue
+
+            if not cmd:
+                cmd, delivery_tag = consume_task_queue(
+                    channel,
+                    opts.amqp,
+                    q.declare_results['public'],
+                    q.declare_results['rhel'],
+                    q.declare_results['statistics'])
+            if not cmd:
+                if opts.loop:
+                    logging.info("All queues are empty, sleeping")
+                    time.sleep(loop_sleep)
+                    continue
+                else:
+                    logging.info("All queues are empty")
+                    return 1
+
+            if isinstance(cmd, list):
+                cmd_str = ' '.join(cmd)
+            else:
+                cmd_str = cmd
+            logging.info("Consuming message with command: %s", cmd_str)
+            p = subprocess.Popen(cmd, shell=isinstance(cmd, str))
+            while p.poll() is None:
+                q.connection.process_data_events()
+                time.sleep(3)
+            if p.returncode != 0:
+                logging.error("%s failed with exit code %i", cmd_str, p.returncode)
+                mail_notification(f"""The queue command
+
+  {cmd_str}
+
+failed with exit code {p.returncode}. Please check the container logs for details.""")
+
             channel.basic_ack(delivery_tag)
-            return 0
-
-        if not cmd:
-            cmd, delivery_tag = consume_task_queue(
-                channel,
-                opts.amqp,
-                q.declare_results['public'],
-                q.declare_results['rhel'],
-                q.declare_results['statistics'])
-        if not cmd:
-            logging.info("All queues are empty")
-            return 1
-
-        if isinstance(cmd, list):
-            cmd_str = ' '.join(cmd)
-        else:
-            cmd_str = cmd
-        logging.info("Consuming message with command: %s", cmd_str)
-        p = subprocess.Popen(cmd, shell=isinstance(cmd, str))
-        while p.poll() is None:
-            q.connection.process_data_events()
-            time.sleep(3)
-        if p.returncode != 0:
-            logging.error("%s failed with exit code %i", cmd_str, p.returncode)
-            mail_notification("""The queue command
-
-  %s
-
-failed with exit code %i. Please check the container logs for details.""" % (cmd_str, p.returncode))
-
-        channel.basic_ack(delivery_tag)
 
     return 0
 

--- a/run-queue
+++ b/run-queue
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import random
+import shlex
 import signal
 import smtplib
 import socket
@@ -40,10 +41,9 @@ logging.basicConfig(level=logging.INFO)
 
 statistics_queue = os.environ.get("RUN_STATISTICS_QUEUE")
 
-# Returns a command to execute and the delivery tag needed to ack the message
-
 
 def consume_webhook_queue(channel, amqp):
+    """Return a command to execute and the delivery tag needed to ack the message"""
     # interpret payload
     # call tests-scan or issue-scan appropriately
     method_frame, header_frame, body = channel.basic_get(queue='webhook')
@@ -94,10 +94,10 @@ def consume_webhook_queue(channel, amqp):
 
     return cmd, method_frame.delivery_tag
 
-# Returns a command to execute and the delivery tag needed to ack the message
-
 
 def consume_task_queue(channel, amqp, declare_public_result, declare_rhel_result, declare_stats_result):
+    """Return (JSON body, delivery tag needed to ack the message, queue name)"""
+
     if statistics_queue and declare_stats_result.method.message_count > 0:
         # statistics queue is quick to process, always do that first
         queue = 'statistics'
@@ -113,14 +113,14 @@ def consume_task_queue(channel, amqp, declare_public_result, declare_rhel_result
                 queue = ['public', 'rhel'][random.randrange(2)]
     else:
         # nothing to do
-        return None, None
+        return None, None, None
 
     method_frame, header_frame, body = channel.basic_get(queue=queue)
     if not method_frame:
-        return None, None
+        return None, None, None
 
     body = json.loads(body)
-    return body['command'], method_frame.delivery_tag
+    return body, method_frame.delivery_tag, queue
 
 
 def mail_notification(body):
@@ -149,6 +149,9 @@ def main():
     parser.add_argument('--loop', action='store_true',
                         help='Run forever until SIGTERM; by default, run a single task or exit '
                              'immediately if queue is empty')
+    parser.add_argument('--wrapper', metavar='PATH',
+                        help='Run the task command through the given executable, with the command as '
+                             'arguments, and $TASK_QUEUE and $TASK_CONTAINER')
     opts = parser.parse_args()
 
     # gracefully handle SIGTERM -- don't interrupt a running task, but stop the main loop
@@ -174,12 +177,14 @@ def main():
                 continue
 
             if not cmd:
-                cmd, delivery_tag = consume_task_queue(
+                body, delivery_tag, queue_name = consume_task_queue(
                     channel,
                     opts.amqp,
                     q.declare_results['public'],
                     q.declare_results['rhel'],
                     q.declare_results['statistics'])
+                if body:
+                    cmd = body['command']
             if not cmd:
                 if opts.loop:
                     logging.info("All queues are empty, sleeping")
@@ -190,11 +195,20 @@ def main():
                     return 1
 
             if isinstance(cmd, list):
-                cmd_str = ' '.join(cmd)
+                cmd_str = shlex.join(cmd)
             else:
                 cmd_str = cmd
+                cmd = ['sh', '-ec', cmd_str]
+            env = os.environ.copy()
             logging.info("Consuming message with command: %s", cmd_str)
-            p = subprocess.Popen(cmd, shell=isinstance(cmd, str))
+
+            if opts.wrapper:
+                cmd.insert(0, opts.wrapper)
+                env['TASK_QUEUE'] = queue_name
+                container = body.get('container')
+                if isinstance(container, str):
+                    env['TASK_CONTAINER'] = container
+            p = subprocess.Popen(cmd, env=env)
             while p.poll() is None:
                 q.connection.process_data_events()
                 time.sleep(3)


### PR DESCRIPTION
Prerequisites for moving our CI to single-shot tasks containers.

I tested `--loop` in `tasks/run-local.sh -i`, that's obvious.

For testing `--wrapper`: In a second container shell (`podman exec -it cockpituous-tasks bash`) I queued this test command:
```
echo 'echo $((1+1)); echo this is my test' | ./publish-queue --amqp $AMQP_SERVER -q public
```

and in the primary, the "normal" direct consumption:

```
bash-5.2$ ./run-queue --amqp $AMQP_SERVER
INFO:root:Consuming message with command: echo $((1+1)); echo this is my test
2
this is my test
```

and with my wrapper:
```sh
cat <<EOF > /tmp/wrapper.sh
#!/bin/sh -ex
echo "got test from queue \$TASK_QUEUE" >> /tmp/log
echo "test command: \$@" >> /tmp/log
"\$@"
EOF
chmod 755 /tmp/wrapper.sh
```

running 
```
./run-queue --amqp $AMQP_SERVER --wrapper /tmp/wrapper.sh
```

it also works:
```
+ echo 2
2
+ echo this is my test
this is my test
```

and /tmp/log is as expected:
```
got test from queue public
test command: echo $((1+1)); echo this is my test
```