### PR TITLE
machine: add TEST_BIND_GLOBAL=1 envvar

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -217,6 +217,7 @@ class VirtNetwork:
 
         isolate: True for no network at all, "user" for QEMU user network instead of bridging
         """
+        localaddr = '' if os.getenv('TEST_BIND_GLOBAL') else '127.0.0.2'
         result = self.interface(number)
         result["mcast"] = self.network
         result["restrict"] = "on" if restrict else "off"
@@ -225,8 +226,8 @@ class VirtNetwork:
         forwards = []
         for remote, local in result["forward"].items():
             local = self._lock(int(local) + result["number"])
-            result["forward"][remote] = f"127.0.0.2:{local}"
-            forwards.append(f"hostfwd=tcp:{result['forward'][remote]}-:{remote}")
+            result["forward"][remote] = f"{localaddr or '127.0.0.1'}:{local}"
+            forwards.append(f"hostfwd=tcp:{localaddr}:{local}-:{remote}")
             if remote == "22":
                 result["control"] = result["forward"][remote]
             elif remote == "9090":


### PR DESCRIPTION
Sometimes it would be nice to be able to test changes to Cockpit from browsers running on other systems (like phones, tablets, Mac, Windows, etc.) which we have on our local networks.

Let's add an environment variable to cause the port forwards for the virtual machine to be bound globally instead of only on 127.0.0.2.  That way, you can hit an address like https://x1.fritz.box:9091/ from your phone.

A minor note about the implementation: although we bind to no particular interface, we still need an address to use for the tests themselves to contact the VM.  Since we're bound to all interfaces, this could be any address for the local machine.  I wanted to use "localhost" here, but it appears as though we try to use this address without DNS lookup, so I went for 127.0.0.1.  That's the address that the tests will use, and it's the address that will be shown in the messages printed by the likes of `vm-run`, which provides a way to see that the "global mode" is in effect.