### PR TITLE
tests-scan: re-enable cross-project 'job' creation

### DIFF
--- a/job-runner.toml
+++ b/job-runner.toml
@@ -50,6 +50,7 @@ driver='github'
 [forge.github]
 clone-url = 'https://github.com/'
 api-url = 'https://api.github.com/'
+content-url = 'https://raw.githubusercontent.com/'
 post = true  # whether to post statuses, open issues, etc.
 user-agent = 'job-runner (cockpit-project/bots)'
 # (at least) one of `token` or `post = false` must be set

--- a/lib/aio/abc.py
+++ b/lib/aio/abc.py
@@ -40,6 +40,10 @@ class Subject(NamedTuple):
     def clone_url(self) -> URL:
         return self.forge.clone / self.repo
 
+    @property
+    def content_url(self) -> URL:
+        return self.forge.content / self.repo
+
 
 class Status:
     link: str
@@ -50,6 +54,7 @@ class Status:
 
 class Forge:
     clone: URL
+    content: URL
 
     async def resolve_subject(self, spec: SubjectSpecification) -> Subject:
         raise NotImplementedError
@@ -61,6 +66,9 @@ class Forge:
         raise NotImplementedError
 
     async def open_issue(self, repo: str, issue: JsonObject) -> None:
+        raise NotImplementedError
+
+    async def read_file(self, subject: Subject, filename: str) -> str | None:
         raise NotImplementedError
 
     @classmethod

--- a/lib/aio/abc.py
+++ b/lib/aio/abc.py
@@ -18,7 +18,16 @@ from typing import AsyncContextManager, NamedTuple, Self
 
 from yarl import URL
 
-from .jsonutil import JsonObject
+from .jsonutil import JsonObject, get_int, get_str
+
+
+class SubjectSpecification:
+    def __init__(self, obj: JsonObject) -> None:
+        self.repo = get_str(obj, 'repo')
+        self.sha = get_str(obj, 'sha', None)
+        self.pull = get_int(obj, 'pull', None)
+        self.branch = get_str(obj, 'branch', None)
+        self.target = get_str(obj, 'target', None)
 
 
 class Subject(NamedTuple):
@@ -35,9 +44,7 @@ class Status:
 
 
 class Forge:
-    async def resolve_subject(
-        self, repo: str, sha: str | None, pull_nr: int | None, branch: str | None, target: str | None
-    ) -> Subject:
+    async def resolve_subject(self, spec: SubjectSpecification) -> Subject:
         raise NotImplementedError
 
     async def check_pr_changed(self, repo: str, pull_nr: int, expected_sha: str) -> str | None:

--- a/lib/aio/abc.py
+++ b/lib/aio/abc.py
@@ -31,9 +31,14 @@ class SubjectSpecification:
 
 
 class Subject(NamedTuple):
-    clone_url: URL
+    forge: 'Forge'
+    repo: str
     sha: str
     rebase: str | None = None
+
+    @property
+    def clone_url(self) -> URL:
+        return self.forge.clone / self.repo
 
 
 class Status:
@@ -44,6 +49,8 @@ class Status:
 
 
 class Forge:
+    clone: URL
+
     async def resolve_subject(self, spec: SubjectSpecification) -> Subject:
         raise NotImplementedError
 

--- a/lib/aio/github.py
+++ b/lib/aio/github.py
@@ -146,19 +146,19 @@ class GitHub(Forge, contextlib.AsyncExitStack):
     async def resolve_subject(self, spec: SubjectSpecification) -> Subject:
         if spec.pull is not None:
             pull = await self.get_obj(f'repos/{spec.repo}/pulls/{spec.pull}')
