### PR TITLE
store-tests: Adjust to job-runner "in progress" message

### DIFF
--- a/store-tests
+++ b/store-tests
@@ -96,7 +96,7 @@ def main():
 
         desc = status["description"]
         if status["state"] == "pending":
-            if "Testing in progress" in desc:
+            if "progress" in desc:
                 cc[-1]["url"] = status["target_url"]
                 cc[-1]["started"] = datetime.strptime(status["created_at"], DATE_FORMAT).timestamp()
             elif "Not yet tested" in desc:


### PR DESCRIPTION
The old `tests-invoke` labeled the status "Testing in progress", while job-runner labels it "In progress". store-tests was too reliant on the precise name, so change the match to be more relaxing. We only need it to tell apart queued ("Not yet tested") from running ("in progress") tests.

---

See [pilot board issue](https://github.com/orgs/cockpit-project/projects/4/views/1?pane=issue&itemId=57303748) for details.

Tested with:
```
rm test-results.db; ./store-tests --verbose --db ./test-results.db --repo cockpit-project/cockpit-machines b0375632254657596d74fbfad913f8b636a8adb0; ./prometheus-stats --db ./test-results.db
```

On main, tests-scan gives broken/nonsensical results:
```
WARNING:root:Pending status has unexpected description 'In progress [rhos-01-27]', skipping.
[...]
DEBUG:root:Processing arch as success that waited 0.0s and took 1256.0s in cockpit-project/cockpit-machines. None
```

And the prometheus report had an empty `top_failures_pct`, `pr_retries_bucket` and so on.

while now it's good again:
```
DEBUG:root:Processing arch as success that waited 3.0s and took 1253.0s in cockpit-project/cockpit-machines. https://cockpit-logs.us-east-1.linodeobjects.com/pull-1516-b0375632-20240325-220643-arch/log.html
```

and prometheus has our favourite flake:
```
# HELP top_failures_pct Most unstable tests in the last 7 days (more than 10% failure rate)
# TYPE top_failures_pct gauge
top_failures_pct{project="cockpit-project/cockpit-machines",test="/test/check-machines-disks TestMachinesDisks.testDetachDisk",context="ubuntu-stable"} 66.66666666666667

```