### PR TITLE
lib: quote a type annotation for Python 3.6

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -278,7 +278,7 @@ def get_test_image(image: str) -> str:
     return image.replace("-distropkg", "")
 
 
-def split_context(context: str) -> tuple[str, int | None, str, str]:
+def split_context(context: str) -> 'tuple[str, int | None, str, str]':
     bots_pr = None
     repo_branch = ""
 


### PR DESCRIPTION
This is breaking testing farm runs, and it's going to take us a while to get those all moved over to the container approach, so quote it for now.