-            return Subject(clone_url,
+            return Subject(self, spec.repo,
                            # mypy needs some help here.  See https://github.com/python/mypy/issues/16659
                            spec.sha if spec.sha else get_str(get_dict(pull, 'head'), 'sha'),
                            spec.target or get_str(get_dict(pull, 'base'), 'ref'))
 
         elif spec.sha is not None:
-            return Subject(clone_url, spec.sha, spec.target)
+            return Subject(self, spec.repo, spec.sha, spec.target)
 
         else:
             branch = spec.branch or get_str(await self.get_obj(f'repos/{spec.repo}'), 'default_branch')
 
             with get_nested(await self.get_obj(f'repos/{spec.repo}/git/refs/heads/{branch}'), 'object') as object:
-                return Subject(clone_url, get_str(object, 'sha'), spec.target)
+                return Subject(self, spec.repo, get_str(object, 'sha'), spec.target)
 
 
 class GitHubStatus(Status):

--- a/lib/aio/job.py
+++ b/lib/aio/job.py
@@ -162,7 +162,11 @@ async def run_job(job: Job, ctx: JobContext) -> None:
         logger.info('Log: %s', log.url)
 
         try:
-            log.start(f'{title}\nRunning on: {platform.node()}\n\nJob(' + json.dumps(job.__dict__, indent=4) + ')\n')
+            log.start(
+                f'{title}\n\n'
+                f'Running on: {platform.node()}\n\n'
+                f'Job({json.dumps(job, default=lambda obj: obj.__dict__, indent=4)})\n'
+            )
             await status.post('pending', 'In progress')
 
             tasks = {run_container(job, subject, ctx, log)}

--- a/lib/aio/jobcontext.py
+++ b/lib/aio/jobcontext.py
@@ -68,6 +68,7 @@ class JobContext(contextlib.AsyncExitStack):
         except FileNotFoundError as exc:
             if missing_ok:
                 logger.debug('No %s configuration found at %s', name, str(path))
+                return
             else:
                 sys.exit(f'{path}: {exc}')
         except OSError as exc:

--- a/lib/aio/jsonutil.py
+++ b/lib/aio/jsonutil.py
@@ -83,6 +83,15 @@ def get_dict(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | J
     return _get(obj, lambda v: typechecked(v, dict), key, default)
 
 
+def get_object(
+    obj: JsonObject,
+    key: str,
+    constructor: Callable[[JsonObject], T],
+    default: Union[DT, _Empty] = _empty
+) -> Union[DT, T]:
+    return _get(obj, lambda v: constructor(typechecked(v, dict)), key, default)
+
+
 def get_str_map(obj: JsonObject, key: str, default: DT | _Empty = _empty) -> DT | Mapping[str, str]:
     def as_str_map(value: JsonValue) -> Mapping[str, str]:
         return {key: typechecked(value, str) for key, value in typechecked(value, dict).items()}

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -221,7 +221,7 @@ async def test_github_pr_lookup(service: GitHubService, api: GitHub) -> None:
 
     # Look up the sha in the PR via the REST API
     subject = await api.resolve_subject(SubjectSpecification({'repo': 'owner/repo', 'pull': pull_nr}))
-    assert subject == (service.CLONE_URL / repo, sha, 'main')
+    assert subject == (api, repo, sha, 'main')
     service.assert_hits(1, 1)
 
     # The next thing that happens is that we poll this API a lot

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -10,6 +10,7 @@ import pytest
 from aioresponses import CallbackResult, aioresponses
 from yarl import URL
 
+from lib.aio.abc import SubjectSpecification
 from lib.aio.github import GitHub
 from lib.aio.jobcontext import JobContext
 from lib.aio.jsonutil import JsonObject, JsonValue, json_merge_patch
@@ -219,7 +220,7 @@ async def test_github_pr_lookup(service: GitHubService, api: GitHub) -> None:
     })
 
     # Look up the sha in the PR via the REST API
-    subject = await api.resolve_subject('owner/repo', None, pull_nr, None, None)
+    subject = await api.resolve_subject(SubjectSpecification({'repo': 'owner/repo', 'pull': pull_nr}))
     assert subject == (service.CLONE_URL / repo, sha, 'main')
     service.assert_hits(1, 1)
 

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -21,6 +21,7 @@ from lib.aio.util import LRUCache
 class GitHubService:
     CLONE_URL = URL('http://github.test/')
     API_URL = URL('http://api.github.test/')
+    CONTENT_URL = URL('http://content.github.test/')
     TOKEN = 'token_ABCDEFG'
     USER_AGENT = __file__  # or any magic unique string
 
