### PR TITLE
testmap: Enable centos-10 for starter-kit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -79,12 +79,12 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-39',
             'fedora-40',
             'centos-8-stream',
+            'centos-10',
             'fedora-rawhide',
             'opensuse-tumbleweed',
         ],
         '_manual': [
             'centos-9-bootc',
-            'centos-10',
         ]
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
Enabled and tested in https://github.com/cockpit-project/starter-kit/pull/839 (but it's for TF, not our CI)