### PR TITLE
job-runner: testing runs isolated to their own container

### DIFF
--- a/checkout-and-run
+++ b/checkout-and-run
@@ -1,0 +1,113 @@
+#!/usr/bin/python3
+
+# NB: This file gets run inside of a container with nothing else present.  It
+# needs to depend on only the Python standard library.
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import time
+from typing import Sequence
+
+
+def log(*parts: object) -> None:
+    print(*parts, file=sys.stderr)
+
+
+def run(*cmd: str, tries: int = 1) -> None:
+    joined = shlex.join(cmd)
+
+    for attempt in range(1, tries + 1):
+        try:
+            log('\n+', joined)
+            subprocess.check_call(cmd)
+            return
+        except subprocess.CalledProcessError as exc:
+            log(f'\n> Attempt {attempt} failed with code {exc.returncode}.')
+            time.sleep(2 ** attempt)
+
+    sys.exit(f'\n*** Failed to run command {joined}.  Aborting.')
+
+
+def output(*cmd: str) -> str:
+    try:
+        return subprocess.check_output(cmd, text=True).strip()
+    except subprocess.CalledProcessError as exc:
+        sys.exit(f'\n*** Failed to run command {shlex.join(cmd)} (code {exc.returncode}).  Aborting.')
+
+
+def git(*cmd: str, tries: int = 1) -> None:
+    run('git', *cmd, tries=tries)
+
+
+def git_output(*cmd: str) -> str:
+    return output('git', *cmd)
+
+
+def checkout_and_run(repository: str, revision: str | None, rebase: str | None, command: Sequence[str]) -> None:
+    run('cat', '/run/.containerenv')
+    run('uname', '-a')
+    run('mkdir', '-p', os.environ['TEST_ATTACHMENTS'])
+
+    git('clone', '--', repository, 'make-checkout-workdir', tries=5)
+
+    print('\n+ cd make-checkout-workdir', file=sys.stderr)
+    os.chdir('make-checkout-workdir')
+
+    if revision:
+        git('fetch', '--', 'origin', revision, tries=5)
+        git('checkout', '--detach', 'FETCH_HEAD')
+
+    if rebase:
+        git('fetch', '--', 'origin', rebase, tries=5)
+        # Do it this way to get the commit ID in the log
+        base = git_output('rev-parse', 'FETCH_HEAD')
+        git('rebase', '--', base)
+
+        git('log', 'HEAD', f'^{base}')
+        git('log', '-n1', base)
+    else:
+        git('log', '-n1')
+
+    commands: Sequence[Sequence[str]]
+    if command:
+        commands = (command,)
+    else:
+        commands = (
+            ('.cockpit-ci/run',),
+            ('test/run',)
+        )
+
+    for cmd in commands:
+        try:
+            log('\n+', shlex.join(cmd))
+            os.execv(cmd[0], tuple(cmd))
+        except FileNotFoundError as exc:
+            log(exc)
+        except OSError as exc:
+            log(exc)
+            break
+
+    sys.exit('\n*** Failed to execute entry point.')
+
+
+def main() -> None:
+    # All output to stdout — otherwise podman reorders things
+    os.dup2(1, 2)
+
+    parser = argparse.ArgumentParser(description="Check out a git repo and run a command; mainly used by job-runner")
+    parser.add_argument('--revision', help="The revision to checkout")
+    parser.add_argument('--rebase', help="Target branch to rebase onto")
+    parser.add_argument('repository', help="The git repository to clone")
+    parser.add_argument('command', nargs='*', help="The command to run [default: .cockpit-ci/run]")
+
+    args = parser.parse_args()
+    log('\n+ [checkout-and-run]', shlex.join(sys.argv[1:]))
+
+    checkout_and_run(args.repository, args.revision, args.rebase, args.command)
+
+
+if __name__ == '__main__':
+    main()

--- a/job-runner
+++ b/job-runner
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import assert_never
+
+from lib.aio.job import Job, run_job
+from lib.aio.jobcontext import JobContext
+from lib.aio.jsonutil import JsonError
+from lib.aio.util import JsonObjectAction, KeyValueAction
+
+logger = logging.getLogger(__name__)
+
+BOTS_DIR = Path(__file__).parent
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', action='store_true', help="Enable debugging output")
+    parser.add_argument('--config-file', '-F', metavar='FILENAME',
+                        help="Config file [default JOB_RUNNER_CONFIG or ~/.config/cockpit-dev/job-runner.toml]")
+    subprograms = parser.add_subparsers(dest='cmd', required=True, title="Subcommands")
+
+    run_parser = subprograms.add_parser("run", help="Run a single job provided on the command line")
+    run_parser.add_argument('repo', help="The repository (like `cockpit-project/cockpit`)")
+    run_parser.add_argument('--pull', type=int, help="The pull request number to run tests on")
+    run_parser.add_argument('--sha', help="The revision sha, exactly 40 hex digits")
+    run_parser.add_argument('--context', help="The status we're reporting against the sha")
+    run_parser.add_argument('--target', help="The target branch")
+    run_parser.add_argument('--report', action=JsonObjectAction, help="Open an issue on failures")
+    run_parser.add_argument('--slug', help="The URL slug (used for logging)")
+    run_parser.add_argument('--title', help="The title for the log page")
+    run_parser.add_argument('--container', help="The container image to use (like `quay.io/cockpit/tasks:latest`)")
+    run_parser.add_argument('--env', help="Environment variables for the test run", action=KeyValueAction)
+    run_parser.add_argument('--timeout', type=int, help="Timeout of the job, in minutes", default=120)
+    run_parser.add_argument('--secret', dest='secrets', default=[], action='append', help="Provide the named secret")
+    run_parser.add_argument('command', nargs='*', help="Command to run [default: .cockpit-ci/run]")
+
+    run_parser = subprograms.add_parser("json", help="Run a single given as a JSON blob")
+    run_parser.add_argument('json', action=JsonObjectAction, help="The job, in JSON format")
+
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    match args.cmd:
+        case 'run':
+            # if this throws, it's an error in the parser setup, above
+            job = Job(vars(args))
+
+        case 'json':
+            try:
+                job = Job(args.json)
+            except JsonError as exc:
+                sys.exit(f'Poorly formed job: {exc}')
+
+        case other:
+            assert_never(other)
+
+    async with JobContext(args.config_file, debug=args.debug) as ctx:
+        await run_job(job, ctx)
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/job-runner.toml
+++ b/job-runner.toml
@@ -1,0 +1,56 @@
+# Default configuration for job-runner
+
+# This file contains the default settings for job-runner and will always be
+# read in order to get the defaults.  It is also meant to act as a rudimentary
+# form of documentation for the options which are available.
+
+# Anything in this file can be overridden by installing a file with a similar
+# format in one of the following locations (in order of precedence):
+#   - the path specified via `--config-file`
+#   - the path specified via the `JOB_RUNNER_CONFIG` environment variable
+#   - XDG_CONFIG_HOME/cockpit-dev/job-runner.toml
+
+# The defaults from this file are merged with overrides from the first such
+# file found.
+
+# The default configuration is intentionally broken.  You'll need to provide a
+# configuration which (at least) does one of:
+#  - provides a valid GitHub API token; and/or
+#  - sets forge.github.post to false
+
+[container]
+command = ['podman']
+run-args = [
+  # '--device=/dev/kvm'
+]
+default-image = 'quay.io/cockpit/tasks:latest'
+
+[container.secrets]
+# see podman-secret(1)
+# github-token = ['--secret=github-token']
+
+[logs]
+driver='local'   # 's3' or 'local'
+
+[logs.s3]
+# hint: podman run --rm --net=host quay.io/minio/minio server /var
+url = 'http://127.0.0.1:9000/tmp/'
+key = {access='minioadmin', secret='minioadmin'}
+user-agent = 'job-runner (cockpit-project/bots)'
+acl = 'public-read'
+
+[logs.local]
+# hint: python -m http.server -b 127.0.0.1 -d ~/.cache/cockpit-dev/job-runner-logs
+dir = '~/.cache/cockpit-dev/job-runner-logs'
+link = 'http://127.0.0.1:8000/'
+
+[forge]
+driver='github'
+
+[forge.github]
+clone-url = 'https://github.com/'
+api-url = 'https://api.github.com/'
+post = true  # whether to post statuses, open issues, etc.
+user-agent = 'job-runner (cockpit-project/bots)'
+# (at least) one of `token` or `post = false` must be set
+# token = 'ghp_XXX'