@@ -34,6 +35,7 @@ class GitHubService:
         self.config: JsonObject = {
             'api-url': str(self.API_URL),
             'clone-url': str(self.CLONE_URL),
+            'content-url': str(self.CONTENT_URL),
             'post': True,
             'token': self.TOKEN,
             'user-agent': self.USER_AGENT,

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -82,8 +82,6 @@ class Handler(MockHandler):
         elif self.path.endswith("/issues"):
             issues = self.server.data.get('issues', [])
             self.replyJson(issues)
-        elif self.path == "/project/repo/abcdef/.cockpit-ci/container":
-            self.replyData("supertasks")
         else:
             self.send_error(404, 'Mock Not Found: ' + self.path)
 
@@ -281,7 +279,6 @@ class TestTestsScan(unittest.TestCase):
                 "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
-                "container": "supertasks",
                 "secrets": ["github-token", "image-download"],
                 "env": {
                     "BASE_BRANCH": "stable-1.0",
@@ -336,8 +333,6 @@ class TestTestsScan(unittest.TestCase):
                     "title": "Tests failed on 9988aa",
                     "labels": ["nightly"],
                 },
-                # project/repo doesn't have a custom container name file
-                "container": None,
                 "secrets": ["github-token", "image-download"],
                 "env": {
                     "COCKPIT_BOTS_REF": "main",
@@ -388,7 +383,6 @@ class TestTestsScan(unittest.TestCase):
                 "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
-                "container": "supertasks",
                 "secrets": ["github-token", "image-download"],
                 "env": {
                     "BASE_BRANCH": "stable-1.0",

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -279,6 +279,7 @@ class TestTestsScan(unittest.TestCase):
                 "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
+                "command-subject": None,
                 "secrets": ["github-token", "image-download"],
                 "env": {
                     "BASE_BRANCH": "stable-1.0",
@@ -333,6 +334,7 @@ class TestTestsScan(unittest.TestCase):
                     "title": "Tests failed on 9988aa",
                     "labels": ["nightly"],
                 },
+                "command-subject": None,
                 "secrets": ["github-token", "image-download"],
                 "env": {
                     "COCKPIT_BOTS_REF": "main",
@@ -383,6 +385,7 @@ class TestTestsScan(unittest.TestCase):
                 "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
+                "command-subject": None,
                 "secrets": ["github-token", "image-download"],
                 "env": {
                     "BASE_BRANCH": "stable-1.0",
@@ -427,14 +430,30 @@ class TestTestsScan(unittest.TestCase):
             f'cd make-checkout-workdir && TEST_OS=fedora BASE_BRANCH={branch} COCKPIT_BOTS_REF=main '
             'TEST_SCENARIO=nightly ../tests-invoke --pull-number 1 --revision abcdef --repo project/repo"')
 
+        slug_repo_branch = repo_branch.replace('@', '-').replace('/', '-')
+
         assert request == {
             "command": expected_command,
             "type": "test",
             "sha": "abcdef",
             "ref": branch,
             "name": f"pull-{self.pull_number}",
-            # job-runner currently disabled for cross-project tests (commit c377eb892)
-            "job": None,
+            "job": {
+                "context": f"fedora/nightly@{repo_branch}",
+                "repo": "project/repo",
+                "pull": int(self.pull_number),
+                "report": None,
+                "sha": "abcdef",
+                "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly-{slug_repo_branch}",
+                "command-subject": {"repo": "cockpit-project/cockpituous", "branch": branch},
+                "secrets": ["github-token", "image-download"],
+                "env": {
+                    "BASE_BRANCH": branch,
+                    "COCKPIT_BOTS_REF": "main",
+                    "TEST_OS": "fedora",
+                    "TEST_SCENARIO": "nightly",
+                }
+            }
         }
 
     def test_amqp_sha_pr_cross_project_default_branch(self):

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -281,7 +281,6 @@ class TestTestsScan(unittest.TestCase):
                 "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
-                "target": "stable-1.0",
                 "container": "supertasks",
                 "secrets": ["github-token", "image-download"],
                 "env": {
@@ -332,7 +331,6 @@ class TestTestsScan(unittest.TestCase):
                 "repo": "project/repo",
                 "sha": "9988aa",
                 "slug": "pull-0-9988aa-20240102-030405-fedora-nightly",
-                "target": None,
                 "pull": None,
                 "report": {
                     "title": "Tests failed on 9988aa",
@@ -390,7 +388,6 @@ class TestTestsScan(unittest.TestCase):
                 "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
-                "target": "stable-1.0",
                 "container": "supertasks",
                 "secrets": ["github-token", "image-download"],
                 "env": {

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -268,7 +268,7 @@ class TestTestsScan(unittest.TestCase):
             " COCKPIT_BOTS_REF=main TEST_SCENARIO=nightly ../tests-invoke --pull-number"
             f" {self.pull_number} --revision {self.revision} --repo {self.repo}\"")
 
-        self.assertEqual(request, {
+        assert request == {
             "command": expected_command,
             "type": "test",
             "sha": "abcdef",
@@ -278,6 +278,7 @@ class TestTestsScan(unittest.TestCase):
                 "context": "fedora/nightly",
                 "repo": "project/repo",
                 "pull": int(self.pull_number),
+                "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
                 "target": "stable-1.0",
@@ -290,7 +291,7 @@ class TestTestsScan(unittest.TestCase):
                     "TEST_SCENARIO": "nightly",
                 }
             }
-        })
+        }
 
     # mock time for predictable test name
     @unittest.mock.patch("time.strftime", return_value="20240102-030405")
@@ -320,7 +321,7 @@ class TestTestsScan(unittest.TestCase):
             'cd make-checkout-workdir && TEST_OS=fedora COCKPIT_BOTS_REF=main '
             'TEST_SCENARIO=nightly ../tests-invoke --revision 9988aa --repo project/repo"')
         self.maxDiff = None
-        self.assertEqual(request, {
+        assert request == {
             "command": expected_command,
             "type": "test",
             "sha": "9988aa",
@@ -332,6 +333,7 @@ class TestTestsScan(unittest.TestCase):
                 "sha": "9988aa",
                 "slug": "pull-0-9988aa-20240102-030405-fedora-nightly",
                 "target": None,
+                "pull": None,
                 "report": {
                     "title": "Tests failed on 9988aa",
                     "labels": ["nightly"],
@@ -345,7 +347,7 @@ class TestTestsScan(unittest.TestCase):
                     "TEST_SCENARIO": "nightly",
                 }
             }
-        })
+        }
 
     # mock time for predictable test name
     @unittest.mock.patch("time.strftime", return_value="20240102-030405")
@@ -375,7 +377,7 @@ class TestTestsScan(unittest.TestCase):
             './make-checkout --verbose --repo=project/repo --rebase=stable-1.0 abcdef && '
             'cd make-checkout-workdir && TEST_OS=fedora BASE_BRANCH=stable-1.0 COCKPIT_BOTS_REF=main '
             'TEST_SCENARIO=nightly ../tests-invoke --pull-number 1 --revision abcdef --repo project/repo"')
-        self.assertEqual(request, {
+        assert request == {
             "command": expected_command,
             "type": "test",
             "sha": "abcdef",
@@ -385,6 +387,7 @@ class TestTestsScan(unittest.TestCase):
                 "context": "fedora/nightly",
                 "repo": "project/repo",
                 "pull": int(self.pull_number),
+                "report": None,
                 "sha": "abcdef",
                 "slug": f"pull-{self.pull_number}-abcdef-20240102-030405-fedora-nightly",
                 "target": "stable-1.0",
@@ -397,7 +400,7 @@ class TestTestsScan(unittest.TestCase):
                     "TEST_SCENARIO": "nightly",
                 }
             }
-        })
+        }
 
     def do_test_tests_invoke(self, attachments_url, expected_logs_url):
         repo = "cockpit-project/cockpit"

