### PR TITLE
testmap: Declare empty cockpituous tests

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -34,6 +34,10 @@ REPO_BRANCH_CONTEXT = {
         # currently no tests outside of GitHub actions, but declares primary branch
         'main': [],
     },
+    'cockpit-project/cockpituous': {
+        # no real tests on our infra, but used in cockpituous' own integration tests
+        'main': [],
+    },
     'cockpit-project/cockpit': {
         'main': [
             *contexts('arch', COCKPIT_SCENARIOS),


### PR DESCRIPTION
This is going to be useful to write an integration test for cross-project testing in cockpituous' `run-local.sh`. That at least needs figuring out the default branch, which requires an entry in the test map.

----

This blocks https://github.com/cockpit-project/cockpituous/pull/593