--- a/lib/aio/abc.py
+++ b/lib/aio/abc.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import Collection
+from typing import AsyncContextManager, NamedTuple, Self
+
+from yarl import URL
+
+from .jsonutil import JsonObject
+
+
+class Subject(NamedTuple):
+    clone_url: URL
+    sha: str
+    rebase: str | None = None
+
+
+class Status:
+    link: str
+
+    async def post(self, state: str, description: str) -> None:
+        raise NotImplementedError
+
+
+class Forge:
+    async def resolve_subject(
+        self, repo: str, sha: str | None, pull_nr: int | None, branch: str | None, target: str | None
+    ) -> Subject:
+        raise NotImplementedError
+
+    async def check_pr_changed(self, repo: str, pull_nr: int, expected_sha: str) -> str | None:
+        raise NotImplementedError
+
+    def get_status(self, repo: str, sha: str, context: str | None, location: URL) -> Status:
+        raise NotImplementedError
+
+    async def open_issue(self, repo: str, issue: JsonObject) -> None:
+        raise NotImplementedError
+
+    @classmethod
+    def new(cls, config: JsonObject) -> Self:
+        raise NotImplementedError
+
+
+class Destination:
+    location: URL
+
+    def has(self, filename: str) -> bool:
+        raise NotImplementedError
+
+    def write(self, filename: str, data: bytes) -> None:
+        raise NotImplementedError
+
+    def delete(self, filenames: Collection[str]) -> None:
+        raise NotImplementedError
+
+
+class LogDriver:
+    def get_destination(self, slug: str) -> AsyncContextManager[Destination]:
+        raise NotImplementedError
+
+    @classmethod
+    def new(cls, config: JsonObject) -> Self:
+        raise NotImplementedError

--- a/lib/aio/github.py
+++ b/lib/aio/github.py
@@ -1,0 +1,186 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import contextlib
+import json
+import logging
+import platform
+from collections.abc import Mapping
+from typing import NamedTuple, Self
+
+import aiohttp
+from yarl import URL
+
+from .abc import Forge, Status, Subject
+from .jsonutil import JsonError, JsonObject, JsonValue, get_bool, get_dict, get_nested, get_str, typechecked
+from .util import LRUCache, create_http_session
+
+logger = logging.getLogger(__name__)
+
+
+class CacheEntry(NamedTuple):
+    conditions: Mapping[str, str]
+    value: JsonValue
+
+
+class GitHub(Forge, contextlib.AsyncExitStack):
+    def __init__(self, config: JsonObject) -> None:
+        super().__init__()
+        self.cache = LRUCache[str, CacheEntry]()
+        self.config = config
+        self.clone = URL(get_str(config, 'clone-url'))
+        self.api = URL(get_str(config, 'api-url'))
+        self.dry_run = not get_bool(config, 'post')
+
+    async def __aenter__(self) -> Self:
+        headers = {}
+        # token is mandatory if `post = true`
+        if token := get_str(self.config, 'token', *((None,) if self.dry_run else ())):
+            headers['Authorization'] = f'token {token.strip()}'
+
+        self.session = await self.enter_async_context(create_http_session(self.config, headers))
+
+        return self
+
+    async def post(self, resource: str, body: JsonValue = None) -> JsonValue:
+        if self.dry_run:
+            logger.info('** Would post to %s: %s', resource, json.dumps(body, indent=4))
+            return body
+
+        async def post_once() -> JsonValue:
+            async with self.session.post(self.api / resource, json=body) as response:
+                logger.debug('response %r', response)
+                return await response.json()  # type: ignore[no-any-return]
+
+        for attempt in range(4):
+            try:
+                return await post_once()
+            except aiohttp.ClientResponseError as exc:
+                if exc.status < 500:
+                    raise
+            except aiohttp.ClientError:
+                pass
+
+            # 1 → 2 → 4 → 8s delay
+            await asyncio.sleep(2 ** attempt)
+
+        # ...last attempt.
+        return await post_once()
+
+    async def get(self, resource: str) -> JsonValue:
+        async def get_once() -> JsonValue:
+            headers = {**self.session.headers}
+            cache_entry = self.cache.get(resource)
+            if cache_entry is not None:
+                headers.update(cache_entry.conditions)
+
+            logger.debug('get %r %r', resource, cache_entry)
+            async with self.session.get(self.api / resource, headers=headers) as response:
+                condition_map = {'etag': 'if-none-match', 'last-modified': 'if-modified-since'}
+                conditions = {c: response.headers[h] for h, c in condition_map.items() if h in response.headers}
+
+                if cache_entry is not None and response.status == 304:
+                    self.cache.add(resource, cache_entry)
+                    logger.debug('  cache hit %r -- returning cached value', resource)
+                    return cache_entry.value
+
+                else:
+                    value = await response.json()
+                    logger.debug('  cache miss %r -- caching and returning %r', resource, conditions)
+                    self.cache.add(resource, CacheEntry(conditions, value))
+                    return value  # type: ignore[no-any-return]
+
+        for attempt in range(4):
+            try:
+                return await get_once()
+            except aiohttp.ClientResponseError as exc:
+                if exc.status < 500:
+                    raise
+            except aiohttp.ClientError:
+                pass
+
+            # 1 → 2 → 4 → 8s delay
+            await asyncio.sleep(2 ** attempt)
+
+        # ...last attempt.
+        return await get_once()
+
+    async def get_obj(self, resource: str) -> JsonObject:
+        return typechecked(await self.get(resource), dict)
+
+    async def check_pr_changed(self, repo: str, pull_nr: int, expected_sha: str) -> str | None:
+        try:
+            pull = await self.get_obj(f'repos/{repo}/pulls/{pull_nr}')
+            if get_str(pull, 'state') != 'open':
+                return f'{repo}#{pull_nr} is closed'
+            if get_str(get_dict(pull, 'head'), 'sha') != expected_sha:
+                return f'{repo}#{pull_nr} changed'
+        except JsonError as exc:
+            return f'Unexpected error when parsing pull request: {exc}'
+        except aiohttp.ClientError as exc:
+            # might be transient, so don't kill the job on account of this...
+            logger.warning('Error when polling for %s#%s: %r', repo, pull_nr, exc)
+            return None
+        else:
+            return None
+
+    async def open_issue(self, repo: str, issue: JsonObject) -> None:
+        await self.post(f'repos/{repo}/issues', issue)
+
+    def get_status(self, repo: str, sha: str, context: str | None, location: URL) -> Status:
+        return GitHubStatus(self, repo, sha, context, location)
+
+    async def resolve_subject(
+        self, repo: str, sha: str | None, pull_nr: int | None, branch: str | None, target: str | None
+    ) -> Subject:
+        clone_url = self.clone / repo
+
+        if sha is not None:
+            # if pull_nr is set and our sha doesn't match the PR, we will
+            # detect it soon
+            return Subject(clone_url, sha, target)
+
+        elif pull_nr is not None:
+            pull = await self.get_obj(f'repos/{repo}/pulls/{pull_nr}')
+            if target is None:
+                target = get_str(get_dict(pull, 'base'), 'ref')
+            return Subject(clone_url, get_str(get_dict(pull, 'head'), 'sha'), target)
+
+        else:
+            if not branch:
+                branch = get_str(await self.get_obj(f'repos/{repo}'), 'default_branch')
+
+            with get_nested(await self.get_obj(f'repos/{repo}/git/refs/heads/{branch}'), 'object') as object:
+                return Subject(clone_url, get_str(object, 'sha'), target)
+
+
+class GitHubStatus(Status):
+    def __init__(self, api: GitHub, repo: str, revision: str, context: str | None, link: URL) -> None:
+        logger.debug('GitHubStatus(%r, %r, %r, %r)', repo, revision, context, link)
+        self.api = api
+        self.resource = f'repos/{repo}/statuses/{revision}'
+        self.link = str(link)
+        self.context = context
+
+    async def post(self, state: str, description: str) -> None:
+        logger.debug('POST statuses/%s %s %s', self.resource, state, description)
+        if self.context is not None:
+            await self.api.post(self.resource, {
+                'context': self.context,
+                'state': state,
+                'description': f'{description} [{platform.node()}]',
+                'target_url': self.link
+            })

