### PR TITLE
tests-scan: don't 'job'-ify other-repo jobs

### DIFF
--- a/tests-scan
+++ b/tests-scan
@@ -225,8 +225,9 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
             "sha": job.revision,
             "ref": job.ref,
             "name": job.name,
-            # future job-runner format; once everything moved over, remove the stuff above
-            "job": {
+
+            # job-runner doesn't support this yet...
+            "job": None if job.repo != options.repo else {
                 "repo": job.repo,
                 "sha": job.revision,
                 "context": job.context,


### PR DESCRIPTION
job-runner doesn't support running jobs from other repositories, so don't emit `'job': { ... }` objects for those.