### PR TITLE
run-queue: Extend queue capability check to job-runner

### DIFF
--- a/run-queue
+++ b/run-queue
@@ -100,8 +100,8 @@ def consume_task_queue(channel, amqp, declare_public_result, declare_rhel_result
     if statistics_queue and declare_stats_result.method.message_count > 0:
         # statistics queue is quick to process, always do that first
         queue = 'statistics'
-    elif os.path.exists('/dev/kvm') or os.getenv('COCKPIT_TESTMAP_INJECT'):
-        # only process test queues in capable environments: with KVM support, or during integration tests
+    elif os.path.exists('/dev/kvm') or os.getenv('JOB_RUNNER_CONFIG'):
+        # only process test queues in capable environments: with KVM or job-runner support
         queue = 'public'
         if redhat_network():
             # Try the rhel queue if the public queue is empty


### PR DESCRIPTION
With job-runner, the bits that actually need /dev/kvm don't run in the "queue monitor" task container any more, but in separate containers. We want to drop importing /dev/kvm into the monitor container [1], so extend the check to also accept the presence of a job-runner configuration.

With that we can drop the check for `COCKPIT_TESTMAP_INJECT` -- that was just a hack, and the cockpituous integration tests define `JOB_RUNNER_CONFIG` already.

[1] https://github.com/cockpit-project/cockpituous/pull/590

----

Tests are blocked on https://github.com/cockpit-project/cockpituous/pull/590 , as currently they use the cockpituous/main tests with the refreshed tasks container from that PR.