### PR TITLE
images: Fix tumbleweed networking issue

### DIFF
--- a/images/opensuse-tumbleweed
+++ b/images/opensuse-tumbleweed
@@ -1,1 +1,1 @@
-opensuse-tumbleweed-3763ca5ebfcfe243bb71d09a63a6482aadd3ccafa8d8b8ece8460d1de4ccd6cd.qcow2
+opensuse-tumbleweed-1a037fec4342b596f72379f0f9f79843d794f63521fd0eb271d9c46858192bb3.qcow2

--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -77,7 +77,6 @@ rpm-config-SUSE \
 "
 
 NETWORK_PACKAGES="\
-systemd-network \
 sssd \
 sssd-dbus \
 "
@@ -121,9 +120,11 @@ echo 'PasswordAuthentication yes' >> /usr/etc/ssh/sshd_config
 rm -f '/etc/systemd/system/multi-user.target.wants/auditd.service'
 rm -rf /var/log/audit/
 
-systemctl enable --now systemd-networkd.service
-
 echo root:foobar | chpasswd
+
+# cloud-init is not needed after initial setup and will only slow down boot time
+# and it trying to re-setup networking on every boot can cause network issues
+zypper remove -y cloud-init
 
 # reduce image size
 zypper clean


### PR DESCRIPTION
cloud-init and systemd-network has somekind of weird interaction that made systemd-networkd-wait-online.service time out on boot.

It turns out that if cloud-init is removed after the initial setup, tumbleweed is able to setup the networking correctly even without systemd-network.

Fixes #6241