--- a/lib/aio/job.py
+++ b/lib/aio/job.py
@@ -1,0 +1,207 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import itertools
+import json
+import logging
+import os
+import platform
+import sys
+import tempfile
+import textwrap
+import traceback
+from pathlib import Path
+from typing import Never
+
+from ..constants import BOTS_DIR
+from .abc import Forge, Subject
+from .jobcontext import JobContext
+from .jsonutil import JsonObject, get_dict, get_int, get_str, get_str_map, get_strv
+from .s3streamer import Index, LogStreamer
+from .spawn import run, spawn
+from .util import gather_and_cancel, read_utf8
+
+logger = logging.getLogger(__name__)
+
+
+class Failure(Exception):
+    pass
+
+
+class Job:
+    def __init__(self, obj: JsonObject) -> None:
+        # test subject specification
+        self.repo = get_str(obj, 'repo')
+        self.sha = get_str(obj, 'sha', None)
+        self.pull = get_int(obj, 'pull', None)
+        self.branch = get_str(obj, 'branch', None)
+        self.target = get_str(obj, 'target', None)
+
+        # test specification
+        self.container = get_str(obj, 'container', None)
+        self.secrets = get_strv(obj, 'secrets', ())
+        self.command = get_strv(obj, 'command', None)
+        self.env = get_str_map(obj, 'env', {})
+        self.timeout = get_int(obj, 'timeout', 120)
+
+        # reporting
+        self.context = get_str(obj, 'context', None)
+        self.slug = get_str(obj, 'slug', None)
+        self.title = get_str(obj, 'title', None)
+        self.report = get_dict(obj, 'report', None)
+
+
+async def timeout_minutes(minutes: float) -> Never:
+    await asyncio.sleep(60 * minutes)
+    raise Failure(f'Timeout after {minutes} minutes')
+
+
+async def poll_pr(api: Forge, repo: str, pull_nr: int, expected_sha: str) -> Never:
+    while True:
+        if reason := await api.check_pr_changed(repo, pull_nr, expected_sha):
+            raise Failure(reason)
+        await asyncio.sleep(60)
+
+
+async def run_container(job: Job, subject: Subject, ctx: JobContext, log: LogStreamer) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir_path:
+        tmpdir = Path(tmpdir_path)
+        cidfile = tmpdir / 'cidfile'
+        attachments = tmpdir / 'attachments'
+
+        args = [
+            *ctx.container_cmd, 'run',
+            *ctx.container_run_args,
+            f'--cidfile={cidfile}',
+            *(f'--env={k}={v}' for k, v in job.env.items()),
+            '--env=TEST_ATTACHMENTS=/var/tmp/attachments',
+            f'--env=COCKPIT_CI_LOG_URL={log.url}',
+            *itertools.chain.from_iterable(args for name, args in ctx.secrets_args.items() if name in job.secrets),
+
+            job.container or ctx.default_image,
+
+            # we might be using podman-remote, so we can't --volume this:
+            'python3', '-c', Path(f'{BOTS_DIR}/checkout-and-run').read_text(),  # lulz
+            f'--revision={subject.sha}'
+        ]
+        if subject.rebase:
+            args.append(f'--rebase={subject.rebase}')
+        args.append(f'{subject.clone_url}')
+
+        if job.command:
+            args.append('--')
+            args.extend(job.command)
+
+        async with spawn(args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT) as container:
+            try:
+                # Log data until we hit EOF
+                assert container.stdout is not None
+                async for block in read_utf8(container.stdout):
+                    log.write(block)
+                    if ctx.debug:
+                        if os.isatty(1):
+                            sys.stdout.write(f'\033[34m{block}\033[0m')  # da ba dee, da ba di...
+                        else:
+                            sys.stdout.write(block)
+
+                # We don't know yet if the container was ever actually created.
+                # We can't rely on the exit status, since it's also non-zero if
+                # the container ran successfully but the job returned non-zero.
+                # We can use the existence of the cidfile, however.  By now
+                # (important: after we got EOF in the loop above), if the
+                # container got created, the cidfile will have also been
+                # created.  If not, this was a container creation failure, which
+                # is an internal error, not a Failure.  Be noisy about it.
+                try:
+                    cid = cidfile.read_text().strip()
+                except FileNotFoundError as exc:
+                    raise RuntimeError('Failed to create container') from exc
+
+                # Upload all attachments
+                # TODO: live updates
+                # TODO: invent async tarfile for StreamReader
+                await run([*ctx.container_cmd, 'cp', '--', f'{cid}:/var/tmp/attachments/.', f'{attachments}'])
+                for file in attachments.rglob('*'):
+                    log.index.write(str(file.relative_to(attachments)), file.read_bytes())
+
+                if returncode := await container.wait():
+                    raise Failure(f'Container exited with code {returncode}')
+
+            finally:
+                await run([*ctx.container_cmd, 'rm', '--force', '--time=0', f'--cidfile={tmpdir}/cidfile'],
+                          stdout=asyncio.subprocess.DEVNULL)  # don't show container ID output
+
+
+async def run_job(job: Job, ctx: JobContext) -> None:
+    subject = await ctx.forge.resolve_subject(job.repo, job.sha, job.pull, job.branch, job.target)
+    title = job.title or f'{job.context}@{job.repo}#{subject.sha[:12]}'
+    slug = job.slug or f'{job.repo}/{job.context or "-"}/{subject.sha[:12]}'
+
+    async with ctx.logs.get_destination(slug) as destination:
+        index = Index(destination)
+        log = LogStreamer(index)
+
+        status = ctx.forge.get_status(job.repo, subject.sha, job.context, log.url)
+        logger.info('Log: %s', log.url)
+
+        try:
+            log.start(f'{title}\nRunning on: {platform.node()}\n\nJob(' + json.dumps(job.__dict__, indent=4) + ')\n')
+            await status.post('pending', 'In progress')
+
+            tasks = {run_container(job, subject, ctx, log)}
+
+            if job.timeout:
+                tasks.add(timeout_minutes(job.timeout))
+
+            if job.pull:
+                tasks.add(poll_pr(ctx.forge, job.repo, job.pull, subject.sha))
+
+            await gather_and_cancel(tasks)
+
+        except Failure as exc:
+            log.write(f'\n*** Failure: {exc}\n')
+            await status.post('failure', str(exc))
+
+            if job.report is not None:
+                issue = {
+                    "title": f"{job.context} failed",
+                    "body": textwrap.dedent(f"""
+                        The job `{job.context}` failed on commit {subject.sha}.
+
+                        Log: {log.url}
+                    """).lstrip(),
+                    **job.report
+                }
+                await ctx.forge.open_issue(job.repo, issue)
+
+        except asyncio.CancelledError:
+            await status.post('error', 'Cancelled')
+            log.write('*** Job cancelled\n')
+            raise
+
+        except BaseException as exc:
+            # ie: bug in this program, but let's be helpful
+            await status.post('error', 'Internal error')
+            log.write('\n\n' + '\n'.join(traceback.format_exception(exc)) + '\n')
+            raise
+
+        else:
+            await status.post('success', 'Success')
+            log.write('\n\nJob ran successfully.  :)\n')
+
+        finally:
+            log.close()
+            index.sync()

