### PR TITLE
images: add an openSUSE image 

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -168,10 +168,16 @@ class BuildAction(ActionBase):
             machine.execute(f'''su builder -c 'rpmbuild --define "_topdir /var/tmp/build" -ts "{vm_source}"' ''')
             srpm = "/var/tmp/build/SRPMS/*.src.rpm"
 
+        # HACK: mock in openSUSE must be called through sudo (but still originally as builder)
+        if "opensuse" in machine.execute("cat /etc/os-release"):
+            mock_sudo = "sudo"
+        else:
+            mock_sudo = ""
+
         # build binary RPMs from srpm; disable all repositorys as mock insists on
         # calling `dnf builddep`, which insists on a cache; our test VMs don't have a cache,
         # as the mock is offline and pre-installed
-        machine.execute("su builder -c 'mock --no-clean --no-cleanup-after --disablerepo=* "
+        machine.execute(f"su builder -c '{mock_sudo} mock --no-clean --no-cleanup-after --disablerepo=* "
                         f"--offline --resultdir /var/tmp/build {mock_opts} --rebuild {srpm}'",
                         timeout=1800, stdout=stdout_disposition)
 

--- a/image-trigger
+++ b/image-trigger
@@ -50,6 +50,7 @@ REFRESH = {
     "fedora-rawhide-boot": {},
     "fedora-rawhide-anaconda-payload": REFRESH_30,
     "fedora-rawhide-live-boot": REFRESH_30,
+    "opensuse-tumbleweed": {},
     "ubuntu-2204": {},
     "ubuntu-stable": {},
     "rhel-7-9": REFRESH_30,

--- a/images/opensuse-tumbleweed
+++ b/images/opensuse-tumbleweed
@@ -1,0 +1,1 @@
+opensuse-tumbleweed-c70032de81803054fa06f5493b9c6cb002c95559cbbaa8edacbfa04c444d9eb2.qcow2

--- a/images/scripts/lib/build-deps.sh
+++ b/images/scripts/lib/build-deps.sh
@@ -23,7 +23,11 @@ case "$OS_VER" in
     rhel*8|centos*8)
         spec=$($GET "$COCKPIT_GIT/rhel-8/tools/cockpit.spec")
         ;;
-
+    *suse*)
+        # macro for determining suse version is %suse_version
+        spec=$($GET "$COCKPIT_GIT/main/tools/cockpit.spec")
+        OS_VER_NO_VARIANT="suse_version $(awk '/%suse_version/{ print $2 }' /usr/lib/rpm/suse/macros)"
+        ;;
     *)
         spec=$($GET "$COCKPIT_GIT/main/tools/cockpit.spec")
         ;;
@@ -37,7 +41,14 @@ echo "$spec" | rpmspec -D "$OS_VER_NO_VARIANT" -D 'version 0' -D 'enable_old_bri
 # - gettext to build/merge GNU gettext translations
 # - desktop-file-utils for validating desktop files
 # - nodejs for starter-kit and other projects which rebuild webpack during RPM build
-EXTRA_DEPS="libappstream-glib rpmlint gettext desktop-file-utils nodejs"
+case "$OS_VER" in
+    *suse*)
+        EXTRA_DEPS="appstream-glib rpmlint gettext-runtime desktop-file-utils nodejs"
+        ;;
+    *)
+        EXTRA_DEPS="libappstream-glib rpmlint gettext desktop-file-utils nodejs-default"
+        ;;
+esac
 
 # TEMP: cockpit needs python3-devel to select the default Python version
 EXTRA_DEPS="$EXTRA_DEPS python3-devel"

--- a/images/scripts/opensuse-tumbleweed.bootstrap
+++ b/images/scripts/opensuse-tumbleweed.bootstrap
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eux
+
+URL='https://download.opensuse.org/tumbleweed/appliances/'
+IMAGE="openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
+
+exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"

