### PR TITLE
tests-scan: Add "image-download" secret

### DIFF
--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -282,7 +282,7 @@ class TestTestsScan(unittest.TestCase):
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
                 "target": "stable-1.0",
                 "container": "supertasks",
-                "secrets": ["github-token"],
+                "secrets": ["github-token", "image-download"],
                 "env": {
                     "BASE_BRANCH": "stable-1.0",
                     "COCKPIT_BOTS_REF": "main",
@@ -338,7 +338,7 @@ class TestTestsScan(unittest.TestCase):
                 },
                 # project/repo doesn't have a custom container name file
                 "container": None,
-                "secrets": ["github-token"],
+                "secrets": ["github-token", "image-download"],
                 "env": {
                     "COCKPIT_BOTS_REF": "main",
                     "TEST_OS": "fedora",
@@ -389,7 +389,7 @@ class TestTestsScan(unittest.TestCase):
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
                 "target": "stable-1.0",
                 "container": "supertasks",
-                "secrets": ["github-token"],
+                "secrets": ["github-token", "image-download"],
                 "env": {
                     "BASE_BRANCH": "stable-1.0",
                     "COCKPIT_BOTS_REF": "main",

--- a/tests-scan
+++ b/tests-scan
@@ -235,8 +235,8 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
                 "slug": slug,
                 "env": env,
                 "container": job.container,
-                # for updating naughty trackers
-                "secrets": ["github-token"],
+                # for updating naughty trackers and downloading private images
+                "secrets": ["github-token", "image-download"],
             }
         }
 


### PR DESCRIPTION
So that job containers can download private images (RHEL). This secret gets defined in https://github.com/cockpit-project/cockpituous/pull/594