### PR TITLE
tests-scan: remove concept of priority

### DIFF
--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -131,7 +131,7 @@ class TestTestsScan(unittest.TestCase):
         # expected human output for our standard mock PR #1 above
         self.expected_human_output = (
             f"pull-{self.pull_number}      {self.context}            {self.revision}"
-            f"      5  ({self.repo}) [bots@main]   {{stable-1.0}}\n")
+            f"       ({self.repo}) [bots@main]   {{stable-1.0}}\n")
 
     def tearDown(self):
         self.server.kill()
@@ -227,7 +227,7 @@ class TestTestsScan(unittest.TestCase):
     def test_no_pull_request_human(self):
         repo = "cockpit-project/cockpit"
         expected_output = (f"pull-0      {self.context}            {self.revision}"
-                           f"      5  ({repo}) [bots@main]\n")
+                           f"       ({repo}) [bots@main]\n")
 
         self.run_success(["--dry", "-v", "--sha", self.revision, "--context", self.context],
                          expected_output, repo=repo)

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -131,7 +131,7 @@ class TestTestsScan(unittest.TestCase):
         # expected human output for our standard mock PR #1 above
         self.expected_human_output = (
             f"pull-{self.pull_number}      {self.context}            {self.revision}"
-            f"     5.99999  ({self.repo}) [bots@main]   {{stable-1.0}}\n")
+            f"      5  ({self.repo}) [bots@main]   {{stable-1.0}}\n")
 
     def tearDown(self):
         self.server.kill()
@@ -227,7 +227,7 @@ class TestTestsScan(unittest.TestCase):
     def test_no_pull_request_human(self):
         repo = "cockpit-project/cockpit"
         expected_output = (f"pull-0      {self.context}            {self.revision}"
-                           f"     6.0  ({repo}) [bots@main]\n")
+                           f"      5  ({repo}) [bots@main]\n")
 
         self.run_success(["--dry", "-v", "--sha", self.revision, "--context", self.context],
                          expected_output, repo=repo)

--- a/tests-scan
+++ b/tests-scan
@@ -250,8 +250,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
         login = pull["head"]["user"]["login"]
         base = pull.get("base", {}).get("ref")  # The branch this pull request targets (None for direct SHA triggers)
 
-        allowed = login in ALLOWLIST
-
         logging.info("Processing #%s titled '%s' on revision %s", number, title, revision)
 
         labels = labels_of_pull(pull)
@@ -306,7 +304,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             # Not this only applies to this specific commit. A new status
             # will apply if the user pushes a new commit.
             changes: JsonObject | None
-            if not allowed and description in (None, github.NO_TESTING):
+            if login not in ALLOWLIST and description in (None, github.NO_TESTING):
                 priority = 0
                 changes = {"description": github.NO_TESTING, "context": context, "state": "pending"}
             else:

--- a/tests-scan
+++ b/tests-scan
@@ -313,38 +313,40 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                     "description": github.NOT_TESTED if opts.amqp else github.NOT_TESTED_DIRECT
                 }
 
-            if update_status(api, revision, status, opts.dry, changes):
-                checkout_ref = ref
-                if project != repo:
-                    checkout_ref = testmap.get_default_branch(project)
+            if not update_status(api, revision, status, opts.dry, changes):
+                continue
 
-                if base != branch:
-                    checkout_ref = branch
+            checkout_ref = ref
+            if project != repo:
+                checkout_ref = testmap.get_default_branch(project)
 
-                if repo == "cockpit-project/bots":
-                    # bots own test doesn't need bots/ setup as there is a permanent symlink to itself there
-                    # otherwise if we're testing an external project (repo != project) then checkout bots from the PR
-                    bots_ref = None if repo == project else ref
+            if base != branch:
+                checkout_ref = branch
+
+            if repo == "cockpit-project/bots":
+                # bots own test doesn't need bots/ setup as there is a permanent symlink to itself there
+                # otherwise if we're testing an external project (repo != project) then checkout bots from the PR
+                bots_ref = None if repo == project else ref
+            else:
+                if bots_pr:
+                    # Note: Don't use `pull/<pr_number>/head` as it may point to an old revision
+                    bots_api = github.GitHub(repo="cockpit-project/bots")
+                    bots_ref = bots_api.getHead(bots_pr) or "xxx"  # Make sure we fail when cannot get the head
                 else:
-                    if bots_pr:
-                        # Note: Don't use `pull/<pr_number>/head` as it may point to an old revision
-                        bots_api = github.GitHub(repo="cockpit-project/bots")
-                        bots_ref = bots_api.getHead(bots_pr) or "xxx"  # Make sure we fail when cannot get the head
-                    else:
-                        bots_ref = "main"
+                    bots_ref = "main"
 
-                yield Job(
-                    distributed_queue.BASELINE_PRIORITY,
-                    "pull-%d" % number,
-                    number,
-                    revision,
-                    checkout_ref,
-                    image_scenario,
-                    branch,
-                    project,
-                    bots_ref,
-                    context,
-                )
+            yield Job(
+                distributed_queue.BASELINE_PRIORITY,
+                "pull-%d" % number,
+                number,
+                revision,
+                checkout_ref,
+                image_scenario,
+                branch,
+                project,
+                bots_ref,
+                context,
+            )
 
 
 def scan_for_pull_tasks(api, contexts, opts, repo):

--- a/tests-scan
+++ b/tests-scan
@@ -22,11 +22,11 @@ import json
 import logging
 import sys
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import NamedTuple
 
 from lib import ALLOWLIST, testmap
-from lib.aio.jsonutil import JsonObject, get_str
+from lib.aio.jsonutil import get_str
 from task import distributed_queue, github, labels_of_pull
 
 sys.dont_write_bytecode = True
@@ -184,28 +184,20 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
         print(json.dumps(body['job']))
 
 
+def update_status(
+    api: github.GitHub, revision: str, last: Mapping[str, str], dry: bool, changes: Mapping[str, str] | None
+) -> bool:
+    if changes is None or {**last, **changes} == last or dry:
+        return True
 
-
-def dict_is_subset(full, check):
-    for (key, value) in check.items():
-        if key not in full or full[key] != value:
-            return False
-    return True
-
-
-def update_status(api, revision, context, last, changes):
-    if changes:
-        changes["context"] = context
-    if changes and not dict_is_subset(last, changes):
-        response = api.post("statuses/" + revision, changes, accept=[422])  # 422 Unprocessable Entity
-        errors = response.get("errors", None)
-        if not errors:
-            return True
-        for error in response.get("errors", []):
-            sys.stderr.write(f"{revision}: {error.get('message', json.dumps(error))}\n")
-            sys.stderr.write(json.dumps(changes))
-        return False
-    return True
+    response = api.post("statuses/" + revision, changes, accept=[422])  # 422 Unprocessable Entity
+    errors = response.get("errors", None)
+    if not errors:
+        return True
+    for error in response.get("errors", []):
+        sys.stderr.write(f"{revision}: {error.get('message', json.dumps(error))}\n")
+        sys.stderr.write(json.dumps(changes))
+    return False
 
 
 def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: str) -> 'Iterable[Job]':
@@ -303,7 +295,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             # For unmarked and untested status, user must be allowed
             # Not this only applies to this specific commit. A new status
             # will apply if the user pushes a new commit.
-            changes: JsonObject | None
+            changes: Mapping[str, str] | None
             if login not in ALLOWLIST and description in (None, github.NO_TESTING):
                 priority = 0
                 changes = {"description": github.NO_TESTING, "context": context, "state": "pending"}
@@ -316,13 +308,14 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                     changes = None
                 else:
                     changes = {
+                        "context": context,
                         "state": "pending",
                         "description": github.NOT_TESTED if opts.amqp else github.NOT_TESTED_DIRECT
                     }
 
                 priority = distributed_queue.BASELINE_PRIORITY
 
