### PR TITLE
test-failure-policy: Avoid `\n` in f-string substitution

### DIFF
--- a/test-failure-policy
+++ b/test-failure-policy
@@ -227,7 +227,7 @@ def update_known_issue(api, number, err, context):
                         # only keep the last 10
                         if len(occurrences) > 10:
                             occurrences.pop(0)
-                        parts[part_idx] = f"{latest[0]}{latest_occurrences}{'\n'.join(occurrences)}"
+                        parts[part_idx] = f"{latest[0]}{latest_occurrences}" + '\n'.join(occurrences)
                         updated = True
                     break
 


### PR DESCRIPTION
That doesn't yet work in RHEL 9's Python 3.9:

    SyntaxError: f-string expression part cannot include a backslash

This broke naughty detection in tmt tests.

---

See e.g. https://artifacts.dev.testing-farm.io/ebf6a99c-6d58-4017-bba1-145a9d95684f/ or https://artifacts.dev.testing-farm.io/79e0df15-a10b-41a9-abed-146c6f8dbe28/

Triggering a few tests to make sure we catch some naughties.