### PR TITLE
job-runner: Run job container with --init

### DIFF
--- a/lib/aio/job.py
+++ b/lib/aio/job.py
@@ -84,6 +84,8 @@ async def run_container(job: Job, subject: Subject, ctx: JobContext, log: LogStr
 
         args = [
             *ctx.container_cmd, 'run',
+            # we run arbitrary commands in that container, which aren't prepared for being pid 1; reap zombies
+            '--init',
             *ctx.container_run_args,
             f'--cidfile={cidfile}',
             *(f'--env={k}={v}' for k, v in job.env.items()),


### PR DESCRIPTION
We run arbitrary commands in these job containers. These don't expect to be PID 1 and be responsible for reaping zombies. This leads to e.g. image-refresh timeouts as when qemu finishes, the process remains around as 'Z' indefinitively, and waiting for it to finish times out.

Fix this by using `podman run --init`, which inserts a minimal pid 1.

Fixes #6036

 * [ ] FAIL: image-refresh debian-stable