--- a/tests-scan
+++ b/tests-scan
@@ -230,7 +230,7 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
             "job": None if job.repo != options.repo else {
                 "repo": job.repo,
                 "sha": job.revision,
-                "context": job.context,
+                "context": job.github_context,
                 "target": job.base,
                 "slug": slug,
                 "env": env,

--- a/tests-scan
+++ b/tests-scan
@@ -119,7 +119,6 @@ class Job(NamedTuple):
     repo: str
     bots_ref: 'str | None'
     github_context: str
-    container: 'str | None'
 
 
 # Prepare a human readable output
@@ -239,7 +238,6 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
                 },
                 "slug": slug,
                 "env": env,
-                "container": job.container,
                 # for updating naughty trackers and downloading private images
                 "secrets": ["github-token", "image-download"],
             }
@@ -365,7 +363,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
         statuses = api.statuses(revision)
         login = pull["head"]["user"]["login"]
         base = pull.get("base", {}).get("ref")  # The branch this pull request targets (None for direct SHA triggers)
-        merge_sha = pull.get("merge_commit_sha", revision)
 
         allowed = login in ALLOWLIST
 
@@ -426,10 +423,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                 checkout_ref = ref
                 if project != repo:
                     checkout_ref = testmap.get_default_branch(project)
-                    project_api = github.GitHub(repo=project)
-                    container = project_api.fetch_file(checkout_ref, '.cockpit-ci/container')
-                else:
-                    container = api.fetch_file(merge_sha, '.cockpit-ci/container')
 
                 if base != branch:
                     checkout_ref = branch