--- a/lib/aio/jobcontext.py
+++ b/lib/aio/jobcontext.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import logging
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import AsyncContextManager, Callable, Self
+
+import tomllib
+
+from ..constants import BOTS_DIR
+from ..directories import xdg_config_home
+from .abc import Forge, LogDriver
+from .github import GitHub
+from .jsonutil import (
+    JsonError,
+    JsonObject,
+    get_nested,
+    get_str,
+    get_strv,
+    json_merge_patch,
+    load_external_files,
+    typechecked,
+)
+from .local import LocalLogDriver
+from .s3 import S3LogDriver
+
+logger = logging.getLogger(__name__)
+
+# __init__ is weird on types, so typecheck this as a callable to enforce correctness
+FORGES: Mapping[str, Callable[[JsonObject], AsyncContextManager[Forge]]] = {
+    'github': GitHub,
+}
+
+LOG_DRIVERS: Mapping[str, Callable[[JsonObject], AsyncContextManager[LogDriver]]] = {
+    's3': S3LogDriver,
+    'local': LocalLogDriver,
+}
+
+
+class JobContext(contextlib.AsyncExitStack):
+    config: JsonObject = {}  # immutable
+    logs: LogDriver
+    forge: Forge
+
+    def load_config(self, path: Path, name: str, *, missing_ok: bool = False) -> None:
+        logger.debug('Loading %s configuration from %s', name, str(path))
+        try:
+            with path.open('rb') as file:
+                content = tomllib.load(file)
+        except tomllib.TOMLDecodeError as exc:
+            sys.exit(f'{path}: {exc}')
+        except FileNotFoundError as exc:
+            if missing_ok:
+                logger.debug('No %s configuration found at %s', name, str(path))
+            else:
+                sys.exit(f'{path}: {exc}')
+        except OSError as exc:
+            sys.exit(f'{path}: {exc}')
+
+        # load_external_files() can throw so make sure it's outside of the above block
+        self.config = json_merge_patch(self.config, load_external_files(content, path.parent))
+
+    def __init__(self, config_file: Path | str | None, *, debug: bool = False) -> None:
+        super().__init__()
+
+        self.debug = debug
+
+        # The config is made out of the built-in config...
+        self.load_config(Path(BOTS_DIR) / 'job-runner.toml', 'built-in')
+
+        # ... plus exactly one of the following:
+        if config_file:
+            self.load_config(Path(config_file), 'command-line')
+        elif config_file := os.environ.get('JOB_RUNNER_CONFIG'):
+            self.load_config(Path(config_file), '$JOB_RUNNER_CONFIG-specified')
+        else:
+            self.load_config(Path(xdg_config_home('cockpit-dev/job-runner.toml')), 'user', missing_ok=True)
+
+    async def __aenter__(self) -> Self:
+        try:
+            with get_nested(self.config, 'container') as container:
+                self.container_cmd = get_strv(container, 'command')
+                self.container_run_args = get_strv(container, 'run-args')
+                with get_nested(container, 'secrets') as secrets:
+                    self.secrets_args = {
+                        name: [
+                            typechecked(arg, str) for arg in typechecked(args, list)
+                        ] for name, args in secrets.items()
+                    }
+                self.default_image = get_str(container, 'default-image')
+
+            with get_nested(self.config, 'logs') as logs:
+                driver = get_str(logs, 'driver')
+                if driver not in LOG_DRIVERS:
+                    sys.exit(f'Unknown log driver {driver}')
+                with get_nested(logs, driver) as driver_config:
+                    self.logs = await self.enter_async_context(LOG_DRIVERS[driver](driver_config))
+
+            with get_nested(self.config, 'forge') as forge:
+                driver = get_str(forge, 'driver')
+                if driver not in FORGES:
+                    sys.exit(f'Unknown forge driver {driver}')
+                with get_nested(forge, driver) as driver_config:
+                    self.forge = await self.enter_async_context(FORGES[driver](driver_config))
+        except JsonError as exc:
+            await self.__aexit__(exc.__class__, exc, None)
+            sys.exit(f'Configuration error: {exc}')
+        except BaseException as exc:
+            await self.__aexit__(exc.__class__, exc, None)
+            raise
+
+        return self

