### PR TITLE
lib: add a COCKPIT_IMAGE_STORES_FILE envvar

### DIFF
--- a/lib/stores.py
+++ b/lib/stores.py
@@ -31,7 +31,7 @@ REDHAT_STORES = [
 
 # local stores
 try:
-    with open(xdg_config_home('cockpit-dev', 'image-stores'), 'r') as fp:
+    with open(xdg_config_home('cockpit-dev', 'image-stores', envvar='COCKPIT_IMAGE_STORES_FILE'), 'r') as fp:
         data = fp.read().strip()
         if data:
             PUBLIC_STORES += data.split("\n")


### PR DESCRIPTION
Similar to the others, we provide this file when testing from run-local.sh (and it's the only one for which we don't yet have an override).