@@ -457,7 +450,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                     project,
                     bots_ref,
                     context,
-                    container,
                 )
 
 

--- a/tests-scan
+++ b/tests-scan
@@ -205,7 +205,8 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
     if command:
         priority = min(job.priority, distributed_queue.MAX_PRIORITY)
 
-        slug = f"{job.name}-{job.revision[:8]}-{time.strftime('%Y%m%d-%H%M%S')}-{job.context.replace('/', '-')}"
+        slug_suffix = job.github_context.replace('/', '-').replace('@', '-')
+        slug = f"{job.name}-{job.revision[:8]}-{time.strftime('%Y%m%d-%H%M%S')}-{slug_suffix}"
         (image, _, scenario) = job.context.partition("/")
 
         env = {

--- a/tests-scan
+++ b/tests-scan
@@ -228,7 +228,7 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
 
             # job-runner doesn't support this yet...
             "job": None if job.repo != options.repo else {
-                "repo": job.repo,
+                "repo": options.repo,
                 "sha": job.revision,
                 "context": job.github_context,
                 "target": job.base,

--- a/tests-scan
+++ b/tests-scan
@@ -232,6 +232,11 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
                 "sha": job.revision,
                 "context": job.github_context,
                 "target": job.base,
+                "pull": job.number or None,  # job.number uses 0 to mean 'None'
+                "report": None if job.number else {
+                    "title": f"Tests failed on {job.revision}",
+                    "labels": ["nightly"],
+                },
                 "slug": slug,
                 "env": env,
                 "container": job.container,
@@ -239,17 +244,6 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
                 "secrets": ["github-token", "image-download"],
             }
         }
-
-        # report issue for nightly runs
-        if isinstance(body['job'], dict):
-            if body["job"] is not None:
-                if job.number == 0:
-                    body["job"]["report"] = {
-                        "title": f"Tests failed on {job.revision}",
-                        "labels": ["nightly"],
-                    }
-                else:
-                    body["job"]["pull"] = job.number
 
         queue = 'rhel' if is_internal_context(job.context) else 'public'
         channel.basic_publish('', queue, json.dumps(body), properties=pika.BasicProperties(priority=priority))

--- a/tests-scan
+++ b/tests-scan
@@ -391,8 +391,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             for context in build_policy(repo, contexts).get(base, []):
                 todos[context] = {}
 
-        container = api.fetch_file(merge_sha, '.cockpit-ci/container')
-
         # there are 3 different HEADs
         # ref:    the PR or SHA that we are testing
         # base:   the target branch of that PR (None for direct SHA trigger)
@@ -428,6 +426,11 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                 checkout_ref = ref
                 if project != repo:
                     checkout_ref = testmap.get_default_branch(project)
+                    project_api = github.GitHub(repo=project)
+                    container = project_api.fetch_file(checkout_ref, '.cockpit-ci/container')
+                else:
+                    container = api.fetch_file(merge_sha, '.cockpit-ci/container')
+
                 if base != branch:
                     checkout_ref = branch
 

--- a/tests-scan
+++ b/tests-scan
@@ -225,9 +225,7 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
             "sha": job.revision,
             "ref": job.ref,
             "name": job.name,
-
-            # job-runner doesn't support this yet...
-            "job": None if job.repo != options.repo else {
+            "job": {
                 "repo": options.repo,
                 "sha": job.revision,
                 "context": job.github_context,
@@ -235,6 +233,10 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
                 "report": None if job.number else {
                     "title": f"Tests failed on {job.revision}",
                     "labels": ["nightly"],
+                },
+                "command-subject": None if job.repo == options.repo else {
+                    "repo": job.repo,
+                    "branch": job.ref,
                 },
                 "slug": slug,
                 "env": env,

--- a/tests-scan
+++ b/tests-scan
@@ -232,7 +232,6 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
                 "repo": options.repo,
                 "sha": job.revision,
                 "context": job.github_context,
-                "target": job.base,
                 "pull": job.number or None,  # job.number uses 0 to mean 'None'
                 "report": None if job.number else {
                     "title": f"Tests failed on {job.revision}",


### PR DESCRIPTION
This should be mostly right.  I'm not 100% sure about this part, though:

```diff
+                    "branch": job.ref,
```

 - [x] Land https://github.com/cockpit-project/cockpituous/pull/593 before and run tests against it
 - [x] https://github.com/cockpit-project/cockpituous/pull/597