### PR TITLE
tests-scan: Eliminate GitHub.has_open_prs()

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -398,12 +398,6 @@ class GitHub(object):
             result = result + issues
         return result
 
-    def has_open_prs(self, sha):
-        pulls = self.get(f"commits/{sha}/pulls")
-        if pulls:
-            return any((pull['state'] == 'open' for pull in pulls))
-        return True
-
     def getHead(self, pr):
         pull = self.get(f"pulls/{pr}")
         if pull:

--- a/task/test-tests-scan
+++ b/task/test-tests-scan
@@ -280,10 +280,8 @@ class TestTestsScan(unittest.TestCase):
     # mock time for predictable test name
     @unittest.mock.patch("time.strftime", return_value="20240102-030405")
     @unittest.mock.patch("task.distributed_queue.DistributedQueue")
-    @unittest.expectedFailure
     def test_amqp_sha_nightly(self, mock_queue, _mock_strftime):
         """Nightly test on main branch, without PR"""
-
         # SHA without PR
         args = ["tests-scan", "--dry", "--repo", self.repo, "--context", self.context,
                 "--sha", "9988aa", "--amqp", "amqp.example.com:1234"]

--- a/tests-scan
+++ b/tests-scan
@@ -73,7 +73,7 @@ def main():
     parser.add_argument('--pull-data', default=None,
                         help='pull_request event GitHub JSON data to evaluate; mutualy exclusive with -p and -s')
     parser.add_argument('-s', '--sha', default=None,
-                        help='SHA to scan for tasks')
+                        help='Trigger for a specific SHA; file issue on failure if SHA is not on a PR')
     parser.add_argument('--amqp', default=None,
                         help='The host:port of the AMQP server to publish to (format host:port)')
 
@@ -303,21 +303,28 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             pulls.append(pull)
         else:
             sys.exit(f"Can't find pull request {opts.pull_number}")
-    elif opts.sha and not api.has_open_prs(opts.sha):
-        logging.info("Processing revision %s without pull request", opts.sha)
-        pulls.append({
-            "title": f"{opts.sha}",
-            "number": 0,
-            "head": {
-                "sha": opts.sha,
-                "user": {
-                    "login": "cockpit-project"
-                }
-            },
-            "labels": [],
-        })
     else:
         pulls = api.pulls()
+
+    # Find matching PR for --sha
+    if opts.sha:
+        for pull in pulls:
+            if pull["head"]["sha"].startswith(opts.sha):
+                pulls = [pull]
+                break
+        else:
+            logging.info("Processing revision %s without pull request", opts.sha)
+            pulls = [{
+                "title": f"{opts.sha}",
+                "number": 0,
+                "head": {
+                    "sha": opts.sha,
+                    "user": {
+                        "login": "cockpit-project"
+                    }
+                },
+                "labels": [],
+            }]
 
     for pull in pulls:
         title = pull["title"]
@@ -331,10 +338,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
         allowed = login in ALLOWLIST
 
         logging.info("Processing #%s titled '%s' on revision %s", number, title, revision)
-
-        # If sha is present only scan PR with selected sha
-        if opts.sha and revision != opts.sha and not revision.startswith(opts.sha):
-            continue
 
         labels = labels_of_pull(pull)
 


### PR DESCRIPTION
That API is broken: The majority of our PRs are from forks, where
GitHub's commits/SHA/pulls would always return [], and `has_open_prs()`
would confusingly return `True` for these. (See commit 96f90e55b04b2).

There simply isn't a GitHub API to map a SHA to a PR (unless it's on the
same repo). What actually happened when a developer triggered a status
via `tests-trigger` is that tests-scan would scan *all* open PRs for
matching the given SHA. This is the correct approach, but it was totally
non-obvious due to the misleading call to `has_open_prs()`. So make that
iteration and the fallback to a stub "pull-0" PR info more explicit in
the code.

This properly fixes triggering a nightly run (`test_amqp_sha_nightly`).

 - [x] Goes on top of PR #5966