--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -ex
+IMAGE="$1"
+
+. /etc/os-release
+
+# avoid failures when running image builds in a non-English locale (ssh transfers the host environment)
+unset LANGUAGE
+unset LANG
+export LC_ALL=C.utf8
+
+# make libpwquality less aggressive, so that our "foobar" password works
+printf 'dictcheck = 0\nminlen = 6\n' >> /etc/security/pwquality.conf
+
+. /etc/os-release
+# We install all dependencies of the cockpit packages since we want
+# them to not spontaneously change from one test run to the next when
+# the distribution repository is updated.
+#
+COCKPIT_DEPS="\
+criu \
+device-mapper \
+glibc-locale \
+glib-networking \
+json-glib \
+kexec-tools \
+libssh2-1 \
+libvirt-daemon-config-network \
+libvirt-daemon-driver-qemu \
+libvirt-daemon-driver-network \
+libvirt-daemon-driver-nodedev \
+libvirt-daemon-driver-storage-core \
+libvirt-daemon-driver-interface \
+libvirt-daemon-driver-storage-disk \
+libvirt-client \
+libvirt-dbus \
+openssl \
+PackageKit \
+pcp \
+pcp-devel \
+python3-pip \
+qemu-block-curl \
+qemu-chardev-spice \
+qemu-hw-usb-host \
+qemu-hw-usb-redirect \
+qemu-kvm \
+realmd \
+tuned \
+virt-install \
+udisks2 \
+libudisks2-0_lvm2 \
+"
+
+TEST_PACKAGES="\
+acl \
+ansible-core \
+clevis-luks \
+cryptsetup \
+firewalld \
+gdb \
+gettext \
+libvirt-daemon-driver-storage-iscsi \
+libvirt-daemon-driver-storage-iscsi-direct \
+libvirt-daemon-driver-storage-logical \
+ltrace \
+nginx \
+podman \
+redis \
+socat \
+strace \
+targetcli \
+tcsh \
+bzip2 \
+rpm-build \
+rpm-config-SUSE \
+"
+
+NETWORK_PACKAGES="\
+systemd-network \
+"
+
+# avoid NM-wait-online hanging on disconnected interfaces
+mkdir -p /etc/NetworkManager/conf.d/
+printf '[main]\nno-auto-default=*\n' > /etc/NetworkManager/conf.d/noauto.conf
+
+# our cloud-init.iso does not set up the host name
+
+echo "127.0.1.1 $(hostname)" >> /etc/hosts
+
+if ! getent passwd admin >/dev/null; then
+    useradd -c Administrator admin
+    echo admin:foobar | chpasswd
+fi
+
+if [ "${IMAGE%-i386}" != "$IMAGE" ]; then
+    TEST_PACKAGES="${TEST_PACKAGES/podman /}"
+fi
+
+
+zypper dup -y
+zypper install -y $TEST_PACKAGES $COCKPIT_DEPS $BUILD_PACKAGES $NETWORK_PACKAGES
+
+
+# Pre-install distribution cockpit packages, for testing cockpit extensions offline and for convenient interactive debugging
+zypper install -y cockpit
+
+zypper addrepo https://download.opensuse.org/repositories/system:packagemanager/openSUSE_Tumbleweed/system:packagemanager.repo
+zypper --non-interactive --gpg-auto-import-keys  refresh
+zypper install -y mock mock-core-configs sudo
+
+echo "%wheel ALL=(ALL) ALL" > /etc/sudoers.d/90-cockpit-wheel
+echo "builder ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/90-susebuild
+useradd -c Builder -G mock builder
+
+su builder -c "sudo mock --verbose -i $(/var/lib/testvm/build-deps.sh "${ID} ${VERSION_ID}")"
+
+# Prevent SSH from hanging for a long time when no external network access
+echo 'UseDNS no' >> /etc/ssh/sshd_config
+
+# Audit events to the journal
+rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
+rm -rf /var/log/audit/
+
+systemctl enable --now systemd-networkd.service
+
+echo root:foobar | chpasswd
+
+# reduce image size
+zypper clean
+/var/lib/testvm/zero-disk.setup

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -78,6 +78,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-40',
             'centos-8-stream',
             'fedora-rawhide',
+            'opensuse-tumbleweed',
         ],
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
this adds opensuse tumbleweed and micro images. unlike the previous PR which used Leap. Leap is currently unsuitable for cockpit as the dependencies are too old, and requires cockpit to be patched to build. Microos is similar to fedora-coreos or rhel4edge being the immutable offering of opensuse

For technical reasons, the actual rebuild happens in mirror PR #6011