### PR TITLE
image-trigger: Disable Fedora ELN images

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -46,8 +46,9 @@ REFRESH = {
     "fedora-39": {},
     "fedora-40": {},
     "fedora-coreos": {},
-    "fedora-eln": {},
-    "fedora-eln-boot": {},
+    # TODO: fix and re-enable once Anaconda team has time and energy to maintain these again
+    # "fedora-eln": {},
+    # "fedora-eln-boot": {},
     "fedora-rawhide": {},
     "fedora-rawhide-boot": {},
     "fedora-rawhide-anaconda-payload": REFRESH_30,


### PR DESCRIPTION
They have been broken since January, and the Anaconda team does not currently have the capacity to maintain/use them. They are already disabled in the testmap.

Closes #5823
Closes #5911