### PR TITLE
naughty: Add pattern for rhbz#2282287

### DIFF
--- a/naughty/fedora-40/6411-nfsd-kernel-crash
+++ b/naughty/fedora-40/6411-nfsd-kernel-crash
@@ -1,0 +1,4 @@
+ File "test/verify/check-sosreport", line *
+    b.wait_not_present("#sos-dialog")
+*
+testlib.Error: timeout


### PR DESCRIPTION
`sos report` hangs due to a kernel crash in the NFS server. That oops unfortunately doesn't show up in the test output, so we can only catch the hang.

This breaks both testVerbose() and testWithUrlRoot(), so skip the test name.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2282287
Known issue #6411

-----

Fixes https://github.com/cockpit-project/cockpit/issues/20488