### PR TITLE
bootc.bootstrap: don't explicitly resize /sysroot

### DIFF
--- a/images/centos-9-bootc
+++ b/images/centos-9-bootc
@@ -1,1 +1,1 @@
-centos-9-bootc-bad634097924d7b81cb096225b937e4712cc0eed89accb1b5ff74afa30a2397a.qcow2
+centos-9-bootc-4dbb34726a75912eca6b05ae71be07a9506cad169ade4bcac31cfe462349849d.qcow2

--- a/images/scripts/lib/bootc.bootstrap
+++ b/images/scripts/lib/bootc.bootstrap
@@ -76,13 +76,10 @@ m.kill()
 # it's too small by default
 subprocess.check_call(['qemu-img', 'resize', '-f', 'qcow2', args.vmpath, '+20G'])
 
+# booting the image will cause bootc-generic-growpart to grow the /sysroot partition
 m = testvm.VirtMachine(image=os.path.abspath(args.vmpath), maintain=True, verbose=True)
 m.start()
 m.wait_boot()
-# resize file system to the full qcow device size
-m.execute('growpart /dev/vda 4')
-m.execute('mount -o remount,rw /sysroot')
-m.execute('xfs_growfs -d /dev/vda4')
 
 # copy OCI image into the VM as well, for cockpit-ostree tests
 # the .setup script processes this further


### PR DESCRIPTION
This gets handled automatically now, by `bootc-generic-growpart.service`.

 * [x] image-refresh centos-9-bootc