### PR TITLE
cockpit-container-update: automate ci container update workflow

### DIFF
--- a/cockpit-container-update
+++ b/cockpit-container-update
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Update .cockpit-ci/container to the latest tasks container tag automatically
+
+import json
+import os
+import sys
+import urllib.request
+
+import task
+from lib.constants import BASE_DIR
+
+sys.dont_write_bytecode = True
+
+
+URL = 'https://quay.io/api/v1/repository/{}/tag/?onlyActiveTags=true'
+
+
+def fetch_tags(url):
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req) as response:
+        return json.loads(response.read().decode().strip())
+
+
+def run(context, verbose=False, **kwargs):
+    container = os.path.join('.cockpit-ci', 'container')
+    container_path = os.path.join(BASE_DIR, container)
+
+    with open(container_path) as fp:
+        content = fp.read()
+
+    container_uri, _, current_tag = content.strip().partition(':')
+
+    if not container_uri.startswith("quay.io"):
+        print("CI container not hosted on quay.io, skipping")
+        return
+
+    url = URL.format(container_uri.removeprefix("quay.io/"))
+    tags = fetch_tags(url)
+
+    # Strip latest tags
+    tags = [t for t in tags['tags'] if t['name'] != 'latest']
+    latest_image = sorted(tags, key=lambda x: x['start_ts'])[-1]
+    latest_tag = latest_image['name']
+    print(f"Latest discovered tag: '{latest_tag}'")
+
+    if current_tag == latest_tag:
+        print("CI container is already up to date, nothing to do")
+        return
+
+    with open(container_path, 'w') as fp:
+        fp.write(f"{container_uri}:{latest_tag}\n")
+
+    if not kwargs['dry']:
+        title = f".cockpit-ci: Update CI container to {latest_tag}"
+        branch = task.branch('cockpit-ci-container', title, pathspec=container, **kwargs)
+        kwargs["title"] = title
+        task.pull(branch, **kwargs)
+
+
+if __name__ == '__main__':
+    task.main(function=run, title="Update CI container for cockpit projects")


### PR DESCRIPTION
Similar to cockpit-lib-update the CI container can be periodically updated using a GitHub workflow (or something similar).

---

Ran it on my machines fork and it a PR!

https://github.com/jelly/cockpit-machines/actions/runs/8279777037
https://github.com/jelly/cockpit-machines/pull/2