### PR TITLE
workflows: Update to podman 4 in cockpituous workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,15 @@ jobs:
           repository: cockpit-project/cockpituous
           path: cockpituous
 
+      # HACK: Ubuntu 22.04 has podman 3.4, which isn't compatible with podman-remote 4 in our tasks container
+      # This PPA is a backport of podman 4.3 from Debian 12; drop this when moving `runs-on:` to ubuntu-24.04
+      - name: Update to newer podman
+        if: steps.changes.outputs.changed
+        run: |
+          sudo add-apt-repository -y ppa:quarckster/containers
+          sudo apt install -y podman
+          systemctl --user daemon-reload
+
       - name: Test local CI deployment
         if: steps.changes.outputs.changed
         run: |


### PR DESCRIPTION
This was introduced for cockpituous in
https://github.com/cockpit-project/cockpituous/commit/4e413fff41 and we need to do the same to keep the test working on the bots side.

---

Otherwise, [unhappy tests](https://github.com/cockpit-project/bots/actions/runs/8161248219/job/22309599970?pr=6017#step:7:197):
```
Error: unable to connect to Podman socket: server API version is too old. Client "4.0.0" server "3.4.4"
```