### PR TITLE
tests-scan: Restore "no-test" handling

### DIFF
--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -192,7 +192,8 @@ class TestTestsScan(unittest.TestCase):
         self.run_success_mock_pr(["--dry", "--context", self.context])
 
     def test_pull_number_human_readable(self):
-        self.run_success(["--dry", "-v", "--context", self.context], self.expected_human_output)
+        self.run_success(["--dry", "-v", "--context", self.context, "--pull-number", str(self.pull_number)],
+                         self.expected_human_output)
 
     def test_pull_data_human_readable(self):
         args = ["--dry", "-v", "--context", self.context,

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -51,6 +51,17 @@ GITHUB_DATA = {
         "labels": [],
         "updated_at": 0,
     },
+    # no-test PR
+    "/repos/project/repo/pulls/3": {
+        "title": "WIP stuff",
+        "number": 1,
+        "state": "open",
+        "body": "Don't run me yet",
+        "base": {"ref": "stable-1.0"},
+        "head": {"sha": "abcdef", "user": {"login": "cockpit-project"}},
+        "labels": [{"name": "no-test"}],
+        "updated_at": 0,
+    },
     "/repos/project/repo/commits/abcdef/status?page=1&per_page=100": {
         "state": "pending",
         "statuses": [],
@@ -78,7 +89,8 @@ class Handler(MockHandler):
         if self.path in self.server.data:
             self.replyJson(self.server.data[self.path])
         elif self.path.startswith('/repos/project/repo/pulls?'):
-            self.replyJson([self.server.data['/repos/project/repo/pulls/1']])
+            self.replyJson([self.server.data['/repos/project/repo/pulls/1'],
+                            self.server.data['/repos/project/repo/pulls/3']])
         elif self.path.endswith("/issues"):
             issues = self.server.data.get('issues', [])
             self.replyJson(issues)
@@ -174,6 +186,10 @@ class TestTestsScan(unittest.TestCase):
         args = ["--dry", "--pull-number", str(self.pull_number), "--context", self.context]
         self.run_success_mock_pr(args)
 
+    def test_notest_pull_number(self):
+        args = ["--dry", "--pull-number=3", "--context", self.context]
+        self.run_success(args, "")
+
     def test_unkown_pull_number(self):
         args = ["--dry", "--pull-number", "2", "--context", "fedora/nightly"]
         code, output, stderr = self.run_tests_scan(args)
@@ -194,6 +210,9 @@ class TestTestsScan(unittest.TestCase):
     def test_pull_number_human_readable(self):
         self.run_success(["--dry", "-v", "--context", self.context, "--pull-number", str(self.pull_number)],
                          self.expected_human_output)
+
+    def test_notest_human_readable(self):
+        self.run_success(["--dry", "-v", "--context", self.context, "--pull-number=3"], "")
 
     def test_pull_data_human_readable(self):
         args = ["--dry", "-v", "--context", self.context,

--- a/tests-scan
+++ b/tests-scan
@@ -144,8 +144,6 @@ def is_internal_context(context):
 
 
 def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
-    priority = min(job.priority, distributed_queue.MAX_PRIORITY)
-
     slug_suffix = job.github_context.replace('/', '-').replace('@', '-')
     slug = f"{job.name}-{job.revision[:8]}-{time.strftime('%Y%m%d-%H%M%S')}-{slug_suffix}"
     (image, _, scenario) = job.context.partition("/")
@@ -183,7 +181,7 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
 
     queue = 'rhel' if is_internal_context(job.context) else 'public'
     if channel:
-        channel.basic_publish('', queue, json.dumps(body), properties=pika.BasicProperties(priority=priority))
+        channel.basic_publish('', queue, json.dumps(body), properties=pika.BasicProperties(priority=job.priority))
         logging.info("Published job: %s", json.dumps(body["job"]))
     else:
         print(json.dumps(body['job']))
@@ -238,6 +236,7 @@ def prioritize(status, title, labels, priority, context, number, direct):
         else:
             update["description"] = github.NOT_TESTED_DIRECT if direct else github.NOT_TESTED
 
+    priority = min(priority, distributed_queue.MAX_PRIORITY)
     return [priority, update]
 
 

--- a/tests-scan
+++ b/tests-scan
@@ -108,7 +108,7 @@ def main():
 
 
 class Job(NamedTuple):
-    priority: str
+    priority: int
     name: str
     number: int
     revision: str
@@ -122,8 +122,6 @@ class Job(NamedTuple):
 
 # Prepare a human readable output
 def tests_human(job: Job, options: argparse.Namespace) -> str:
-    if not job.priority and not options.force:
-        return ""
     return "{name:11} {context:25} {revision:10} {priority:2}{repo}{bots_ref}{branches}".format(
         priority=job.priority,
         revision=job.revision[0:7],
@@ -350,7 +348,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             # will apply if the user pushes a new commit.
             status = todos[context]
             if not allowed and status.get("description", github.NO_TESTING) == github.NO_TESTING:
-                priority = github.NO_TESTING
+                priority = 0
                 changes = {"description": github.NO_TESTING, "context": context, "state": "pending"}
             else:
                 # with --amqp (as called from run-queue), trigger tests as NOT_TESTED, as they already get queued;
@@ -360,6 +358,9 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                     status, title, labels, baseline, context, number, direct=not opts.amqp
                 )
             if opts.dry or update_status(api, revision, context, status, changes):
+                if not priority and not opts.force:
+                    continue
+
                 checkout_ref = ref
                 if project != repo:
                     checkout_ref = testmap.get_default_branch(project)


### PR DESCRIPTION
The dropped `tests_invoke()` in commit 23a5f798466360 also cared about
skipping tests with priority == 0, so dropping that function caused
"no-test" PRs to still get tested.

Factorize this check into the main scanning function, so that
tests_human() and queue_tests() don't need to duplicate it.

Also fix the typing: Consistently handle `priority` as `int`, and fix
the bogus `priority = github.NO_TESTING` (which is a string constant).
That was the reason why the old `tests_invoke()` had to ignore TypeError
on int conversion.

Add a no-test PR to the unit test. Without the above fix, this caused
three tests to fail due to the unexpected queueing of PR #3. But also
add explicit human and JSON unit tests for a no-test  PR.

-----

I also tested this on https://github.com/martinpitt/cockpit-podman/pull/11 with a local testmap modification:
```diff
--- lib/testmap.py
+++ lib/testmap.py
@@ -87,7 +87,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel4edge',
         ],
     },
-    'cockpit-project/cockpit-podman': {
+    'martinpitt/cockpit-podman': {
         'main': [
             'arch',
             'rhel-8-10',
```

Now `./tests-scan --repo martinpitt/cockpit-podman -p 11` behaves correctly. Previously, it first said "skipping because it is no-test" and then queued them anyway.