### PR TITLE
testmap: Fix c-machines rhel-8 branch name

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -132,7 +132,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel-9-4',
             'rhel-9-5',
         ],
-        'rhel8': [
+        'rhel-8': [
             'rhel-8-10',
             'rhel-9-4',
             'rhel-9-4/firefox',


### PR DESCRIPTION
Mea culpa.. It's https://github.com/cockpit-project/cockpit-machines/tree/rhel-8