### PR TITLE
Revert "task: Fix has_open_prs() return value"

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -402,7 +402,7 @@ class GitHub(object):
         pulls = self.get(f"commits/{sha}/pulls")
         if pulls:
             return any((pull['state'] == 'open' for pull in pulls))
-        return False
+        return True
 
     def getHead(self, pr):
         pull = self.get(f"pulls/{pr}")

--- a/task/test-tests-scan
+++ b/task/test-tests-scan
@@ -283,7 +283,7 @@ class TestTestsScan(unittest.TestCase):
     # mock time for predictable test name
     @unittest.mock.patch("time.strftime", return_value="20240102-030405")
     @unittest.mock.patch("task.distributed_queue.DistributedQueue")
-    def test_amqp_sha(self, mock_queue, _mock_strftime):
+    def disabled_test_amqp_sha(self, mock_queue, _mock_strftime):
         """Simulate nightly test on main branch"""
 
         # SHA without PR


### PR DESCRIPTION
This function is broken beyond repair -- it needs to be called on the PR *source* repo (i.e. the fork), the GitHub API endpoint will always return `[]` for tests which run for a PR for a fork.

There is no easy way to fix this -- the necessary information gets lost in translation, and e.g. in tests-scan we can't rely on always having a `--pull-number`: When we retry a test with `./tests-trigger`, that will become a statuses event which has no idea any more whether it belongs to a PR or not.

So for the time being, stop the firehose of bogus "Nightly test failed" issues by reverting commit 7c4f06c2b359e2984458711d51677ea10e8fb446.

This breaks test_amqp_sha(), so disable it for now.

Fixes #5960