### PR TITLE
testmap: Introduce cockpit-machines rhel-8 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -132,6 +132,11 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel-9-4',
             'rhel-9-5',
         ],
+        'rhel8': [
+            'rhel-8-10',
+            'rhel-9-4',
+            'rhel-9-4/firefox',
+        ],
         '_manual': [
             'centos-10',
             'fedora-rawhide',


### PR DESCRIPTION
Due to synced RHEL releases, this will also receive updates for RHEL 9.4.

---

I just pushed the branch. The very first PR against it will/has to fix CI, so I didn't bother with `_manual`.