### PR TITLE
naughty: Adjust #2412 pattern for current bots

### DIFF
--- a/naughty/rhel-8/2412-unlocking-stratis-during-boot
+++ b/naughty/rhel-8/2412-unlocking-stratis-during-boot
@@ -1,4 +1,4 @@
   File "check-storage-stratis", line *, in testEncrypted
     m.*reboot()
 *
-machine_core.exceptions.Failure: Timeout waiting for system to reboot properly
+*exceptions.Failure: Timeout waiting for system to reboot properly

--- a/naughty/rhel-9/2412-unlocking-stratis-during-boot
+++ b/naughty/rhel-9/2412-unlocking-stratis-during-boot
@@ -1,4 +1,0 @@
-  File "check-storage-stratis", line *, in testEncrypted
-    m.*reboot()
-*
-machine_core.exceptions.Failure: Timeout waiting for system to reboot properly


### PR DESCRIPTION
The traceback now includes the top-level `machine` module.

Delete the pattern on RHEL 9. The bug is fixed there, and the naughty hasn't matched any more since April for the same reason.

Closes https://github.com/cockpit-project/cockpit/pull/20373

----

See https://github.com/cockpit-project/cockpit/pull/20373 for all the debugging details.