-            if opts.dry or update_status(api, revision, context, status, changes):
+            if update_status(api, revision, status, opts.dry, changes):
                 if not priority:
                     continue
 

--- a/tests-scan
+++ b/tests-scan
@@ -189,11 +189,11 @@ def prioritize(
     description: str | None,
     title: str,
     labels: Container[str],
-    priority: int,
     context: str,
     number: int,
     direct: bool
 ) -> tuple[int, JsonObject | None]:
+    priority = distributed_queue.BASELINE_PRIORITY
     update: dict[str, JsonValue] | None = {"state": "pending"}
 
     # This commit definitively succeeded or failed
@@ -314,13 +314,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
 
         labels = labels_of_pull(pull)
 
-        baseline: float = distributed_queue.BASELINE_PRIORITY
-        # amqp automatically prioritizes on age
-        if not opts.amqp:
-            # modify the baseline slightly to favor older pull requests, so that we don't
-            # end up with a bunch of half tested pull requests
-            baseline += 1.0 - (min(100000, float(number)) / 100000)
-
         # Create list of statuses to process: always process the requested contexts, if given
         todos: dict[str, dict[str, object]] = {context: {} for context in contexts}
         for status in statuses:  # Firstly add all valid contexts that already exist in github
@@ -364,7 +357,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                 # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
                 # so that the webhook queues them
                 (priority, changes) = prioritize(
-                    state, description, title, labels, baseline, context, number, direct=not opts.amqp
+                    state, description, title, labels, context, number, direct=not opts.amqp
                 )
             if opts.dry or update_status(api, revision, context, status, changes):
                 if not priority:

