### PR TITLE
tests-scan: Expose repository name and target branch in AMQP queue job

### DIFF
--- a/tests-scan
+++ b/tests-scan
@@ -195,6 +195,8 @@ def queue_test(priority, name, number, revision, ref, context, base,
         body = {
             "command": command,
             "type": "test",
+            "repo": repo,
+            "base": base,
             "sha": revision,
             "ref": ref,
             "name": name,


### PR DESCRIPTION
`run-queue` can potentially use this to start project/branch specific test containers.