### PR TITLE
tests-invoke: Drop has_open_prs() call for issue filing

### DIFF
--- a/tests-invoke
+++ b/tests-invoke
@@ -96,7 +96,7 @@ def main():
                 time.sleep(int(os.getenv("TEST_INVOKE_SLEEP", "60")))
         return_code = p.returncode
         sys.stderr.write(f"Test run finished, return code: {return_code}\n")
-        if not api.has_open_prs(opts.revision) and not collision_detected and return_code != 0:
+        if not opts.pull_number and not collision_detected and return_code != 0:
             logs_url = os.getenv("TEST_ATTACHMENTS_URL")
             test_scenario = os.getenv("TEST_SCENARIO", "")
             test_os = os.getenv("TEST_OS")


### PR DESCRIPTION
That API is broken as-is. But we also don't need it here at all, as we already know via our CLI arguments whether or not we run for a PR.

Fixes #5958