### PR TITLE
naughty: Add two recent rawhide SELinux regressions

### DIFF
--- a/naughty/fedora-41/6620-selinux-init-netfilter-socket
+++ b/naughty/fedora-41/6620-selinux-init-netfilter-socket
@@ -1,0 +1,5 @@
+TestLogin.testSELinuxRestrictedUser)
+*
+*avc:  denied  { create } for  pid=1 comm=systemd scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=netlink_netfilter_socket permissive=0
+*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages

--- a/naughty/fedora-41/6621-selinux-abrt-dynamicuser
+++ b/naughty/fedora-41/6621-selinux-abrt-dynamicuser
@@ -1,0 +1,2 @@
+*avc:  denied  { write } for * comm="abrt-dump-journ" name="io.systemd.*" dev="tmpfs" * scontext=system_u:system_r:abrt_dump_oops_t:s0 tcontext=system_u:object_r:systemd_userdbd_runtime_t:s0 tclass=sock_file*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages


### PR DESCRIPTION
Happens in all upstream SELinux PRs now, e.g. https://github.com/fedora-selinux/selinux-policy/pull/2086 with [this log](https://artifacts.dev.testing-farm.io/68ba767a-9042-42fe-80f6-e69e94b8fffa).