### PR TITLE
naughty: Add pattern for pmproxy crash on ubuntu-stable

### DIFF
--- a/naughty/ubuntu-stable/6178-pmproxy-web-crash
+++ b/naughty/ubuntu-stable/6178-pmproxy-web-crash
@@ -1,0 +1,3 @@
+TestHistoryMetrics.testPmProxySettings*
+*FAIL: Test completed, but found unexpected journal messages:
+Process * (pmproxy) of user 997 dumped core.


### PR DESCRIPTION
Known issue #6178
Downstream report: https://launchpad.net/bugs/2060275

---

Quite prominent on the weather report. Examples:

 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-6177-6626b317-20240404-225904-ubuntu-stable-other-cockpit-project-cockpit/log.html#34
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-20264-13fcc041-20240404-201827-ubuntu-stable-other/log.html#34
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-20261-d1621935-20240404-105717-ubuntu-stable-other/log.html
 - https://cockpit-logs.us-east-1.linodeobjects.com/pull-20261-d1621935-20240404-112845-ubuntu-stable-other/log.html