### PR TITLE
task: Change ellipsis type check for mypy 1.9.0 compatibility

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -293,7 +293,7 @@ class GitHub:
             elif modified:
                 headers['If-Modified-Since'] = modified
         response = self.request("GET", resource, "", headers)
-        if response['status'] == 404 and default is not ...:
+        if response['status'] == 404 and not isinstance(default, EllipsisType):
             return default
         elif cached and response['status'] == 304:  # Not modified
             self.cache.write(qualified, cached)


### PR DESCRIPTION
mypy 1.9.0 started failing on this:

> task/github.py:297: error: Incompatible return value type (got "_DT | EllipsisType", expected "_T | _DT")  [return-value]

which is nonsense -- the `default is not ...` explicitly ensures that we are not returning an ellipsis.

Rewrite this using a type instead of a value check, which works.

Fixes #6271