### PR TITLE
First round of preparation for job-runner

### DIFF
--- a/image-download
+++ b/image-download
@@ -135,6 +135,11 @@ def download(dest, force, state, quiet, stores):
         stores = PUBLIC_STORES
         if redhat_network():
             stores += REDHAT_STORES
+        if image_upload_store := os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE'):
+            # NB: This is an *addition* to the built-in stores, used for
+            # testing.  Compare with image-upload which *only* uploads to this
+            # store, if it's present.
+            stores += image_upload_store
 
     # The time condition for If-Modified-Since
     exists = not force and os.path.exists(dest)

--- a/image-refresh
+++ b/image-refresh
@@ -2,7 +2,7 @@
 
 # This file is part of Cockpit.
 #
-# Copyright (C) 2016 Red Hat, Inc.
+# Copyright (C) 2016-2024 Red Hat, Inc.
 #
 # Cockpit is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by
@@ -17,56 +17,62 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import os
+import shlex
 import subprocess
 import sys
-import time
-import urllib.parse
+from typing import Any
 
 import task
-from lib import s3, stores, testmap
+from lib import testmap
 from lib.constants import BOTS_DIR, SCRIPTS_DIR
 
 sys.dont_write_bytecode = True
 
 
-def run(image, verbose=False, **kwargs):
-    if not image:
-        raise RuntimeError("no image specified")
+def run(*cmd, check: bool = True, **kwargs) -> int:
+    print('\n+', shlex.join(cmd), file=sys.stderr)
+    result = subprocess.run(cmd, **kwargs, check=check)
+    return result.returncode
 
-    triggers = testmap.tests_for_image(image)
 
-    # Cleanup any extraneous disk usage elsewhere
-    subprocess.check_call([os.path.join(BOTS_DIR, "vm-reset")])
+def with_logs(n: int, log_url: str | None) -> int | tuple[int, str]:
+    if log_url:
+        return n, log_url
+    return n
 
-    # download the current image, for comparing them; that may not exist yet for newly introduced images
-    if subprocess.call([os.path.join(BOTS_DIR, "image-download"), image]) == 0:
-        old_image = os.path.realpath(os.path.join(BOTS_DIR, "images", image))
-    else:
-        old_image = None
 
-    # create the new image
-    cmd = [os.path.join(BOTS_DIR, "image-create"), "--verbose", "--capture-console", "--upload", image]
-    os.environ['VIRT_BUILDER_NO_CACHE'] = "yes"
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    log = result.stdout
-    if result.returncode == 0:
+def image_refresh(image: str, **kwargs: Any):
+    try:
+        log_url = os.environ.get('COCKPIT_CI_LOG_URL')
+
+        dry_run: bool = kwargs['dry']
+        triggers = testmap.tests_for_image(image)
+
+        # Cleanup any extraneous disk usage elsewhere
+        run('./vm-reset')
+
+        # download the current image, for comparing them; that may not exist yet for newly introduced images
+        if run('./image-download', image, check=False) == 0:
+            old_image = f'{BOTS_DIR}/images/{image}'
+        else:
+            old_image = None
+
+        # create the new image
+        run('./image-create', '--verbose', '--capture-console', image,
+            env={**os.environ, 'VIRT_BUILDER_NO_CACHE': "yes"})
+
+        # upload the new image
+        if dry_run:
+            task.would('./image-upload', '--prune-s3', image)
+        else:
+            run('./image-upload', '--prune-s3', image)
+
         # compare it to the previous one (on hosts we can ssh to)
