### PR TITLE
lib: Add $COCKPIT_IMAGES_DATA_DIR env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ For running and debugging the images:
 ## Image location
 
 Downloaded images are stored into ~/.cache/cockpit-images/ by default. If you
-want to change that, you can set the `cockpit.bots.images-data-dir` variable
-with `git config` to a directory where to store the pristine virtual machine
-images.  For example:
+want to change that, you can set `$COCKPIT_IMAGES_DATA_DIR` or the
+`cockpit.bots.images-data-dir` variable with `git config` to a directory where
+to store the pristine virtual machine images.  For example:
 
     git config cockpit.bots.images-data-dir /srv/cockpit/images
 

--- a/lib/directories.py
+++ b/lib/directories.py
@@ -61,9 +61,11 @@ def get_images_data_dir() -> str:
     global _images_data_dir
 
     if _images_data_dir is None:
-        _images_data_dir = get_git_config('--type=path', 'cockpit.bots.images-data-dir')
-
+        _images_data_dir = os.getenv('COCKPIT_IMAGES_DATA_DIR')
         if _images_data_dir is None:
-            _images_data_dir = xdg_cache_home('cockpit-images')
+            _images_data_dir = get_git_config('--type=path', 'cockpit.bots.images-data-dir')
+
+            if _images_data_dir is None:
+                _images_data_dir = xdg_cache_home('cockpit-images')
 
     return _images_data_dir


### PR DESCRIPTION
Similarly to commit 85b0db4a0bfd5c and commit 6b7864a1e6d76b, this lets us configure the image cache volume in one place (job-runner.toml), instead of having to hardcode it in the tasks Containerfile. This will replace
https://github.com/cockpit-project/cockpituous/blob/accb1fdc6a/tasks/Containerfile#L73