### PR TITLE
Convert .format() to f-strings

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -125,7 +125,7 @@ def scan(api, force, verbose):
         if perform:
             text = f"Image refresh for {image}"
             issue = task.issue(text, text, "image-refresh", image)
-            sys.stderr.write("#{0}: image-refresh {1}\n".format(issue["number"], image))
+            sys.stderr.write(f'#{issue["number"]}: image-refresh {image}\n')
 
 
 if __name__ == '__main__':

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -218,7 +218,7 @@ class VirtNetwork:
         for remote, local in result["forward"].items():
             local = self._lock(int(local) + result["number"])
             result["forward"][remote] = f"127.0.0.2:{local}"
-            forwards.append("hostfwd=tcp:{}-:{}".format(result["forward"][remote], remote))
+            forwards.append(f"hostfwd=tcp:{result['forward'][remote]}-:{remote}")
             if remote == "22":
                 result["control"] = result["forward"][remote]
             elif remote == "9090":

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -133,8 +133,8 @@ class SSHConnection(object):
                     break
         if not boot_id:
             self.print_console_log()
-            raise exceptions.Failure("Unable to reach machine {0} via ssh: {1}:{2}".format(
-                self.label, self.ssh_address, self.ssh_port))
+            raise exceptions.Failure(
+                f"Unable to reach machine {self.label} via ssh: {self.ssh_address}:{self.ssh_port}")
         self.boot_id = boot_id
 
     def wait_reboot(self, timeout_sec=180):

--- a/naughty-prune
+++ b/naughty-prune
@@ -74,10 +74,9 @@ def run(unused, verbose=False, **kwargs):
         execute("find", "naughty/", "-name", f"{number}-*", "-delete")
 
         # Create a pull request from these changes
-        title = "naughty: Close {0}: {1}".format(number, issue["title"])
+        title = f"naughty: Close {number}: {issue['title']}"
         days = int((now - updated) / SECONDS_PER_DAY)
-        body = "Known issue which has not occurred in {0} days\n\n{1}\n\nFixes #{2}".format(
-            days, issue["title"], number)
+        body = f"Known issue which has not occurred in {days} days\n\n{issue['title']}\n\nFixes #{number}"
         branch = task.branch(number, f"{title}\n\n{body}", pathspec="naughty/", **kwargs)
 
         if branch:

--- a/npm-update
+++ b/npm-update
@@ -86,7 +86,7 @@ def run(context, verbose=False, **kwargs):
                 for pkg in packages.split(", "):
                     pending_updates.append(pkg)
                     if task.verbose:
-                        sys.stderr.write("Ignoring '{0}' as there is pending PR #{1}\n".format(pkg, issue["number"]))
+                        sys.stderr.write(f"Ignoring '{pkg}' as there is pending PR #{issue['number']}\n")
 
     package_json_path = os.path.join(BASE_DIR, "package.json")
     old = read_package_json(package_json_path)

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -111,7 +111,7 @@ def main(**kwargs):
         ret = ret[0]
 
     if ret:
-        sys.stderr.write("{0}: {1}\n".format(task["name"], ret))
+        sys.stderr.write(f"{task['name']}: {ret}\n")
 
     sys.exit(ret and 1 or 0)
 
@@ -164,7 +164,7 @@ def report_finish(ret, name, context, issue, duration, dry=False):
     # Note that we check whether pass or fail ... this is because
     # the task is considered "done" until a human comes through and
     # triggers it again by unchecking the box.
-    item = "{0} {1}".format(name, context or "").strip()
+    item = f"{name} {context or ''}".strip()
     checklist = github.Checklist(issue["body"])
     checklist.check(item, result == "Failed" and "FAIL" or True)
 
@@ -185,7 +185,7 @@ def run(context, function, **kwargs):
         if not issue:
             return f"No such issue: {number}"
         elif issue["title"].startswith("WIP:"):
-            return "Issue is work in progress: {0}: {1}\n".format(number, issue["title"])
+            return f"Issue is work in progress: {number}: {issue['title']}\n"
         issue["number"] = int(number)
         kwargs["issue"] = issue
         kwargs["title"] = issue["title"]
