### PR TITLE
workflows: Drop obsolete git safe.directory config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,6 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-      - name: Pacify git's permission check
-        run: git config --global --add safe.directory /__w/bots/bots
-
       - name: Run test
         run: test/run
 


### PR DESCRIPTION
actions/checkout@v4 does this by default.