### PR TITLE
images: Relax Fedora rawhide cloud image name match

### DIFF
--- a/images/fedora-rawhide
+++ b/images/fedora-rawhide
@@ -1,1 +1,1 @@
-fedora-rawhide-16abb6b8c8bea997aff50e2727de651a98d1ca668a9421bf41c2352ea5e981db.qcow2
+fedora-rawhide-66fe51e3536a01ada943b61d6a65c8eb8198329ff68fe64adc8c464e532891f3.qcow2

--- a/images/scripts/fedora-rawhide.bootstrap
+++ b/images/scripts/fedora-rawhide.bootstrap
@@ -20,7 +20,7 @@
 set -eux
 
 URL='https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Cloud/x86_64/images/'
-IMAGE=$(curl -L -s "$URL"  | grep -o 'Fedora-Cloud-Base-Rawhide[^"]*qcow2' | tr -d '"' | tail -n1)
+IMAGE=$(curl -L -s "$URL"  | grep -o 'Fedora-Cloud-Base-[^"]*Rawhide[^"]*qcow2' | tr -d '"' | tail -n1)
 [ -n "$IMAGE" ]
 
 exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "$URL/$IMAGE"


### PR DESCRIPTION
The images were renamed to "Fedora-Cloud-Base-Generic.x86_64-Rawhide-….qcow2".

Fixes #6081

 * [x] image-refresh fedora-rawhide