### PR TITLE
image-refresh: Unbreak image-diff

### DIFF
--- a/image-refresh
+++ b/image-refresh
@@ -55,7 +55,7 @@ def image_refresh(image: str, **kwargs: Any):
 
         # download the current image, for comparing them; that may not exist yet for newly introduced images
         if run('./image-download', image, check=False) == 0:
-            old_image = f'{BOTS_DIR}/images/{image}'
+            old_image = os.path.realpath(f'{BOTS_DIR}/images/{image}')
         else:
             old_image = None
 


### PR DESCRIPTION
Commit 788da12845f7d dropped the realpath() around resolving the old image. But that's crucial, as after calling `image-create`, the link will point to the *new* image, and thus image-diff will compare the image to itself. That caused all images to appear as "nothing changed" since then.

-----

See for  example the [recent F39 refresh](https://cockpit-logs.us-east-1.linodeobjects.com/image-refresh-fedora-39-20240305-223721-85b0db4a-image-refresh-fedora-39/log.html).

 * [x] image-refresh debian-testing