### PR TITLE
task: Fix task module type annotation for Python 3.6

### DIFF
--- a/task/__init__.py
+++ b/task/__init__.py
@@ -395,7 +395,7 @@ def labels_of_pull(pull):
     return [label["name"] for label in pull["labels"]]
 
 
-def comment(issue, comment, dry: bool = False) -> dict[str, object]:
+def comment(issue, comment, dry: bool = False) -> 'dict[str, object]':
     try:
         number = issue["number"]
     except TypeError:


### PR DESCRIPTION
This is imported from Cockpit's testlib and must be able to run on RHEL 8. Commit 426759eaf introduced a type annotation which doesn't work with Python 3.6:

    TypeError: 'type' object is not subscriptable

------

Seen in https://github.com/cockpit-project/starter-kit/pull/799 , see https://artifacts.dev.testing-farm.io/9e63b357-7b2d-40e9-845a-e24eaf723888/

I validated in a `quay.io/centos/centos:stream8` container that this fix is sufficient.