### PR TITLE
naughty: Add variation of #5979

### DIFF
--- a/naughty/fedora-38/5979-virtinterfaced-crash-lookup-by-mac-udev-2
+++ b/naughty/fedora-38/5979-virtinterfaced-crash-lookup-by-mac-udev-2
@@ -1,0 +1,3 @@
+#* udevConnectListAllInterfaces*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/fedora-39/5979-virtinterfaced-crash-lookup-by-mac-udev-2
+++ b/naughty/fedora-39/5979-virtinterfaced-crash-lookup-by-mac-udev-2
@@ -1,0 +1,3 @@
+#* udevConnectListAllInterfaces*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/fedora-40/5979-virtinterfaced-crash-lookup-by-mac-udev-2
+++ b/naughty/fedora-40/5979-virtinterfaced-crash-lookup-by-mac-udev-2
@@ -1,0 +1,3 @@
+#* udevConnectListAllInterfaces*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.


### PR DESCRIPTION
This can also crash in udevConnectListAllInterfaces() instead of udevInterfaceLookupByMACString(), but it's the same root cause.

Fixes https://github.com/cockpit-project/cockpit-machines/issues/1490