@@ -370,7 +370,7 @@ def pull(branch, body=None, issue=None, base=None, labels=['bot'], run_tests=Tru
 
         # Make sure we return the updated pull data
         for retry in range(20):
-            new_data = api.get("pulls/{}".format(pull["number"]))
+            new_data = api.get(f"pulls/{pull['number']}")
             if pull["head"]["sha"] != new_data["head"]["sha"]:
                 pull = new_data
                 break
@@ -383,7 +383,7 @@ def pull(branch, body=None, issue=None, base=None, labels=['bot'], run_tests=Tru
 
 def label(issue, labels=['bot']):
     try:
-        resource = "issues/{0}/labels".format(issue["number"])
+        resource = f"issues/{issue['number']}/labels"
     except TypeError:
         resource = f"issues/{issue}/labels"
     return api.post(resource, labels)
@@ -391,7 +391,7 @@ def label(issue, labels=['bot']):
 
 def labels_of_pull(pull):
     if "labels" not in pull:
-        pull["labels"] = api.get("issues/{0}/labels".format(pull["number"]))
+        pull["labels"] = api.get(f"issues/{pull['number']}/labels")
     return [label["name"] for label in pull["labels"]]
 
 
@@ -409,7 +409,7 @@ def comment(issue, comment, dry: bool = False) -> 'dict[str, object]':
 
 
 def comment_done(issue, name, clean, branch, context=None, dry: bool = False) -> None:
-    message = "{0} {1} done: {2}/commits/{3}".format(name, context or "", clean, branch)
+    message = f"{name} {context or ''} done: {clean}/commits/{branch}"
     comment(issue, message, dry=dry)
 
 

--- a/task/github.py
+++ b/task/github.py
@@ -252,13 +252,8 @@ class GitHub(object):
         heads = {}
         for (header, value) in response.getheaders():
             heads[header.lower()] = value
-        self.log.write('{0} - - [{1}] "{2} {3} HTTP/1.1" {4} -\n'.format(
-            self.url.netloc,
-            time.asctime(),
-            method,
-            resource,
-            response.status
-        ))
+        self.log.write(
+            f'{self.url.netloc} - - [{time.asctime()}] "{method} {resource} HTTP/1.1" {response.status} -\n')
         return {
             "status": response.status,
             "reason": response.reason,
@@ -385,7 +380,8 @@ class GitHub(object):
         count = 100
         label = ",".join(labels)
         if since:
-            since = "&since={0}".format(time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(since)))
+            now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(since))
+            since = f"&since={now}"
         else:
             since = ""
 
@@ -415,7 +411,7 @@ class Checklist(object):
         if isinstance(check, str):
             status = check + ": "
             check = False
-        return " * [{0}] {1}{2}".format(check and "x" or " ", status, item)
+        return f" * [{check and 'x' or ' '}] {status}{item}"
 
     @staticmethod
     def parse_line(line):

--- a/test-failure-policy
+++ b/test-failure-policy
@@ -227,7 +227,7 @@ def update_known_issue(api, number, err, context):
                         # only keep the last 10
                         if len(occurrences) > 10:
                             occurrences.pop(0)
-                        parts[part_idx] = "{0}{1}{2}".format(latest[0], latest_occurrences, "\n".join(occurrences))
+                        parts[part_idx] = f"{latest[0]}{latest_occurrences}{'\n'.join(occurrences)}"
                         updated = True
                     break
 
@@ -261,7 +261,7 @@ Times recorded: 1
 
                 body = "<hr>\n".join(parts)
 
-            return api.patch("issues/comments/{0}".format(comment['id']), {"body": body})
+            return api.patch(f"issues/comments/{comment['id']}", {"body": body})
 
     # create a new comment, since we didn't find one to update
 

--- a/tests-policy
+++ b/tests-policy
@@ -250,7 +250,7 @@ def update_known_issue(api, number, err, details, context, timestamp=None):
                         # only keep the last 10
                         if len(occurrences) > 10:
                             occurrences.pop(0)
-                        parts[part_idx] = "{0}{1}{2}".format(latest[0], latest_occurrences, "\n".join(occurrences))
+                        parts[part_idx] = f"{latest[0]}{latest_occurrences}{'\n'.join(occurrences)}"
                         updated = True
                     break
 
@@ -284,7 +284,7 @@ Times recorded: 1
 
                 body = "<hr>\n".join(parts)
 
-            return api.patch("issues/comments/{0}".format(comment['id']), {"body": body})
+            return api.patch(f"issues/comments/{comment['id']}", {"body": body})
 
     # create a new comment, since we didn't find one to update
 
@@ -330,7 +330,7 @@ def post_github(api, number, output, image):
         if statuses:
             for status in statuses:
                 if status["context"] == context:
-                    link = "revision {0}, [logs]({1})".format(revision, status["target_url"])
+                    link = f"revision {revision}, [logs]({status['target_url']})"
                     break
     update_known_issue(api, number, output, link, context)
 

--- a/tests-scan
+++ b/tests-scan
@@ -321,7 +321,7 @@ def update_status(api, revision, context, last, changes):
         if not errors:
             return True
         for error in response.get("errors", []):
-            sys.stderr.write("{0}: {1}\n".format(revision, error.get('message', json.dumps(error))))
+            sys.stderr.write(f"{revision}: {error.get('message', json.dumps(error))}\n")
             sys.stderr.write(json.dumps(changes))
         return False
     return True

--- a/tests-trigger
+++ b/tests-trigger
@@ -65,7 +65,7 @@ def trigger_pull(api, opts):
             # also allow override with --force or --requeue
             if not (manual_testing or opts.force) and not (queued and opts.requeue):
                 if not all:
-                    sys.stderr.write("{0}: isn't in triggerable state (is: {1})\n".format(context, status["state"]))
+                    sys.stderr.write(f"{context}: isn't in triggerable state (is: {status['state']})\n")
                     ret = 1
                 continue
         sys.stderr.write(f"{context}: triggering on {target}\n")


### PR DESCRIPTION
ruff 0.3.1 (which we will get with the next tasks container refresh) starts complaining about some .format() usages.

---

See [this test run](https://github.com/cockpit-project/cockpituous/actions/runs/8186987774/job/22386529483?pr=586#step:7:361), which was running against a locally (in the workflow) refreshed tasks container.

Our integration test already exercises PRs, image refresh etc., but I still triggered two tests for good measure.