-        if old_image and os.path.exists(os.path.join(SCRIPTS_DIR, image + '.setup')):
-            result = subprocess.run([os.path.join(BOTS_DIR, "image-diff"), old_image, image],
-                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            log += result.stdout
+        if old_image and os.path.exists(f'{SCRIPTS_DIR}/{image}.setup'):
+            run('./image-diff', old_image, image)
 
-    # upload the log to S3
-    log_url = os.path.join(
-        os.getenv('S3_LOGS_URL', stores.LOG_STORE),
-        f"image-refresh-logs/{image}-{time.strftime('%Y%m%d-%H%M%M')}.log"
-    )
-    with s3.urlopen(urllib.parse.urlparse(log_url), data=log, method="PUT",
-                    headers={"Content-Type": "text/plain", s3.ACL: s3.PUBLIC}):
-        pass
-
-    if result.returncode == 0:
         # create branch and push it
         branch = task.branch(image, f"images: Update {image} image", pathspec="images", **kwargs)
 
@@ -74,15 +80,36 @@ def run(image, verbose=False, **kwargs):
         if branch and "pull" not in kwargs:
             pull = task.pull(branch, labels=['bot', 'no-test'], run_tests=False, **kwargs)
 
-            # Trigger this pull request
-            api = task.github.GitHub()
-            head = pull["head"]["sha"]
-            for trigger in triggers:
-                api.post(f"statuses/{head}", {"state": "pending", "context": trigger,
-                                                       "description": task.github.NOT_TESTED_DIRECT})
+            if log_url:
+                # Create a synthetic status for the log URL
+                log_status = {
+                    'state': 'success',
+                    'context': f'image-refresh/{image}',
+                    'description': 'Forwarded status',
+                    'target_url': log_url
+                }
+                if dry_run:
+                    task.would('add status', json.dumps(log_status, indent=4))
+                else:
+                    task.api.post(f"statuses/{pull['head']['sha']}", log_status)
 
-    return (result.returncode, log_url)
+            # Trigger this pull request
+            if dry_run:
+                task.would('trigger tests:', json.dumps(triggers, indent=4))
+            else:
+                head = pull["head"]["sha"]
+                for trigger in triggers:
+                    task.api.post(f"statuses/{head}", {
+                        "state": "pending",
+                        "context": trigger,
+                        "description": task.github.NOT_TESTED_DIRECT
+                    })
+
+    except subprocess.CalledProcessError as exc:
+        return with_logs(exc.returncode, log_url)
+    else:
+        return with_logs(0, log_url)
 
 
 if __name__ == '__main__':
-    task.main(function=run, title="Refresh image")
+    task.main(function=image_refresh, title="Refresh image")

--- a/image-upload
+++ b/image-upload
@@ -98,6 +98,12 @@ def main():
 
         stores = args.store
         if not stores:
+            if image_upload_store := os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE'):
+                # NB: This is a *complete replacement* of the built-in stores,
+                # used for testing.  Compare with image-download which only
+                # adds this to the list, if it's present.
+                stores = [image_upload_store]
+        if not stores:
             stores = PUBLIC_STORES
             if redhat_network():
                 stores += REDHAT_STORES

--- a/issue-scan
+++ b/issue-scan
@@ -122,30 +122,25 @@ def output_task(command, issue, repo, verbose):
     number = issue.get("number", None)
     if number is None:
         return None
+    number = int(number)
 
-    context = context.strip()
-
-    cmd = "./{name} --verbose --issue='{issue}' {context}"
+    context = shlex.quote(context.strip())
 
     # `--issues-data` should also be able to receive pull_request events, in that
     # case pull_request won't be present in the object, but commits will be
     if "pull_request" in issue or "commits" in issue:
-        checkout = "./make-checkout --verbose --repo {repo} pull/{issue}/head && "
+        ref = f"pull/{number}/head"
     else:
-        checkout = "./make-checkout --verbose --repo {repo} {repo_default_branch} && "
+        ref = testmap.get_default_branch(repo)
 
     if verbose:
-        return f"issue-{int(number)} {name} {context}"
-    else:
-        if context:
-            context = shlex.quote(context)
-        return (checkout + "cd make-checkout-workdir && " + cmd + " ; cd ..").format(
-            issue=int(number),
-            name=name,
-            context=context,
-            repo=repo,
-            repo_default_branch=testmap.get_default_branch(repo),
-        )
+        return f"issue-{number} {name} {context} {ref}"
+
+    cmd = f"./make-checkout --verbose --repo {repo} {ref} && cd make-checkout-workdir && "
+    cmd += f"./{name} --verbose --issue={number} {context}; "
+    cmd += "cd .."
+
+    return cmd
 
 
 def queue_task(channel, result):

--- a/issue-scan
+++ b/issue-scan
@@ -26,10 +26,6 @@ import sys
 from lib import ALLOWLIST, testmap
 from task import distributed_queue, github, labels_of_pull
 
-NAMES = [
-    "image-refresh",
-]
-
 # RHEL tasks have to be done inside Red Hat network
 REDHAT_TASKS = [
     "rhel",
@@ -47,7 +43,7 @@ except ImportError:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Scan issues for tasks")
+    parser = argparse.ArgumentParser(description="Scan issues for image-refresh tasks")
     parser.add_argument("-v", "--human-readable", "--verbose", action="store_true", default=False,
                         dest="verbose", help="Print verbose information")
     parser.add_argument('--amqp', default=None,
@@ -121,7 +117,7 @@ def tasks_for_issues(issues_data, opts_repo):
 
 def output_task(command, issue, repo, verbose):
     name, unused, context = command.partition(" ")
-    if name not in NAMES:
+    if name != "image-refresh" or not repo.endswith("/bots"):
         return None
     number = issue.get("number", None)
     if number is None:
@@ -130,12 +126,7 @@ def output_task(command, issue, repo, verbose):
     context = context.strip()
     checkout = "PRIORITY={priority:04d} "
 
-    if repo == "cockpit-project/bots":
-        # when working on bots run from project root
-        cmd = "./{name} --verbose --issue='{issue}' {context}"
-    else:
-        # for external projects, nothing checks out bots/ subdir for them, so do it here
-        cmd = "git clone .. bots && bots/{name} --verbose --issue='{issue}' {context}"
+    cmd = "./{name} --verbose --issue='{issue}' {context}"
 
     # `--issues-data` should also be able to receive pull_request events, in that
     # case pull_request won't be present in the object, but commits will be

--- a/issue-scan
+++ b/issue-scan
@@ -22,6 +22,7 @@ import json
 import logging
 import shlex
 import sys
+import time
 
 from lib import ALLOWLIST, testmap
 from task import distributed_queue, github, labels_of_pull
@@ -126,19 +127,25 @@ def output_task(command, issue, repo, verbose):
 
     context = shlex.quote(context.strip())
 
+    api = github.GitHub(repo=repo)
+
     # `--issues-data` should also be able to receive pull_request events, in that
     # case pull_request won't be present in the object, but commits will be
     if "pull_request" in issue or "commits" in issue:
         ref = f"pull/{number}/head"
+        sha = api.get(f"git/ref/{ref}")["object"]["sha"]
     else:
         ref = testmap.get_default_branch(repo)
+        sha = api.get(f"git/ref/heads/{ref}")["object"]["sha"]
 
     if verbose:
         return f"issue-{number} {name} {context} {ref}"
 
-    cmd = f"./make-checkout --verbose --repo {repo} {ref} && cd make-checkout-workdir && "
-    cmd += f"./{name} --verbose --issue={number} {context}; "
-    cmd += "cd .."
+    current = time.strftime('%Y%m%d-%H%M%S')
+    cmd = f"./s3-streamer --repo {repo} --test-name {name}-{context}-{current} " \
+        f"--github-context {name}/{context} --revision {sha} -- sh -exc '"
+    cmd += f"./make-checkout --verbose --repo {repo} {ref}; cd make-checkout-workdir; "
+    cmd += f"./{name} --verbose --issue={number} {context}'"
 
     return cmd
 

--- a/issue-scan
+++ b/issue-scan
@@ -124,25 +124,23 @@ def output_task(command, issue, repo, verbose):
         return None
 
     context = context.strip()
-    checkout = "PRIORITY={priority:04d} "
 
     cmd = "./{name} --verbose --issue='{issue}' {context}"
 
     # `--issues-data` should also be able to receive pull_request events, in that
     # case pull_request won't be present in the object, but commits will be
     if "pull_request" in issue or "commits" in issue:
-        checkout += "./make-checkout --verbose --repo {repo} pull/{issue}/head && "
+        checkout = "./make-checkout --verbose --repo {repo} pull/{issue}/head && "
     else:
-        checkout += "./make-checkout --verbose --repo {repo} {repo_default_branch} && "
+        checkout = "./make-checkout --verbose --repo {repo} {repo_default_branch} && "
 
     if verbose:
-        return f"issue-{int(number)} {name} {context}    {distributed_queue.MAX_PRIORITY}"
+        return f"issue-{int(number)} {name} {context}"
     else:
         if context:
             context = shlex.quote(context)
         return (checkout + "cd make-checkout-workdir && " + cmd + " ; cd ..").format(
             issue=int(number),
-            priority=distributed_queue.MAX_PRIORITY,
             name=name,
             context=context,
             repo=repo,

--- a/s3-streamer
+++ b/s3-streamer
@@ -302,7 +302,12 @@ def main() -> None:
         index = Index(destination)
         attachments_directory = AttachmentsDirectory(index, tmpdir)
         log_uploader = ChunkedUploader(index, 'log')
-        env = dict(os.environ, TEST_ATTACHMENTS=tmpdir, TEST_ATTACHMENTS_URL=destination.directory)
+        env = {
+            **os.environ,
+            'TEST_ATTACHMENTS': tmpdir,
+            'TEST_ATTACHMENTS_URL': destination.directory,
+            'COCKPIT_CI_LOG_URL': destination.directory + 'log.html'
+        }
 
         with subprocess.Popen(args.cmd, env=env,
                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT,


### PR DESCRIPTION
Three critical pieces:

 - add support for overriding the store used by `image-upload`, via the environment (and cause `image-download` to also additionally check this store for images)
 - teach s3-streamer to set `COCKPIT_CI_LOG_URL`
 - restore stdio logging to `image-refresh` and teach it about `COCKPIT_CI_LOG_URL`, removing its need to do its own S3 logging

One nice to have:
 - more suppressed operations and better logging output from various tasks commands when run with `--dry`, for example:

```
** Would git push origin +HEAD:refs/heads/image-refresh-cirros-20240221-091240

** Would open PR on cockpit-project/bots: {
    "head": "image-refresh-cirros-20240221-091240",
    "base": "main",
    "maintainer_can_modify": true,
    "title": "[no-test] Image refresh for cirros",
}
```

One critical missing component, and blocked until we have it:
 - teach `issue-scan` to spawn bots jobs under s3-streamer

One nice to have, related to above:
 - also add equivalent `Job` entries from `issue-scan`

Here's a test case (which I originally opened as an issue) for how this looks like when run from my local testing environment:

https://github.com/allisonkarlitskaya/bots/pull/14

Which can be reroduced via:

```
$ ./job-runner json '{
    "repo": "allisonkarlitskaya/bots",
    "sha": "abedb1827a118aff6a88d103dd57ec8a1077f85b",
    "context": "image-refresh/cirros",
    "target": null,
    "slug": null,
    "title": null,
    "report": false,
    "container": null,
    "secrets": [
        "github-token",
        "image-upload"
    ],
    "command": [
        "./image-refresh",
        "cirros",
        "--issue",
        "14"
    ],
    "env": {},
    "timeout": 120
}'
```

(which also validates that the Job json blob in the log can, indeed, be pasted verbatim into a new `job-runner` commandline).