### PR TITLE
run-queue: Don't ack failed commands

### DIFF
--- a/run-queue
+++ b/run-queue
@@ -187,6 +187,7 @@ def main():
   %s
 
 failed with exit code %i. Please check the container logs for details.""" % (cmd_str, p.returncode))
+            return 1
 
         channel.basic_ack(delivery_tag)
 


### PR DESCRIPTION
These are an infrastructure error which needs to be fixed. Instead of draining all test requests (which are easy to recover, though) and statistics update requests (which are a lot harder to recover), keep them in the queue. Either another runner will have more luck, or they keep getting kicked around until we fix things.

----

I messed up the recent container cleanup on OpenShift, and it ate our whole statistics queue without actually processing it. This also often causes abandoned test statuses (which are "pending" or "in progress") without ever finishing, when some random network/S3 error occurs.