--- a/tests-scan
+++ b/tests-scan
@@ -202,10 +202,6 @@ def prioritize(
         priority = 0
         update = None
 
-    # This test errored, we try again but low priority
-    if state in ["error"]:
-        priority -= 2
-
     if state in ["pending"]:
         logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
         update = None

--- a/tests-scan
+++ b/tests-scan
@@ -26,7 +26,7 @@ from collections.abc import Iterable
 from typing import NamedTuple
 
 from lib import ALLOWLIST, testmap
-from lib.aio.jsonutil import JsonObject, JsonValue, get_str
+from lib.aio.jsonutil import JsonObject, get_str
 from task import distributed_queue, github, labels_of_pull
 
 sys.dont_write_bytecode = True
@@ -184,25 +184,6 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
         print(json.dumps(body['job']))
 
 
-def prioritize(
-    state: str | None,
-    description: str | None,
-    context: str,
-    number: int,
-    direct: bool
-) -> tuple[int, JsonObject | None]:
-    priority = distributed_queue.BASELINE_PRIORITY
-    update: dict[str, JsonValue] | None = {"state": "pending"}
-
-    if state in ["pending"]:
-        logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
-        update = None
-
-    if update:
-        update["description"] = github.NOT_TESTED_DIRECT if direct else github.NOT_TESTED
-
-    priority = min(priority, distributed_queue.MAX_PRIORITY)
-    return (priority, update)
 
 
 def dict_is_subset(full, check):
@@ -332,9 +313,17 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                 # with --amqp (as called from run-queue), trigger tests as NOT_TESTED, as they already get queued;
                 # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
                 # so that the webhook queues them
-                (priority, changes) = prioritize(
-                    state, description, context, number, direct=not opts.amqp
-                )
+                if state in ["pending"]:
+                    logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
+                    changes = None
+                else:
+                    changes = {
+                        "state": "pending",
+                        "description": github.NOT_TESTED if opts.amqp else github.NOT_TESTED_DIRECT
+                    }
+
+                priority = distributed_queue.BASELINE_PRIORITY
+
             if opts.dry or update_status(api, revision, context, status, changes):
                 if not priority:
                     continue

--- a/tests-scan
+++ b/tests-scan
@@ -203,10 +203,10 @@ def prioritize(
         update = None
 
     # This test errored, we try again but low priority
-    elif state in ["error"]:
+    if state in ["error"]:
         priority -= 2
 
-    elif state in ["pending"]:
+    if state in ["pending"]:
         logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
         update = None
 

--- a/tests-scan
+++ b/tests-scan
@@ -198,13 +198,6 @@ def prioritize(
         logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
         update = None
 
-    if priority > 0:
-        # Is testing already in progress?
-        if description and description.startswith(github.TESTING):
-            logging.info("Skipping '%s' on #%s because it is already running", context, number)
-            priority = 0
-            update = None
-
     if update:
         if priority <= 0:
             logging.info("Not updating status for '%s' on #%s because of low priority", context, number)
@@ -326,6 +319,10 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             # the context was directly triggered
             if (('no-test' in labels or '[no-test]' in title) and description != github.NOT_TESTED_DIRECT):
                 logging.info("Skipping '%s' on #%s because it is no-test", context, number)
+                continue
+
+            if description and description.startswith(github.TESTING):
+                logging.info("Skipping '%s' on #%s because it is already running", context, number)
                 continue
 
             # For unmarked and untested status, user must be allowed

--- a/tests-scan
+++ b/tests-scan
@@ -295,30 +295,25 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             # For unmarked and untested status, user must be allowed
             # Not this only applies to this specific commit. A new status
             # will apply if the user pushes a new commit.
-            changes: Mapping[str, str] | None
             if login not in ALLOWLIST and description in (None, github.NO_TESTING):
-                priority = 0
-                changes = {"description": github.NO_TESTING, "context": context, "state": "pending"}
-            else:
-                # with --amqp (as called from run-queue), trigger tests as NOT_TESTED, as they already get queued;
-                # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
-                # so that the webhook queues them
-                if state in ["pending"]:
-                    logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
-                    changes = None
-                else:
-                    changes = {
-                        "context": context,
-                        "state": "pending",
-                        "description": github.NOT_TESTED if opts.amqp else github.NOT_TESTED_DIRECT
-                    }
+                update_status(api, revision, status, opts.dry,
+                              {"description": github.NO_TESTING, "context": context, "state": "pending"})
+                continue
 
-                priority = distributed_queue.BASELINE_PRIORITY
+            # with --amqp (as called from run-queue), trigger tests as NOT_TESTED, as they already get queued;
+            # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
+            # so that the webhook queues them
+            if state in ["pending"]:
+                logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
+                changes = None
+            else:
+                changes = {
+                    "context": context,
+                    "state": "pending",
+                    "description": github.NOT_TESTED if opts.amqp else github.NOT_TESTED_DIRECT
+                }
 
             if update_status(api, revision, status, opts.dry, changes):
-                if not priority:
-                    continue
-
                 checkout_ref = ref
                 if project != repo:
                     checkout_ref = testmap.get_default_branch(project)
@@ -339,7 +334,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                         bots_ref = "main"
 
                 yield Job(
-                    priority,
+                    distributed_queue.BASELINE_PRIORITY,
                     "pull-%d" % number,
                     number,
                     revision,

--- a/tests-scan
+++ b/tests-scan
@@ -227,7 +227,7 @@ def prioritize(status, title, labels, priority, context, number, direct):
         description = status.get("description", "")
         if description.startswith(github.TESTING):
             logging.info("Skipping '%s' on #%s because it is already running", context, number)
-            priority = description
+            priority = 0
             update = None
 
     if update:

--- a/tests-scan
+++ b/tests-scan
@@ -22,7 +22,7 @@ import json
 import logging
 import sys
 import time
-from collections.abc import Container, Iterable
+from collections.abc import Iterable
 from typing import NamedTuple
 
 from lib import ALLOWLIST, testmap
@@ -187,8 +187,6 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
 def prioritize(
     state: str | None,
     description: str | None,
-    title: str,
-    labels: Container[str],
     context: str,
     number: int,
     direct: bool
@@ -201,15 +199,6 @@ def prioritize(
         update = None
 
     if priority > 0:
-        if "priority" in labels:
-            priority += 2
-        if "blocked" in labels:
-            priority -= 1
-
-        # Pull requests where the title starts with WIP get penalized
-        if title.startswith("WIP") or "needswork" in labels:
-            priority -= 1
-
         # Is testing already in progress?
         if description and description.startswith(github.TESTING):
             logging.info("Skipping '%s' on #%s because it is already running", context, number)
@@ -351,7 +340,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                 # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
                 # so that the webhook queues them
                 (priority, changes) = prioritize(
-                    state, description, title, labels, context, number, direct=not opts.amqp
+                    state, description, context, number, direct=not opts.amqp
                 )
             if opts.dry or update_status(api, revision, context, status, changes):
                 if not priority:

--- a/tests-scan
+++ b/tests-scan
@@ -200,13 +200,6 @@ def prioritize(
         logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
         update = None
 
-    # Ignore context when the PR has [no-test] in the title or as label, unless
-    # the context was directly triggered
-    if (('no-test' in labels or '[no-test]' in title) and description != github.NOT_TESTED_DIRECT):
-        logging.info("Skipping '%s' on #%s because it is no-test", context, number)
-        priority = 0
-        update = None
-
     if priority > 0:
         if "priority" in labels:
             priority += 2
@@ -338,6 +331,12 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             # This commit definitively succeeded or failed
             if state in ["success", "failure"]:
                 logging.info("Skipping '%s' on #%s because it has already finished", context, number)
+                continue
+
+            # Ignore context when the PR has [no-test] in the title or as label, unless
+            # the context was directly triggered
+            if (('no-test' in labels or '[no-test]' in title) and description != github.NOT_TESTED_DIRECT):
+                logging.info("Skipping '%s' on #%s because it is no-test", context, number)
                 continue
 
             # For unmarked and untested status, user must be allowed

--- a/tests-scan
+++ b/tests-scan
@@ -199,11 +199,7 @@ def prioritize(
         update = None
 
     if update:
-        if priority <= 0:
-            logging.info("Not updating status for '%s' on #%s because of low priority", context, number)
-            update = None
-        else:
-            update["description"] = github.NOT_TESTED_DIRECT if direct else github.NOT_TESTED
+        update["description"] = github.NOT_TESTED_DIRECT if direct else github.NOT_TESTED
 
     priority = min(priority, distributed_queue.MAX_PRIORITY)
     return (priority, update)

--- a/tests-scan
+++ b/tests-scan
@@ -185,9 +185,9 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
 
 
 def update_status(
-    api: github.GitHub, revision: str, last: Mapping[str, str], dry: bool, changes: Mapping[str, str] | None
+    api: github.GitHub, revision: str, last: Mapping[str, str], dry: bool, changes: Mapping[str, str]
 ) -> bool:
-    if changes is None or {**last, **changes} == last or dry:
+    if {**last, **changes} == last or dry:
         return True
 
     response = api.post("statuses/" + revision, changes, accept=[422])  # 422 Unprocessable Entity
@@ -300,21 +300,19 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                               {"description": github.NO_TESTING, "context": context, "state": "pending"})
                 continue
 
-            # with --amqp (as called from run-queue), trigger tests as NOT_TESTED, as they already get queued;
-            # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
-            # so that the webhook queues them
-            if state in ["pending"]:
-                logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
-                changes = None
-            else:
+            if state != "pending":
+                # with --amqp (as called from run-queue), trigger tests as NOT_TESTED, as they already get queued;
+                # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
+                # so that the webhook queues them
                 changes = {
                     "context": context,
                     "state": "pending",
                     "description": github.NOT_TESTED if opts.amqp else github.NOT_TESTED_DIRECT
                 }
-
-            if not update_status(api, revision, status, opts.dry, changes):
-                continue
+                if not update_status(api, revision, status, opts.dry, changes):
+                    continue
+            else:
+                logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
 
             checkout_ref = ref
             if project != repo:

--- a/tests-scan
+++ b/tests-scan
@@ -104,7 +104,6 @@ def main():
 
 
 class Job(NamedTuple):
-    priority: int
     name: str
     number: int
     revision: str
@@ -118,8 +117,7 @@ class Job(NamedTuple):
 
 # Prepare a human readable output
 def tests_human(job: Job, options: argparse.Namespace) -> str:
-    return "{name:11} {context:25} {revision:10} {priority:2}{repo}{bots_ref}{branches}".format(
-        priority=job.priority,
+    return "{name:11} {context:25} {revision:10} {repo}{bots_ref}{branches}".format(
         revision=job.revision[0:7],
         context=job.context,
         name=job.name,
@@ -178,7 +176,8 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
 
     queue = 'rhel' if is_internal_context(job.context) else 'public'
     if channel:
-        channel.basic_publish('', queue, json.dumps(body), properties=pika.BasicProperties(priority=job.priority))
+        properties = pika.BasicProperties(priority=distributed_queue.BASELINE_PRIORITY)
+        channel.basic_publish('', queue, json.dumps(body), properties=properties)
         logging.info("Published job: %s", json.dumps(body["job"]))
     else:
         print(json.dumps(body['job']))
@@ -334,7 +333,6 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                     bots_ref = "main"
 
             yield Job(
-                distributed_queue.BASELINE_PRIORITY,
                 "pull-%d" % number,
                 number,
                 revision,

--- a/tests-scan
+++ b/tests-scan
@@ -61,8 +61,6 @@ def main():
                         help='Display human readable output rather than tasks')
     parser.add_argument('-n', '--dry', action="store_true", default=False,
                         help="Don't actually change anything on GitHub")
-    parser.add_argument('-f', '--force', action="store_true", default=False,
-                        help='Perform all actions, even those that should be skipped')
     parser.add_argument('--repo', default=None,
                         help='Repository to scan and checkout.')
     parser.add_argument('-c', '--context', action="append", default=[],
@@ -82,10 +80,6 @@ def main():
         return 1
     if opts.pull_data and (opts.pull_number or opts.sha):
         parser.error("--pull-data and --pull-number/--sha are mutually exclusive")
-
-    if opts.force:
-        if not opts.repo or not opts.context or not (opts.pull_number or opts.sha):
-            parser.error('--force requires --repo, --context, and one of --pull-number or --sha')
 
     api = github.GitHub(repo=opts.repo)
 
@@ -361,7 +355,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                     status, title, labels, baseline, context, number, direct=not opts.amqp
                 )
             if opts.dry or update_status(api, revision, context, status, changes):
-                if not priority and not opts.force:
+                if not priority:
                     continue
 
                 checkout_ref = ref

--- a/tests-scan
+++ b/tests-scan
@@ -196,12 +196,6 @@ def prioritize(
     priority = distributed_queue.BASELINE_PRIORITY
     update: dict[str, JsonValue] | None = {"state": "pending"}
 
-    # This commit definitively succeeded or failed
-    if state in ["success", "failure"]:
-        logging.info("Skipping '%s' on #%s because it has already finished", context, number)
-        priority = 0
-        update = None
-
     if state in ["pending"]:
         logging.info("Not updating status for '%s' on #%s because it is pending", context, number)
         update = None
@@ -340,6 +334,11 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
 
             # Note: Don't use `pull/<pr_number>/head` as it may point to an old revision
             ref = revision
+
+            # This commit definitively succeeded or failed
+            if state in ["success", "failure"]:
+                logging.info("Skipping '%s' on #%s because it has already finished", context, number)
+                continue
 
             # For unmarked and untested status, user must be allowed
             # Not this only applies to this specific commit. A new status

--- a/tests-scan
+++ b/tests-scan
@@ -22,9 +22,11 @@ import json
 import logging
 import sys
 import time
-from typing import Iterable, NamedTuple
+from collections.abc import Container, Iterable
+from typing import NamedTuple
 
 from lib import ALLOWLIST, testmap
+from lib.aio.jsonutil import JsonObject, JsonValue, get_str
 from task import distributed_queue, github, labels_of_pull
 
 sys.dont_write_bytecode = True
@@ -182,9 +184,17 @@ def queue_test(job: Job, channel, options: argparse.Namespace) -> None:
         print(json.dumps(body['job']))
 
 
-def prioritize(status, title, labels, priority, context, number, direct):
-    state = status.get("state", None)
-    update = {"state": "pending"}
+def prioritize(
+    state: str | None,
+    description: str | None,
+    title: str,
+    labels: Container[str],
+    priority: int,
+    context: str,
+    number: int,
+    direct: bool
+) -> tuple[int, JsonObject | None]:
+    update: dict[str, JsonValue] | None = {"state": "pending"}
 
     # This commit definitively succeeded or failed
     if state in ["success", "failure"]:
@@ -202,7 +212,7 @@ def prioritize(status, title, labels, priority, context, number, direct):
 
     # Ignore context when the PR has [no-test] in the title or as label, unless
     # the context was directly triggered
-    if (('no-test' in labels or '[no-test]' in title) and status.get("description", "") != github.NOT_TESTED_DIRECT):
+    if (('no-test' in labels or '[no-test]' in title) and description != github.NOT_TESTED_DIRECT):
         logging.info("Skipping '%s' on #%s because it is no-test", context, number)
         priority = 0
         update = None
@@ -218,8 +228,7 @@ def prioritize(status, title, labels, priority, context, number, direct):
             priority -= 1
 
         # Is testing already in progress?
-        description = status.get("description", "")
-        if description.startswith(github.TESTING):
+        if description and description.startswith(github.TESTING):
             logging.info("Skipping '%s' on #%s because it is already running", context, number)
             priority = 0
             update = None
@@ -232,7 +241,7 @@ def prioritize(status, title, labels, priority, context, number, direct):
             update["description"] = github.NOT_TESTED_DIRECT if direct else github.NOT_TESTED
 
     priority = min(priority, distributed_queue.MAX_PRIORITY)
-    return [priority, update]
+    return (priority, update)
 
 
 def dict_is_subset(full, check):
@@ -328,7 +337,10 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
         # base:   the target branch of that PR (None for direct SHA trigger)
         # branch: the branch of the external project that we are testing
         #         against this PR (only applies to cockpit-project/bots PRs)
-        for context in todos:
+        for context, status in todos.items():
+            state = get_str(status, 'state', None)
+            description = get_str(status, 'description', None)
+
             # Get correct project and branch. Ones from test name have priority
             project = repo
             branch = base
@@ -343,8 +355,8 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
             # For unmarked and untested status, user must be allowed
             # Not this only applies to this specific commit. A new status
             # will apply if the user pushes a new commit.
-            status = todos[context]
-            if not allowed and status.get("description", github.NO_TESTING) == github.NO_TESTING:
+            changes: JsonObject | None
+            if not allowed and description in (None, github.NO_TESTING):
                 priority = 0
                 changes = {"description": github.NO_TESTING, "context": context, "state": "pending"}
             else:
@@ -352,7 +364,7 @@ def cockpit_tasks(api: github.GitHub, contexts, opts: argparse.Namespace, repo: 
                 # without --amqp (as called manually or from workflows), trigger tests as NOT_TESTED_DIRECT,
                 # so that the webhook queues them
                 (priority, changes) = prioritize(
-                    status, title, labels, baseline, context, number, direct=not opts.amqp
+                    state, description, title, labels, baseline, context, number, direct=not opts.amqp
                 )
             if opts.dry or update_status(api, revision, context, status, changes):
                 if not priority:


### PR DESCRIPTION
This kills off the prioritize() function and makes a lot of related changes.

To my eye, the main logic of the program through the `todos` loop in `cockpit_tasks()` is a lot easier to understand now.

There is a ridiculous number of commits here, but I've been very careful about each commit either being a straight refactor or an intentional and obvious logic change (mostly to do with removing priorities).  I've verified that each commit passes `pytest`, and have made test adjustments in the "logic change" commits.

There's more work to do, but I wanted to subject this to a full CI run before I continue.