### PR TITLE
images: Put OCI image of its own deployment onto bootc images

### DIFF
--- a/images/centos-9-bootc
+++ b/images/centos-9-bootc
@@ -1,1 +1,1 @@
-centos-9-bootc-85cad3abe10831b8e6111c9f7507dc94ff0c98bd7d9b4bd42ece905816b5ba09.qcow2
+centos-9-bootc-3bc182f321bd2a169c33972693c567b52cfca8e46d9cded4e259b772fe42084e.qcow2

--- a/images/scripts/bootc.setup
+++ b/images/scripts/bootc.setup
@@ -9,6 +9,21 @@ podman pull quay.io/jitesoft/nginx
 # for c-podman tests
 /var/lib/testvm/podman-images.setup
 
+# store our own OCI image into a local registry, for c-ostree tests
+podman load < /var/cache/bootc.oci.tar
+
+mkdir /var/lib/cockpit-test-registry
+chcon -t container_file_t /var/lib/cockpit-test-registry/
+podman run -d --rm --name ostree-registry -p 5000:5000 -v /var/lib/cockpit-test-registry:/var/lib/registry localhost/test-registry
+mv /etc/containers/registries.conf /etc/containers/registries.conf.orig
+printf '[registries.insecure]\nregistries = ["localhost:5000"]\n' > /etc/containers/registries.conf
+
+podman tag localhost/bootc:latest localhost:5000/bootc:latest
+podman push localhost:5000/bootc:latest
+podman rmi localhost:5000/bootc:latest localhost/bootc:latest
+podman rm -f -t0 ostree-registry
+rm /var/cache/bootc.oci.tar
+
 # disable various maintenance tasks which interfere with tests and don't make sense for our tests
 systemctl disable bootc-fetch-apply-updates.timer fstrim.timer logrotate.timer raid-check.timer
 

--- a/images/scripts/lib/bootc.bootstrap
+++ b/images/scripts/lib/bootc.bootstrap
@@ -66,3 +66,16 @@ m.execute(['podman', 'run', '--rm', '-i', '--privileged', '--security-opt=label=
 m.download('output/qcow2/disk.qcow2', args.vmpath)
 
 m.kill()
+
+# it's too small by default
+subprocess.check_call(['qemu-img', 'resize', '-f', 'qcow2', args.vmpath, '+20G'])
+
+m = testvm.VirtMachine(image=os.path.abspath(args.vmpath), maintain=True, verbose=True)
+m.start()
+m.wait_boot()
+# resize file system to the full qcow device size
+m.execute('growpart /dev/vda 4')
+m.execute('mount -o remount,rw /sysroot')
+m.execute('resize2fs /dev/vda4')
+m.shutdown()
+m.kill()

--- a/images/scripts/lib/bootc.bootstrap
+++ b/images/scripts/lib/bootc.bootstrap
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(1, os.path.realpath(__file__ + '/../../../..'))
@@ -62,8 +63,13 @@ m.execute(['podman', 'run', '--rm', '-i', '--privileged', '--security-opt=label=
            '--config', '/config.json',
            OCI_TAG], timeout=720, stdout=None)
 
-# copy out the image
+# copy out the converted qcow2 image
 m.download('output/qcow2/disk.qcow2', args.vmpath)
+
+# copy out the container image
+oci_image = tempfile.NamedTemporaryFile()
+m.execute(f"podman save {OCI_TAG}", stdout=oci_image)
+oci_image.flush()
 
 m.kill()
 
@@ -77,5 +83,10 @@ m.wait_boot()
 m.execute('growpart /dev/vda 4')
 m.execute('mount -o remount,rw /sysroot')
 m.execute('resize2fs /dev/vda4')
+
+# copy OCI image into the VM as well, for cockpit-ostree tests
+# the .setup script processes this further
+m.upload([oci_image.name], '/var/cache/bootc.oci.tar')
+
 m.shutdown()
 m.kill()

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -281,7 +281,7 @@ class SSHConnection:
         command: str | Sequence[str],
         input: str | None = None,  # noqa:A002  # shadows `input()` but so does subprocess module
         environment: Mapping[str, str] = {},
-        stdout: int | IO[str] | None = subprocess.PIPE,
+        stdout: int | IO[str] | IO[bytes] | None = subprocess.PIPE,
         quiet: bool = False,
         direct: bool = False,
         timeout: int = 120,


### PR DESCRIPTION
We want this for testing cockpit-ostree, so that it can have a base
bootc image and create a derived image from it for testing upgrades
purely out of the VM image itself, without internet access.

Store the image in a local registry directory volume. This makes it
efficiently available for cockpit-ostree without interfering with
cockpit-podman's tests, i.e. it survives a `podman system reset`.

-----

This gets used in https://github.com/cockpit-project/cockpit-ostree/pull/579

 * [x] image-refresh centos-9-bootc