### PR TITLE
naughty: Add pattern for broken cockpit-composer test on F38

### DIFF
--- a/naughty/fedora-38/6180-composer-broken-testCreateAndDeleteBlueprint
+++ b/naughty/fedora-38/6180-composer-broken-testCreateAndDeleteBlueprint
@@ -1,0 +1,4 @@
+  File "test/verify/check-blueprintWizard", line *, in testCreateAndDeleteBlueprint
+    b.click("li[data-testid='openssh-server']")
+*
+wait_js_cond(ph_is_present("li[data-testid='openssh-server']:not([disabled]):not([aria-disabled=true])")): Uncaught (in promise) Error: condition did not become true


### PR DESCRIPTION
This test has been flaky for a long time, and on F38 it has failed robustly for months without upstream reaction.

Upstream report: https://github.com/osbuild/cockpit-composer/issues/1995
Known issue #6180


[example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6127-5861e415-20240321-232401-fedora-38-osbuild-cockpit-composer/log.html#3-2)