### PR TITLE
images: Add Fedora ELN bootc

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -46,6 +46,7 @@ REFRESH = {
     "fedora-39": {},
     "fedora-40": {},
     "fedora-coreos": {},
+    "fedora-eln-bootc": {},
     "fedora-rawhide": {},
     "fedora-rawhide-boot": {},
     "fedora-rawhide-anaconda-payload": REFRESH_30,

--- a/images/scripts/fedora-eln-bootc.Containerfile
+++ b/images/scripts/fedora-eln-bootc.Containerfile
@@ -1,0 +1,18 @@
+FROM quay.io/centos-bootc/fedora-bootc:eln
+
+# pre-install the distro version, which is useful for testing extensions and manual experiments
+RUN \
+    dnf install -y --setopt install_weak_deps=False cockpit-system cockpit-networkmanager && \
+    dnf clean all
+
+ADD lib/mcast1.nmconnection /usr/lib/NetworkManager/system-connections/
+
+# NM insists on tight permissions
+RUN chmod 600 /usr/lib/NetworkManager/system-connections/mcast1.nmconnection
+
+# HACK: workaround for https://github.com/osbuild/bootc-image-builder/issues/143
+# so that we can configure root password/ssh key
+RUN mkdir /var/roothome
+
+# HACK: workaround for https://github.com/osbuild/bootc-image-builder/issues/326
+RUN rm -rf /usr/local; ln -s ../var/usrlocal /usr/local

--- a/images/scripts/fedora-eln-bootc.bootstrap
+++ b/images/scripts/fedora-eln-bootc.bootstrap
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+
+# osbuild needs a privileged container with kvm, so we can't build or run this
+# directly in our CI tasks container or GitHub workflows; so run it in a VM.
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(1, os.path.realpath(__file__ + '/../../..'))
+
+from lib.constants import BOTS_DIR, DEFAULT_IDENTITY_PUB_FILE, TEST_OS_DEFAULT
+from machine import testvm
+
+IMAGE = 'localhost/fedora-eln-bootc:latest'
+DEST = os.path.abspath(sys.argv[1])
+
+subprocess.check_call([os.path.join(BOTS_DIR, 'image-download'), TEST_OS_DEFAULT])
+m = testvm.VirtMachine(image=TEST_OS_DEFAULT, verbose=True)
+m.start()
+m.wait_boot()
+
+# build OS bootc container image
+m.upload([str(Path(testvm.SCRIPTS_DIR, 'fedora-eln-bootc.Containerfile'))], '/root')
+m.upload([str(Path(testvm.SCRIPTS_DIR, 'lib'))], '/root')
+m.execute(f'podman build -f fedora-eln-bootc.Containerfile -t {IMAGE} .', timeout=720, stdout=None)
+
+# convert container to qcow2 with image builder
+# see https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file
+
+pubkey = Path(DEFAULT_IDENTITY_PUB_FILE).read_text().strip()
+config = {
+    'blueprint': {
+        'customizations': {
+            'user': [
+                {'name': 'admin', 'password': 'foobar', 'key': pubkey},
+                {'name': 'root', 'password': 'foobar', 'key': pubkey},
+            ]
+        }
+    }
+}
+m.write('/root/config.json', json.dumps(config))
+
+m.execute('mkdir output')
+
+m.execute(['podman', 'run', '--rm', '-i', '--privileged', '--security-opt=label=type:unconfined_t',
+           # for --local
+           '--volume=/var/lib/containers/storage:/var/lib/containers/storage',
+           '--volume=./config.json:/config.json',
+           '--volume=./output:/output',
+           'quay.io/centos-bootc/bootc-image-builder:latest',
+           # image-builder args
+           '--type=qcow2',
+           '--local',
+           '--config', '/config.json',
+           IMAGE], timeout=720, stdout=None)
+
+# copy out the image
+m.download('output/qcow2/disk.qcow2', DEST)
+
+m.kill()

--- a/images/scripts/fedora-eln-bootc.setup
+++ b/images/scripts/fedora-eln-bootc.setup
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eux
+
+IMAGE="$1"
+
+podman pull quay.io/cockpit/ws
+podman pull quay.io/jitesoft/nginx
+
+# for c-podman tests
+/var/lib/testvm/podman-images.setup
+
+# disable various maintenance tasks which interfere with tests and don't make sense for our tests
+systemctl disable bootc-fetch-apply-updates.timer fstrim.timer logrotate.timer raid-check.timer
+
+# reduce image size
+rm -rf /var/log/journal/*
+/var/lib/testvm/zero-disk.setup

--- a/images/scripts/lib/mcast1.nmconnection
+++ b/images/scripts/lib/mcast1.nmconnection
@@ -1,0 +1,13 @@
+# don't hang/fail on non-existing DHCP on ens15 (second interface for mcast) on boot
+
+[connection]
+id=mcast1
+type=ethernet
+interface-name=ens15
+autoconnect-priority=-100
+
+[ipv4]
+method=disabled
+
+[ipv6]
+method=ignore

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -18,7 +18,7 @@
 import os
 
 # Images which are OSTree based
-OSTREE_IMAGES = ["fedora-coreos", "rhel4edge"]
+OSTREE_IMAGES = ["fedora-coreos", "fedora-eln-bootc", "rhel4edge"]
 
 LIB_DIR = os.path.dirname(__file__)
 BOTS_DIR = os.path.dirname(LIB_DIR)

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -81,6 +81,9 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-rawhide',
             'opensuse-tumbleweed',
         ],
+        '_manual': [
+            'fedora-eln-bootc',
+        ]
     },
     'cockpit-project/cockpit-ostree': {
         'main': [
@@ -88,6 +91,9 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-coreos/devel',
             'rhel4edge',
         ],
+        '_manual': [
+            'fedora-eln-bootc',
+        ]
     },
     'cockpit-project/cockpit-podman': {
         'main': [
@@ -106,6 +112,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         ],
         '_manual': [
             'centos-8-stream',
+            'fedora-eln-bootc',
             'fedora-rawhide',
             'opensuse-tumbleweed',
         ],
@@ -238,6 +245,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
     "fedora-coreos": "fedora-39",
+    "fedora-eln-bootc": TEST_OS_DEFAULT,
     "rhel4edge": "rhel-9-2",
 }
 


### PR DESCRIPTION
This introduces an image which uses [bootc](https://containers.github.io/bootc/) for deploying OCI container images as OS.

The initial installation is a bit tricky as it requires converting a container image to a bootable qcow2 image. That happens with https://github.com/osbuild/bootc-image-builder which is very demanding: It needs both /dev/kvm and a `--privileged` container, so the only place where we can run this is in a VM on our own CI.

https://issues.redhat.com/browse/COCKPIT-1108

 * [x] image-refresh fedora-eln-bootc