### PR TITLE
image-download: Remove walrus

### DIFF
--- a/image-download
+++ b/image-download
@@ -135,7 +135,8 @@ def download(dest, force, state, quiet, stores):
         stores = PUBLIC_STORES
         if redhat_network():
             stores += REDHAT_STORES
-        if image_upload_store := os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE'):
+        image_upload_store = os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE')
+        if image_upload_store:
             # NB: This is an *addition* to the built-in stores, used for
             # testing.  Compare with image-upload which *only* uploads to this
             # store, if it's present.


### PR DESCRIPTION
This was introduced in commit e2f51db3b15. But `image-download` is being used by cockpit-machines TMT tests on RHEL 8, which doesn't yet know about `:=`.

----

See [failed test](https://artifacts.dev.testing-farm.io/52dde88e-0734-4c27-a08e-4537fccb9e86/) in https://github.com/cockpit-project/cockpit-machines/pull/1454