--- a/lib/aio/jsonutil.py
+++ b/lib/aio/jsonutil.py
@@ -1,0 +1,158 @@
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import contextlib
+from enum import Enum
+from pathlib import Path
+from typing import Callable, ContextManager, Iterator, Mapping, Sequence, Type, TypeVar, Union
+
+JsonLiteral = str | float | bool | None
+JsonValue = Union['JsonObject', Sequence['JsonValue'], JsonLiteral]
+JsonObject = Mapping[str, JsonValue]
+
+
+DT = TypeVar('DT')
+T = TypeVar('T')
+
+
+class JsonError(Exception):
+    value: object
+
+    def __init__(self, value: object, msg: str):
+        super().__init__(msg)
+        self.value = value
+
+
+def typechecked(value: JsonValue, expected_type: Type[T]) -> T:
+    """Ensure a JSON value has the expected type, returning it if so."""
+    if not isinstance(value, expected_type):
+        raise JsonError(value, f'must have type {expected_type.__name__}')
+    return value
+
+
+# We can't use None as a sentinel because it's often the actual default value
+# EllipsisType is difficult because it's not available before 3.10.
+# See https://peps.python.org/pep-0484/#support-for-singleton-types-in-unions
+class _Empty(Enum):
+    TOKEN = 0
+
+
+_empty = _Empty.TOKEN
+
+
+def _get(obj: JsonObject, cast: Callable[[JsonValue], T], key: str, default: DT | _Empty) -> T | DT:
+    try:
+        value = obj[key]
+        if default is not _empty and value is default:
+            return default
+        return cast(obj[key])
+    except KeyError:
+        if default is not _empty:
+            return default
+        raise JsonError(obj, f"attribute '{key}' required") from None
+    except JsonError as exc:
+        target = f"attribute '{key}'" + (' elements:' if exc.value is not obj[key] else ':')
+        raise JsonError(obj, f"{target} {exc!s}") from exc
+
+
+def get_bool(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | bool:
+    return _get(obj, lambda v: typechecked(v, bool), key, default)
+
+
+def get_int(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | int:
+    return _get(obj, lambda v: typechecked(v, int), key, default)
+
+
+def get_str(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | str:
+    return _get(obj, lambda v: typechecked(v, str), key, default)
+
+
+def get_dict(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | JsonObject:
+    return _get(obj, lambda v: typechecked(v, dict), key, default)
+
+
+def get_str_map(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | Mapping[str, str]:
+    def as_str_map(value: JsonValue) -> Mapping[str, str]:
+        return {key: typechecked(value, str) for key, value in typechecked(value, dict).items()}
+    return _get(obj, as_str_map, key, default)
+
+
+def get_strv(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | Sequence[str]:
+    def as_strv(value: JsonValue) -> Sequence[str]:
+        return tuple(typechecked(item, str) for item in typechecked(value, list))
+    return _get(obj, as_strv, key, default)
+
+
+def get_nested(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> ContextManager[DT | JsonObject]:
+    # workaround for https://github.com/microsoft/pyright/issues/7386
+    @contextlib.contextmanager
+    def wrapper() -> Iterator[DT | JsonObject]:
+        try:
+            yield get_dict(obj, key, default)
+        except KeyError:
+            if default is not _empty:
+                yield default
+            raise JsonError(obj, f"attribute '{key}' required") from None
+        except JsonError as exc:
+            target = f"attribute '{key}'" + (' elements:' if exc.value is not obj[key] else ':')
+            raise JsonError(obj, f"{target} {exc!s}") from exc
+    return wrapper()
+
+
+def json_merge_patch(current: JsonObject, patch: JsonObject) -> JsonObject:
+    """Perform a JSON merge patch (RFC 7396) using 'current' and 'patch'.
+    Neither of the original dictionaries is modified — the result is returned.
+    """
+    # Always take a copy ('result') — we never modify the input ('current')
+    result = dict(current)
+    for key, patch_value in patch.items():
+        if isinstance(patch_value, Mapping):
+            current_value = current.get(key, None)
+            if not isinstance(current_value, Mapping):
+                current_value = {}
+            result[key] = json_merge_patch(current_value, patch_value)
+        elif patch_value is not None:
+            result[key] = patch_value
+        else:
+            result.pop(key, None)
+
+    return result
+
+
+def parse_filename(value: JsonValue) -> str | None:
+    # magic: must look exactly like [{file="filename"}]
+    if not isinstance(value, Sequence) or len(value) != 1:
+        return None
+    item, = value
+    if not isinstance(item, Mapping) or len(item) != 1:
+        return None
+    (key, filename), = item.items()
+    if key != 'file' or not isinstance(filename, str):
+        return None
+    return filename
+
+
+def load_external_files(obj: JsonObject, path: Path) -> JsonObject:
+    """Perform a JSON merge patch (RFC 7396) using 'current' and 'patch'.
+    Neither of the original dictionaries is modified — the result is returned.
+    """
+    result = {}
+    for key, value in obj.items():
+        if filename := parse_filename(value):
+            value = (path / filename).read_text()
+        elif isinstance(value, dict):
+            value = load_external_files(value, path)
+        result[key] = value
+    return result

--- a/lib/aio/local.py
+++ b/lib/aio/local.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import logging
+import os
+from collections.abc import Collection
+from pathlib import Path
+from typing import AsyncIterator
+
+from yarl import URL
+
+from .abc import Destination, LogDriver
+from .jsonutil import JsonObject, get_str
+
+logger = logging.getLogger(__name__)
+
+
+class LocalDestination(Destination):
+    def __init__(self, directory: Path, location: URL) -> None:
+        logger.debug('LocalDestination(%r, %r)', directory, location)
+        self.dir = directory
+        self.location = location
+        os.makedirs(self.dir, exist_ok=True)
+
+    def has(self, filename: str) -> bool:
+        return (self.dir / filename).exists()
+
+    def write(self, filename: str, data: bytes) -> None:
+        logger.debug('Write %s', self.dir / filename)
+        (self.dir / filename).write_bytes(data)
+
+    def delete(self, filenames: Collection[str]) -> None:
+        for filename in filenames:
+            logger.debug('Delete %s', self.dir / filename)
+            (self.dir / filename).unlink()
+
+
+class LocalLogDriver(LogDriver, contextlib.AsyncExitStack):
+    def __init__(self, config: JsonObject) -> None:
+        super().__init__()
+        self.directory = Path(get_str(config, 'dir')).expanduser()
+        self.link = URL(get_str(config, 'link'))
+
+    @contextlib.asynccontextmanager
+    async def get_destination(self, slug: str) -> AsyncIterator[Destination]:
+        yield LocalDestination(self.directory / slug, self.link / slug)

--- a/lib/aio/s3.py
+++ b/lib/aio/s3.py
@@ -1,0 +1,197 @@
+# Copyright (C) 2022-2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import contextlib
+import hashlib
+import hmac
+import logging
+import mimetypes
+import time
+from types import TracebackType
+from typing import Collection, Mapping, NamedTuple, Self
+
+import aiohttp
+from yarl import URL
+
+from .abc import Destination, LogDriver
+from .jsonutil import JsonError, JsonObject, get_nested, get_str
+from .util import AsyncQueue, create_http_session
+
+logger = logging.getLogger(__name__)
+
+
+class S3Key(NamedTuple):
+    access: str
+    secret: str
+
+
+class HttpRequest(NamedTuple):
+    method: str
+    url: URL
+    headers: Mapping[str, str]
+    data: bytes = b''
+
+
+class HttpQueue:
+    def __init__(self, session: aiohttp.ClientSession, s3_key: S3Key) -> None:
+        self.session = session
+        self._queue = AsyncQueue[HttpRequest]()
+        self._task: asyncio.Task[None] | None = None
+        self._level: int = logging.DEBUG
+        self._s3_key = s3_key
+
+    async def request_once(self, request: HttpRequest, checksum: str) -> None:
+        # NB: Re-sign each attempt.  Time's arrow neither stands still nor reverses.
+        headers = s3_sign(request.url, request.method, request.headers, checksum, self._s3_key)
+        logger.log(self._level, '%s %s', request.method, request.url)
+        async with self.session.request(request.method, request.url, data=request.data, headers=headers) as response:
+            logger.debug('response %s %s %r', request.method, request.url, response)
+
+    async def request(self, request: HttpRequest) -> None:
+        checksum = hashlib.sha256(request.data).hexdigest()
+        for attempt in range(5):
+            try:
+                return await self.request_once(request, checksum)
+            except aiohttp.ClientResponseError as exc:
+                if exc.status < 500:
+                    raise  # We actually care about 4xx errors, but blindly retry 5xx.
+            except aiohttp.ClientError:
+                pass  # That's DNS, connection, etc. errors.  Always retry those.
+
+            # 1 → 4 → 16 → 64 → 256s
+            await asyncio.sleep(4 ** attempt)
+
+        # last attempt — return the exception (...or pass)
+        return await self.request_once(request, checksum)
+
+    async def run_queue(self) -> None:
+        while request := await self._queue.next():
+            await self.request(request)
+            self._queue.done(request)
+
+    def request_soon(self, request: HttpRequest) -> None:
+        assert self._queue is not None
+        self._queue.put(request)
+
+    async def __aenter__(self) -> Self:
+        self._task = asyncio.create_task(self.run_queue())
+        return self
+
+    async def __aexit__(self,
+                        exc_type: type[BaseException] | None,
+                        exc_value: BaseException | None,
+                        traceback: TracebackType | None) -> None:
+        assert self._task
+
+        if items := len(self._queue):
+            logger.info('Waiting for %r queued HTTP requests to complete...', items)
+            self._level = logging.INFO  # make the rest of the output a bit louder
+
+        self._queue.eof()
+        await self._task
+
+    def s3_put(self, url: URL, body: bytes, headers: Mapping[str, str]) -> None:
+        self.request_soon(HttpRequest('PUT', url, headers, body))
+
+    def s3_delete(self, url: URL) -> None:
+        self.request_soon(HttpRequest('DELETE', url, {}))
+
+
+def s3_sign(
+    url: URL, method: str, headers: Mapping[str, str], checksum: str, keys: S3Key
+) -> Mapping[str, str]:
+    """Signs an AWS request using the AWS4-HMAC-SHA256 algorithm
+
+    Returns a dictionary of extra headers which need to be sent along with the request.
+    If the method is PUT then the checksum of the data to be uploaded must be provided.
+    @headers, if given, are a dict of additional headers to be signed (eg: `x-amz-acl`)
+    """
+    amzdate = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
+    assert url.host is not None
+
+    # Header canonicalisation demands all header names in lowercase
+    headers = {key.lower(): value for key, value in headers.items()}
+    headers.update({'host': url.host, 'x-amz-content-sha256': checksum, 'x-amz-date': amzdate})
+    headers_str = ''.join(f'{k}:{v}\n' for k, v in sorted(headers.items()))
+    headers_list = ';'.join(sorted(headers))
+
+    credential_scope = f'{amzdate[:8]}/any/s3/aws4_request'
+    signing_key = f'AWS4{keys.secret}'.encode('ascii')
+    for item in credential_scope.split('/'):
+        signing_key = hmac.new(signing_key, item.encode('ascii'), hashlib.sha256).digest()
+
+    algorithm = 'AWS4-HMAC-SHA256'
+    canonical_request = f'{method}\n{url.path}\n{url.query_string}\n{headers_str}\n{headers_list}\n{checksum}'
+    request_hash = hashlib.sha256(canonical_request.encode('ascii')).hexdigest()
+    string_to_sign = f'{algorithm}\n{amzdate}\n{credential_scope}\n{request_hash}'
+    signature = hmac.new(signing_key, string_to_sign.encode('ascii'), hashlib.sha256).hexdigest()
+    headers['Authorization'] = f'{algorithm} Credential={keys.access}/{credential_scope},' \
+        f'SignedHeaders={headers_list},Signature={signature}'
+
+    return headers
+
+
+class S3Destination(Destination, contextlib.AsyncExitStack):
+    def __init__(self, session: aiohttp.ClientSession, url: URL, key: S3Key) -> None:
+        super().__init__()
+        self.session = session
+        self.location = url
+        self.key = key
+
+    def url(self, filename: str) -> URL:
+        return self.location / filename
+
+    def has(self, filename: str) -> bool:
+        raise NotImplementedError('use Index')
+
+    def write(self, filename: str, data: bytes) -> None:
+        content_type, content_encoding = mimetypes.guess_type(filename)
+        headers = {**self.session.headers, 'Content-Type': content_type or 'text/plain'}
+        if content_encoding:
+            headers['Content-Encoding'] = content_encoding
+
+        self.queue.s3_put(self.url(filename), data, headers)
+
+    def delete(self, filenames: Collection[str]) -> None:
+        # to do: multi-object delete API
+        for filename in filenames:
+            self.queue.s3_delete(self.url(filename))
+
+    async def __aenter__(self) -> Self:
+        self.queue = await self.enter_async_context(HttpQueue(self.session, self.key))
+        return self
+
+
+class S3LogDriver(LogDriver, contextlib.AsyncExitStack):
+    def __init__(self, config: JsonObject) -> None:
+        super().__init__()
+        self.config = config
+        self.url = URL(get_str(config, 'url'))
+        try:
+            access, secret = get_str(config, 'key').split()
+            self.key = S3Key(access, secret)
+        except (ValueError, JsonError):
+            with get_nested(config, 'key') as key:
+                self.key = S3Key(get_str(key, 'access'), get_str(key, 'secret'))
+
+    def get_destination(self, slug: str) -> contextlib.AbstractAsyncContextManager[S3Destination]:
+        url = self.url / slug.replace('//', '--').replace(':', '-')
+        return S3Destination(self.session, url, self.key)
+
+    async def __aenter__(self) -> Self:
+        headers = {'x-amz-acl': get_str(self.config, 'acl')}
+        self.session = await self.enter_async_context(create_http_session(self.config, headers))
+        return self

--- a/lib/aio/s3streamer.py
+++ b/lib/aio/s3streamer.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2022-2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import codecs
+import json
+import locale
+import logging
+import os
+import textwrap
+from typing import ClassVar, Collection
+
+from ..constants import LIB_DIR
+from .abc import Destination
+
+logger = logging.getLogger(__name__)
+
+
+class Index(Destination):
+    files: set[str]
+
+    def __init__(self, destination: Destination, filename: str = 'index.html') -> None:
+        self.destination = destination
+        self.filename = filename
+        self.files = set()
+        self.dirty = True
+
+    def has(self, filename: str) -> bool:
+        return filename in self.files
+
+    def write(self, filename: str, data: bytes) -> None:
+        self.destination.write(filename, data)
+        self.files.add(filename)
+        self.dirty = True
+
+    def delete(self, filenames: Collection[str]) -> None:
+        raise NotImplementedError
+
+    def sync(self) -> None:
+        if self.dirty:
+            self.destination.write(self.filename, textwrap.dedent('''
+                <html>
+                  <body>
+                    <h1>Directory listing for /</h1>
+                    <hr>
+                    <ul>''' + ''.join(f'''
+                      <li><a href={f}>{f}</a></li> ''' for f in sorted(self.files)) + '''
+                    </ul>
+                  </body>
+                </html>
+                ''').encode('utf-8'))
+            self.dirty = False
+
+
+class AttachmentsDirectory:
+    def __init__(self, destination: Destination, local_directory: str) -> None:
+        self.destination = destination
+        self.path = local_directory
+
+    def scan(self) -> None:
+        for subdir, _dirs, files in os.walk(self.path):
+            for filename in files:
+                path = os.path.join(subdir, filename)
+                name = os.path.relpath(path, start=self.path)
+
+                if not self.destination.has(name):
+                    logger.debug('Uploading attachment %s', name)
+                    with open(path, 'rb') as file:
+                        data = file.read()
+                    self.destination.write(name, data)
+
+
+class LogStreamer:
+    SIZE_LIMIT: ClassVar[int] = 1000000  # 1MB
+    TIME_LIMIT: ClassVar[int] = 30       # 30s
+
+    chunks: list[list[bytes]]
+    suffixes: set[str]
+    send_at: float | None
+
+    def __init__(self, index: Index) -> None:
+        assert locale.getpreferredencoding() == 'UTF-8'
+        self.input_decoder = codecs.getincrementaldecoder('UTF-8')(errors='replace')
+        self.suffixes = {'chunks'}
+        self.chunks = []
+        self.index = index
+        self.destination = index.destination
+        self.pending = b''
+        self.timer: asyncio.TimerHandle | None = None
+        self.url = self.destination.location / 'log.html'
+
+    def clear_timer(self) -> None:
+        if self.timer:
+            self.timer.cancel()
+        self.timer = None
+
+    def send_pending(self) -> None:
+        # Consume the pending buffer into the chunks list.
+        self.chunks.append([self.pending])
+        self.pending = b''
+        self.clear_timer()
+
+        # 2048 algorithm.
+        #
+        # This can be changed to merge more or less often, or to never merge at
+        # all. The only restriction is that it may only ever update the last
+        # item in the list.
+        while len(self.chunks) > 1 and len(self.chunks[-1]) == len(self.chunks[-2]):
+            last = self.chunks.pop()
+            second_last = self.chunks.pop()
+            self.chunks.append(second_last + last)
+
+        # Now we figure out how to send that last item.
+        # Let's keep the client dumb: it doesn't need to know about blocks: only bytes.
+        chunk_sizes = [sum(len(block) for block in chunk) for chunk in self.chunks]
+
+        if chunk_sizes:
+            last_chunk_start = sum(chunk_sizes[:-1])
+            last_chunk_end = last_chunk_start + chunk_sizes[-1]
+            last_chunk_suffix = f'{last_chunk_start}-{last_chunk_end}'
+            self.destination.write(f'log.{last_chunk_suffix}', b''.join(self.chunks[-1]))
+            self.suffixes.add(last_chunk_suffix)
+
+        self.destination.write('log.chunks', json.dumps(chunk_sizes).encode('ascii'))
+
+    def start(self, data: str) -> None:
+        # Send the initial data immediately, to get the chunks file written out.
+        self.pending = data.encode()
+        self.send_pending()
+        AttachmentsDirectory(self.index, f'{LIB_DIR}/s3-html').scan()
+
+    def write(self, data: str) -> None:
+        self.pending += data.encode()
+
+        if len(self.pending) > LogStreamer.SIZE_LIMIT:
+            self.send_pending()
+
+        elif self.pending and self.timer is None:
+            self.timer = asyncio.get_running_loop().call_later(LogStreamer.TIME_LIMIT, self.send_pending)
+
+    def close(self) -> None:
+        # We're about to delete all of the chunks, so don't bother with
+        # anything still pending...
+        self.clear_timer()
+
+        everything = b''.join(b''.join(block for block in chunk) for chunk in self.chunks) + self.pending
+        self.index.write('log', everything)
+
+        # If the client ever sees a 404, it knows that the streaming is over.
+        self.destination.delete([f'log.{suffix}' for suffix in self.suffixes])

--- a/lib/aio/spawn.py
+++ b/lib/aio/spawn.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import contextlib
+import logging
+from typing import Any, AsyncIterator, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.asynccontextmanager
+async def spawn(args: Sequence[str], **kwargs: Any) -> AsyncIterator[asyncio.subprocess.Process]:
+    logger.debug('spawn(%r)', args)
+    process = await asyncio.create_subprocess_exec(*args, **kwargs)
+    pid = process.pid
+    logger.debug('spawn: pid %r', pid)
+    try:
+        yield process
+    finally:
+        logger.debug('spawn: waiting for pid %r', pid)
+        status = await process.wait()
+        logger.debug('spawn: pid %r exited, %r', pid, status)
+
+
+async def run(args: Sequence[str], **kwargs: Any) -> None:
+    logger.debug('run(%r)', args)
+    process = await asyncio.create_subprocess_exec(*args, **kwargs)
+    pid = process.pid
+    logger.debug('run: waiting for pid %r', pid)
+    status = await process.wait()
+    logger.debug('run: pid %r exited, %r', pid, status)

--- a/lib/aio/util.py
+++ b/lib/aio/util.py
@@ -1,0 +1,142 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import asyncio
+import codecs
+import collections
+import contextlib
+import json
+import logging
+import ssl
+from typing import Any, AsyncIterator, Collection, Coroutine, Hashable, Mapping, Sequence, TypeVar
+
+import aiohttp
+
+from .jsonutil import JsonError, JsonObject, get_str, typechecked
+
+logger = logging.getLogger(__name__)
+
+# When mypy gets PEP 695 support: https://github.com/python/mypy/issues/15238
+# type JsonValue = None | bool | int | float | Sequence[JsonValue] | Mapping[str, JsonValue]
+K = TypeVar('K', bound=Hashable)
+T = TypeVar('T')
+V = TypeVar('V')
+
+
+class AsyncQueue(collections.deque[T]):
+    def __init__(self) -> None:
+        self._nonempty = asyncio.Event()
+        self._eof = False
+
+    async def next(self) -> T | None:
+        await self._nonempty.wait()
+        return self[0] if self else None
+
+    def done(self, item: T) -> None:
+        assert self.popleft() is item
+        if not self and not self._eof:
+            self._nonempty.clear()
+
+    def put(self, item: T) -> None:
+        self.append(item)
+        self._nonempty.set()
+
+    def eof(self) -> None:
+        self._nonempty.set()
+        self._eof = True
+
+
+# Simple LRU cache: when full, evict the least-recently `add()`-ed item.
+class LRUCache(dict[K, V]):
+    def __init__(self, max_items: int = 128) -> None:
+        self.max_items = max_items
+
+    def add(self, key: K, value: V) -> None:
+        # In order to make sure the value gets inserted at the end, we need to
+        # remove a previous value, otherwise it will just take its place.
+        self.pop(key, None)
+        self[key] = value
+        while len(self) > self.max_items:
+            oldest = next(iter(self))
+            logger.debug('evicting cached data for %r', oldest)
+            self.pop(oldest)
+
+
+class KeyValueAction(argparse.Action):
+    def __init__(self, option_strings: str, dest: str, **kwargs: Any) -> None:
+        super().__init__(option_strings, dest, **kwargs, default={})
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[str] | None,
+        option_string: str | None = None
+    ) -> None:
+        assert isinstance(values, str)
+        key, eq, value = values.partition('=')
+        if not eq:
+            raise ValueError(f'--env parameter `{value}` must contain `=`')
+        getattr(namespace, self.dest)[key] = value
+
+
+class JsonObjectAction(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str | Sequence[str] | None,
+        option_string: str | None = None
+    ) -> None:
+        assert isinstance(values, str)
+        try:
+            setattr(namespace, self.dest, typechecked(json.loads(values), dict))
+        except (JsonError, json.JSONDecodeError) as exc:
+            parser.error(f'invalid argument {self.dest}: {exc}')
+
+
+async def gather_and_cancel(aws: Collection[Coroutine[None, None, None]]) -> None:
+    tasks = {asyncio.create_task(coro) for coro in aws}
+
+    try:
+        (done,), tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        done.result()  # to raise the exception, if applicable
+    finally:
+        for task in tasks:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+async def read_utf8(stream: asyncio.StreamReader) -> AsyncIterator[str]:
+    decoder = codecs.getincrementaldecoder('UTF-8')(errors='replace')
+    while data := await stream.read(1 << 20):  # 1MB
+        yield decoder.decode(data)
+    yield decoder.decode(b'', final=True)
+
+
+def create_http_session(config: JsonObject, headers: Mapping[str, str]) -> aiohttp.ClientSession:
+    if cadata := get_str(config, 'ca', None):
+        connector = aiohttp.TCPConnector(ssl=ssl.create_default_context(cadata=cadata))
+    else:
+        connector = None
+
+    headers = {
+        'User-Agent': get_str(config, 'user-agent'),
+        **headers,
+    }
+
+    return aiohttp.ClientSession(connector=connector, headers=headers, raise_for_status=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,11 @@ ignore = [
 [tool.pytest.ini_options]
 addopts = ["--cov-config=pyproject.toml"]  # for subprocesses
 pythonpath = ["."]
+required_plugins = ["pytest-asyncio"]
+asyncio_mode = 'auto'
 
 [tool.coverage.run]
-branch=true
+branch = true
 
 [tool.coverage.report]
 show_missing = true

--- a/run-queue
+++ b/run-queue
@@ -119,7 +119,11 @@ def consume_task_queue(channel, amqp, declare_public_result, declare_rhel_result
         return None, None
 
     body = json.loads(body)
-    return body['command'], method_frame.delivery_tag
+    if job := body.get('job'):
+        command = ['./job-runner', 'json', json.dumps(job)]
+    else:
+        command = body['command']
+    return command, method_frame.delivery_tag
 
 
 def mail_notification(body):

--- a/test/run
+++ b/test/run
@@ -12,10 +12,13 @@ test_ruff() {
 test_mypy() {
     command -v mypy >/dev/null || { echo 'no mypy installed'; return 0; }
     mypy_strict_files='
+      lib/aio
       lib/directories.py
       lib/network.py
+      checkout-and-run
+      job-runner
     '
-    mypy --no-error-summary --strict $mypy_strict_files
+    mypy  --scripts-are-modules --no-error-summary --strict $mypy_strict_files
 }
 
 test_ruff

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -1,0 +1,279 @@
+import hashlib
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any, AsyncIterator, Sequence
+
+import aiohttp
+import pytest
+from aioresponses import CallbackResult, aioresponses
+from yarl import URL
+
+from lib.aio.github import GitHub
+from lib.aio.jobcontext import JobContext
+from lib.aio.jsonutil import JsonObject, JsonValue, json_merge_patch
+from lib.aio.s3 import S3Key, S3LogDriver
+from lib.aio.util import LRUCache
+
+
+class GitHubService:
+    CLONE_URL = URL('http://github.test/')
+    API_URL = URL('http://api.github.test/')
+    TOKEN = 'token_ABCDEFG'
+    USER_AGENT = __file__  # or any magic unique string
+
+    db: JsonObject = {}  # immutable
+
+    def __init__(self) -> None:
+        self.resources: dict[URL, CallbackResult] = {}
+        self.flakes: list[Exception | tuple[int, str]] = []
+        self.hits = 0
+        self.points = 0  # ie: GitHub rate-limiting "points"
+        self.config: JsonObject = {
+            'api-url': str(self.API_URL),
+            'clone-url': str(self.CLONE_URL),
+            'post': True,
+            'token': self.TOKEN,
+            'user-agent': self.USER_AGENT,
+        }
+
+    def assert_hits(self, expected_hits: int, expected_points) -> None:
+        assert self.hits == expected_hits
+        assert self.points == expected_points
+        self.hits = self.points = 0
+
+    def add(self, resource: str, *, etag: bool = False, mtime: bool = False, **kwargs) -> None:
+        headers = {}
+        if etag:
+            all_data = str(kwargs.get('body')) + ':' + str(kwargs.get('payload'))
+            headers['etag'] = hashlib.sha256(all_data.encode()).hexdigest()
+        if mtime:
+            headers['last-modified'] = str(time.monotonic())  # accurate enough to change each time
+        self.resources[self.API_URL / resource] = CallbackResult(headers=headers, **kwargs)
+
+    def update(self, resource: str, value: JsonValue, *, etag: bool = True, mtime: bool = False) -> None:
+        self.db = json_merge_patch(self.db, {resource: value})
+        if resource in self.db:
+            self.add(resource, body=json.dumps(self.db[resource]), etag=etag, mtime=mtime)
+        else:
+            del self.resources[self.API_URL / resource]
+
+    def flake(self, flakes: Sequence[Exception | tuple[int, str]]) -> None:
+        self.flakes.extend(flakes)
+
+    async def post(self, url: URL, headers: dict[str, str], **kwargs: str) -> CallbackResult:
+        assert False
+
+    async def get(self, url: URL, headers: dict[str, str], **kwargs: str) -> CallbackResult:
+        if self.flakes:
+            flake = self.flakes.pop(0)
+            if isinstance(flake, Exception):
+                raise flake
+            else:
+                status, reason = flake
+                return CallbackResult(status=status, reason=reason)
+
+        self.hits += 1  # every request is a hit
+
+        assert headers['User-Agent'] == self.USER_AGENT
+        assert headers['Authorization'] == f'token {self.TOKEN}'
+        assert url in self.resources
+
+        result = self.resources[url]
+        assert result.headers is not None  # because we add it ourselves
+        # do etag/last-modified checks. in theory this needs to be
+        # case-insensitive, but we use lowercase throughout.  if we return 304
+        # then that doesn't impact our rate-limiting score.
+        if (etag := result.headers.get('etag')) and headers.get('if-none-match') == etag:
+            return CallbackResult(status=304, reason='Not Modified')
+        if (lm := result.headers.get('last-modified')) and headers.get('if-modified-since') == lm:
+            return CallbackResult(status=304, reason='Not Modified')
+
+        self.points += 1  # "full strength" return, counts as rate-limit points
+        return result
+
+
+def test_lru_cache():
+    cache = LRUCache[str, int](max_items=2)
+    cache.add('a', 1)
+    cache.add('b', 2)
+    assert cache == {'a': 1, 'b': 2}
+    cache.add('c', 3)
+    assert cache == {'b': 2, 'c': 3}
+    cache.add('d', 4)
+    assert cache == {'c': 3, 'd': 4}
+    cache.add('c', 3)  # refresh 'c' without value change
+    assert cache == {'c': 3, 'd': 4}
+    cache.add('e', 5)  # now 'd' should be evicted
+    assert cache == {'c': 3, 'e': 5}
+    cache.add('c', 300)  # refresh 'c' with value change
+    assert cache == {'c': 300, 'e': 5}
+    cache.add('f', 6)  # now 'e' should be evicted
+    assert cache == {'c': 300, 'f': 6}
+    cache.add('c', 3)  # refresh 'c' some more
+    assert cache == {'c': 3, 'f': 6}
+    cache.add('c', 3)
+    assert cache == {'c': 3, 'f': 6}
+    cache.add('f', 6)  # but now bump 'f' up again
+    assert cache == {'c': 3, 'f': 6}
+    cache.add('g', 7)  # 'c' should now be evicted
+    assert cache == {'f': 6, 'g': 7}
+
+
+@pytest.fixture
+async def service() -> AsyncIterator[GitHubService]:
+    server = GitHubService()
+    with aioresponses() as mock:
+        mock.post(re.compile(''), callback=server.post, repeat=True)
+        mock.get(re.compile(''), callback=server.get, repeat=True)
+        yield server
+
+
+@pytest.fixture
+async def api(service: GitHubService) -> AsyncIterator[GitHub]:
+    async with GitHub(service.config) as github:
+        yield github
+
+
+async def test_github_404(service: GitHubService, api: GitHub) -> None:
+    # Make sure 4xx errors get raised immediately without retries
+    service.add('x', status=404, reason='Not Found')
+    with pytest.raises(aiohttp.ClientResponseError, match='404.*Not Found'):
+        await api.get('x') == {}
+    service.assert_hits(1, 1)
+
+
+async def test_github_api_flakes(service: GitHubService, api: GitHub) -> None:
+    # Make sure 5xx errors and network issues get retries
+    service.flake([(503, 'Busy'), aiohttp.ClientConnectionError()])
+    service.update('x', {'a': 'b'}, etag=True)
+    assert await api.get('x') == {'a': 'b'}
+
+
+async def test_github_cache(service: GitHubService, api: GitHub) -> None:
+    # verify fundamentals of caching behaviour
+    service.update('x', {'a': 'b'}, etag=True)
+    assert await api.get('x') == {'a': 'b'}
+    service.assert_hits(1, 1)
+    assert await api.get('x') == {'a': 'b'}
+    service.assert_hits(1, 0)
+
+    service.update('x', {'a': 'b'}, etag=True)
+    assert await api.get('x') == {'a': 'b'}
+    service.assert_hits(1, 0)
+
+    service.update('x', {'a': 'c'}, etag=True)
+    assert await api.get('x') == {'a': 'c'}
+    service.assert_hits(1, 1)
+
+    service.update('y', {'a': 'b'}, etag=False, mtime=True)
+    assert await api.get('y') == {'a': 'b'}
+    service.assert_hits(1, 1)
+    assert await api.get('y') == {'a': 'b'}
+    service.assert_hits(1, 0)
+
+    service.update('y', {'a': 'b'}, etag=False, mtime=True)  # this changes the mtime, even with the same body
+    assert await api.get('y') == {'a': 'b'}
+    service.assert_hits(1, 1)
+
+    service.update('y', {'a': 'c'}, etag=False, mtime=True)  # this changes the mtime, different body
+    assert await api.get('y') == {'a': 'c'}
+    service.assert_hits(1, 1)
+
+    CACHE_SIZE = 128  # this is the default
+
+    # fill the cache and evict 'x' and 'y'
+    for i in range(CACHE_SIZE):
+        service.update(f'n/{i}', {'n': i})
+        assert await api.get(f'n/{i}') == {'n': i}
+    service.assert_hits(CACHE_SIZE, CACHE_SIZE)
+
+    # verify that our etag usage prevents us from getting more "points"
+    for i in range(CACHE_SIZE):
+        assert await api.get(f'n/{i}') == {'n': i}
+    service.assert_hits(CACHE_SIZE, 0)
+
+    # verify that our 'x' and 'y' score "points" now
+    assert await api.get('x') == {'a': 'c'}
+    assert await api.get('y') == {'a': 'c'}
+    service.assert_hits(2, 2)
+
+    # finally, re-read our n/[0 .. 127] items in the pathological order,
+    # causing each one to be evicted just before we would have read it
+    for i in range(CACHE_SIZE):
+        assert await api.get(f'n/{i}') == {'n': i}
+    service.assert_hits(CACHE_SIZE, CACHE_SIZE)
+
+
+async def test_github_pr_lookup(service: GitHubService, api: GitHub) -> None:
+    pull_nr = 123
+    repo = 'owner/repo'
+    sha = '89abcdef' * 5
+
+    # open a PR
+    service.update(f'repos/{repo}/pulls/{pull_nr}', {
+        'state': 'open',
+        'base': {'ref': 'main'},
+        'head': {'sha': sha},
+    })
+
+    # Look up the sha in the PR via the REST API
+    subject = await api.resolve_subject('owner/repo', None, pull_nr, None, None)
+    assert subject == (service.CLONE_URL / repo, sha, 'main')
+    service.assert_hits(1, 1)
+
+    # The next thing that happens is that we poll this API a lot
+    for _ in range(100):
+        assert await api.check_pr_changed(repo, pull_nr, subject.sha) is None
+    # IMPORTANT: we should have used an etag each time, so no extra rate-limit points
+    service.assert_hits(100, 0)
+
+    # Close the PR and poll once more
+    service.update(f'repos/{repo}/pulls/{pull_nr}', {'state': 'closed'})
+    message = await api.check_pr_changed(repo, pull_nr, subject.sha)
+    assert message and f'#{pull_nr} is closed' in message
+    service.assert_hits(1, 1)  # etag changed, so this scores "points"
+
+    # Re-open the PR, do a force-push, and poll once more
+    service.update(f'repos/{repo}/pulls/{pull_nr}', {'state': 'open', 'head': {'sha': '12345678' * 5}})
+    message = await api.check_pr_changed(repo, pull_nr, subject.sha)
+    assert message and f'#{pull_nr} changed' in message
+    service.assert_hits(1, 1)  # etag changed, so this scores "points"
+
+
+async def test_config(tmp_path: Path) -> None:
+    config_file = tmp_path / 'config'
+    config_file.write_text('''
+        [test]
+        text = [{file="./abc"}]
+
+        [forge.github]
+        token=[{file="./github-token"}]
+
+        [logs]
+        driver='s3'
+        s3.key=[{file="./s3-key"}]
+    ''')
+    (tmp_path / 'abc').write_text('xyz')
+    (tmp_path / 'github-token').write_text('tok_ABCDEFG\n')
+    (tmp_path / 's3-key').write_text('\n ACC\t SEC  \t \n')
+
+    async with JobContext(config_file) as context:
+        # make our lives easier with mypy for the following asserts
+        config: Any = context.config
+
+        # test override of built-in config
+        assert config['logs']['driver'] == 's3'
+
+        # test built-in config
+        assert config['container']['command'] == ['podman']
+
+        # test file loading
+        assert config['test']['text'] == 'xyz'
+
+        assert isinstance(context.forge, GitHub)
+        assert context.forge.session.headers['Authorization'] == 'token tok_ABCDEFG'
+
+        assert isinstance(context.logs, S3LogDriver)
+        assert context.logs.key == S3Key('ACC', 'SEC')


### PR DESCRIPTION
Introduce job-runner, a new asyncio python application designed to replace a good chunk of our backend CI infra:
 - `tests-invoke`
 - `make-checkout`
 - `s3-streamer`
 - (eventually, maybe) `run-queue`

and dramatically simplify others:
 - `issue-scan`
 - `tests-scan`

while making it easier to play with our testing infrastructure locally.

The main new feature vs. the existing stuff is that each testing job is run in its own one-time-use container.  The image for that container is under control of the revision being tested, allowing for gating of task container upgrades (avoiding the usual wave of broken pixels, linting changes, etc.).

Instead of running our jobs from the giant blobs of shell pasted together in `issue-scan` or `tests-scan` we consume them as the new "Job" json format, already introduced in #5932.

The new approach also makes a conscious effort to reduce the amount of exposure of secrets to test runs (although we have some more work to do here).

TODO:
 - [x] Includes #6018 to fix tests
 - [x] Needs https://github.com/cockpit-project/cockpituous/pull/586 ; once that lands, revert the "TEMP HACK" commit
 - [x] Needs https://github.com/cockpit-project/cockpituous/pull/583 **deployed to prod** (it isn't yet) before  landing, so that it will actually work
 - [x] Needs https://github.com/cockpit-project/cockpituous/pull/588 to ensure we don't break image refreshes
 - [x] [Add host name to log](https://github.com/cockpit-project/bots/pull/6017#issuecomment-1980207904), like the old s3-streamer
 - [ ] ~cidfile crash after successful runs https://paste.centos.org/view/01fcdfc8 with `podman-remote`; this breaks attachments, thus a blocker~ not reproducible, ignore