### PR TITLE
images: Install nftables onto Debian images

### DIFF
--- a/images/debian-stable
+++ b/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-c83723acb07cc4fc090fcb07e3cb0814b269e8d0539fad8495ccb9b208b1c2f9.qcow2
+debian-stable-5505b257d2348f1dafab3fc9908e7194ed6a96bd9c48880091a4b996dfac425d.qcow2

--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-5a0a0cf5ff7d0cfd70d8f71462ccd8d7f07def69aa63c6faa6209013279a5d2a.qcow2
+debian-testing-7aabaf323c32c4ebdb4994b6862ba68ad226453e60ebe0f6ca823a9a5d903626.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -85,6 +85,7 @@ tang \
 libnss-myhostname \
 virtiofsd \
 wireguard-tools \
+nftables \
 "
 
 # older libvirt have this builtin


### PR DESCRIPTION
It already is on the Ubuntu images by way of the "ubuntu-standard" metapackage, but not on the Debian ones.

----

This will, through another immediate step, unblock https://github.com/cockpit-project/cockpit/pull/20321

 * [x] image-refresh debian-stable
 * [x] image-refresh debian-testing