### PR TITLE
images: Fix nodejs build dependency again

### DIFF
--- a/images/opensuse-tumbleweed
+++ b/images/opensuse-tumbleweed
@@ -1,1 +1,1 @@
-opensuse-tumbleweed-c70032de81803054fa06f5493b9c6cb002c95559cbbaa8edacbfa04c444d9eb2.qcow2
+opensuse-tumbleweed-24b87225621346b2bfb341726cceaf252332b2128beeeb1fffd883809ac443d0.qcow2

--- a/images/scripts/lib/build-deps.sh
+++ b/images/scripts/lib/build-deps.sh
@@ -43,10 +43,10 @@ echo "$spec" | rpmspec -D "$OS_VER_NO_VARIANT" -D 'version 0' -D 'enable_old_bri
 # - nodejs for starter-kit and other projects which rebuild webpack during RPM build
 case "$OS_VER" in
     *suse*)
-        EXTRA_DEPS="appstream-glib rpmlint gettext-runtime desktop-file-utils nodejs"
+        EXTRA_DEPS="appstream-glib rpmlint gettext-runtime desktop-file-utils nodejs-default"
         ;;
     *)
-        EXTRA_DEPS="libappstream-glib rpmlint gettext desktop-file-utils nodejs-default"
+        EXTRA_DEPS="libappstream-glib rpmlint gettext desktop-file-utils nodejs"
         ;;
 esac
 


### PR DESCRIPTION
Commit 26b51601c433 accidentally changed "nodejs-default" on non-SUSE.

---

This fixes the recently failing image refreshes, #6129, #6131, #6132

 * [x] image-refresh opensuse-tumbleweed