### PR TITLE
naughty: Add patterns for virtinterfaced crashes

### DIFF
--- a/naughty/fedora-38/5979-virtinterfaced-crash-lookup-by-mac-udev
+++ b/naughty/fedora-38/5979-virtinterfaced-crash-lookup-by-mac-udev
@@ -1,0 +1,3 @@
+#* udevInterfaceLookupByMACString*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/fedora-38/5980-virtinterfaced-crash-lookup-by-mac-xdr
+++ b/naughty/fedora-38/5980-virtinterfaced-crash-lookup-by-mac-xdr
@@ -1,0 +1,3 @@
+#* xdr_remote_interface_lookup_by_mac_string_args*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/fedora-39/5979-virtinterfaced-crash-lookup-by-mac-udev
+++ b/naughty/fedora-39/5979-virtinterfaced-crash-lookup-by-mac-udev
@@ -1,0 +1,3 @@
+#* udevInterfaceLookupByMACString*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/fedora-39/5980-virtinterfaced-crash-lookup-by-mac-xdr
+++ b/naughty/fedora-39/5980-virtinterfaced-crash-lookup-by-mac-xdr
@@ -1,0 +1,3 @@
+#* xdr_remote_interface_lookup_by_mac_string_args*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/fedora-40/5979-virtinterfaced-crash-lookup-by-mac-udev
+++ b/naughty/fedora-40/5979-virtinterfaced-crash-lookup-by-mac-udev
@@ -1,0 +1,3 @@
+#* udevInterfaceLookupByMACString*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/fedora-40/5980-virtinterfaced-crash-lookup-by-mac-xdr
+++ b/naughty/fedora-40/5980-virtinterfaced-crash-lookup-by-mac-xdr
@@ -1,0 +1,3 @@
+#* xdr_remote_interface_lookup_by_mac_string_args*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.


### PR DESCRIPTION
They have two distinct stack traces, so let's treat them as two separate bugs for the time being.

Downstream report for udev variant: https://bugzilla.redhat.com/show_bug.cgi?id=2266014
Downstream report for xdr variant: https://bugzilla.redhat.com/show_bug.cgi?id=2266017

Fixes https://github.com/cockpit-project/cockpit-machines/issues/1391