### PR TITLE
workflows: Replace deprecated :set-output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         id: changes
         run: |
           git log --exit-code --stat HEAD --not origin/${{ github.event.pull_request.base.ref }} -- \
+              ':!.github/workflows' \
               ':!README.md' \
               ':!HACKING.md' \
               ':!images' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
               ':!lib/allowlist.py' \
               ':!lib/testmap.py' \
               ':!vm-run' \
-          >&2 || echo "::set-output name=changed::true"
+          >&2 || echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Ensure branch was proposed from origin
         if: steps.changes.outputs.changed


### PR DESCRIPTION
This causes a "will soon be removed" warning, see
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

----

This is also included in https://github.com/cockpit-project/cockpituous/pull/587 where it covers the "positive" case of a changed repo with a container rebuild. Here it should *not* run cockpituous test.