### PR TITLE
naughty: add systemd-logind naughty to Fedora rawhide

### DIFF
--- a/naughty/fedora-41/6384-systemd-logind-utmp
+++ b/naughty/fedora-41/6384-systemd-logind-utmp
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "*test/verify/check-users", line *, in testUserPasswords
+    b.wait_visible("#account-logout[disabled]")
+*
+testlib.Error: timeout
+wait_js_cond(ph_is_present("#account-logout[disabled]")): condition did not become true


### PR DESCRIPTION
We can't test naughties on Packit but you can see the failure here:

https://artifacts.dev.testing-farm.io/67ee8504-29c3-4c4e-ad3a-66d686d4d475/work-basic7sdo6kuy/plans/all/basic/execute/data/guest/default-0/test/browser/basic-1/output.txt

I'll fill the systemd issue later today, it needs some more investigation.