### PR TITLE
images: Add "foonux" mock image

### DIFF
--- a/images/scripts/foonux.bootstrap
+++ b/images/scripts/foonux.bootstrap
@@ -1,0 +1,4 @@
+#!/bin/sh
+# mock image which doesn't need any qemu/kvm; used by cockpituous integration tests
+echo fakeimage > $1
+date >> $1


### PR DESCRIPTION
This will be used by cockpituous integration tests. The "cirros" image requires kvm to build, and we also don't want to suffer through the download. It's also better to keep a separate name to ensure that we don't accidentally push a broken cirros image anywhere public.