### PR TITLE
testmap: test cockpit on fedora-40

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -43,6 +43,7 @@ REPO_BRANCH_CONTEXT = {
             *contexts('ubuntu-stable', COCKPIT_SCENARIOS),
             *contexts('fedora-38', COCKPIT_SCENARIOS),
             *contexts('fedora-39', COCKPIT_SCENARIOS),
+            *contexts('fedora-40', COCKPIT_SCENARIOS),
             # this runs coverage, reports need the whole test suite
             *contexts(TEST_OS_DEFAULT, ['devel']),
             *contexts(TEST_OS_DEFAULT, ['firefox'], COCKPIT_SCENARIOS),
@@ -64,7 +65,6 @@ REPO_BRANCH_CONTEXT = {
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-rawhide',
-            'fedora-40',
             'rhel-8-10',
         ],
     },

--- a/naughty/fedora-40/4796-stratis-runs-clevis-too-early
+++ b/naughty/fedora-40/4796-stratis-runs-clevis-too-early
@@ -1,0 +1,2 @@
+  File "check-storage-stratis", line *, in testBasic
+    b.wait_text(self.card_row_col("Stratis filesystems", 1, 1), "fsys1")  # should be started after boot

--- a/naughty/fedora-40/5106-journalctl-since-until-behaviour-change
+++ b/naughty/fedora-40/5106-journalctl-since-until-behaviour-change
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*", line *, in testEvents
+*
+testlib.Error: timeout
+wait_js_cond(ph_is_present(".cockpit-log-message:contains('Created slice cockpittest.slice.')")): Uncaught (in promise) Error: condition did not become true

--- a/naughty/fedora-40/5106-journalctl-since-until-behaviour-change-2
+++ b/naughty/fedora-40/5106-journalctl-since-until-behaviour-change-2
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "*", line *, in testRebootAndTime
+*
+        *"January 1, 2037"*"check-journal"*"BEFORE BOOT"* condition did not become true

--- a/naughty/fedora-40/5957-gnutls-fips
+++ b/naughty/fedora-40/5957-gnutls-fips
@@ -1,0 +1,8 @@
+  File "test/verify/check-system-info", line *, in test*CryptoPolic*
+    self.login_and_go("/system")
+*
+testlib.Error: timeout
+*
+Process * (cockpit-certifi) of user 0 dumped core.
+*
+#*cockpit-certificate-ensure*


### PR DESCRIPTION
### issues

#### apps

Fedora-40 moved to /usr/share/swcatalog/xml  and the test fails because there is still some valid xml's left.

**PR in Cockpit**

#### TestConnection.testTls

```
subject=CN = fedora-39-127-0-0-2-2201
```
VS:

```
subject=CN=fedora-40-127-0-0-2-2201
```

#### TestHistoryMetrics.testEvents

Copy naughty 5106 from Arch

#### TestStorageMultipath.testBasic

#### TestStorageStratisNBDE.testBasic

Copy naught 4796 from Arch

#### TestSystemInfo.testCryptoPolicies and TestSystemInfo.testInconsistentCryptoPolicy

Cockpit-tls segfault, maybe due to setting a stricter crypto policy? Smells like gnutls issue with FIPS

**Bugzillza'd**