### PR TITLE
naughty: Copy relevant libvirt-related naughties from Fedora 40

### DIFF
--- a/naughty/rhel-10/2538-iso-over-https
+++ b/naughty/rhel-10/2538-iso-over-https
@@ -1,0 +1,1 @@
+Unknown driver 'https'

--- a/naughty/rhel-10/4915-libvirt-getstats-timeout
+++ b/naughty/rhel-10/4915-libvirt-getstats-timeout
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*", line *, in testVsock
+*
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Shut off"))*

--- a/naughty/rhel-10/5944-selinux-libvirt-swtpm
+++ b/naughty/rhel-10/5944-selinux-libvirt-swtpm
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "test/check-machines-create", line *, in testConfigureBeforeInstallBiosTPM
+    b.wait_in_text(f"#vm-{vmName}-system-state", "Running")
+*
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Running")): * actual text: Shut off

--- a/naughty/rhel-10/5944-selinux-libvirt-swtpm-2
+++ b/naughty/rhel-10/5944-selinux-libvirt-swtpm-2
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "test/check-machines-create", line *, in testConfigureBeforeInstall
+    testlib.wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)
+*
+    raise Error(msg or "Condition did not become true.")
+testlib.Error: Condition did not become true.

--- a/naughty/rhel-10/5944-selinux-libvirt-swtpm-3
+++ b/naughty/rhel-10/5944-selinux-libvirt-swtpm-3
@@ -1,0 +1,7 @@
+> error: *"exit_status":1* internal error: Could not run '/usr/bin/swtpm_setup'*
+*
+Traceback (most recent call last):
+  File "test/check-machines-create", line *, in testConfigureBeforeInstallEFI
+    b.wait_in_text(f"#vm-{vmName}-system-state", "Running")
+*
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Running")): Uncaught (in promise) Error: actual text: Shut off

--- a/naughty/rhel-10/5979-virtinterfaced-crash-lookup-by-mac-udev
+++ b/naughty/rhel-10/5979-virtinterfaced-crash-lookup-by-mac-udev
@@ -1,0 +1,3 @@
+#* udevInterfaceLookupByMACString*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.

--- a/naughty/rhel-10/5979-virtinterfaced-crash-lookup-by-mac-udev-2
+++ b/naughty/rhel-10/5979-virtinterfaced-crash-lookup-by-mac-udev-2
@@ -1,0 +1,3 @@
+#* udevConnectListAllInterfaces*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *virtinterfaced* dumped core.


### PR DESCRIPTION
We want to start testing c-machines on RHEL/CentOS 10 [1]. That has interited a bunch of bugs from Fedora 40, copy the naughties.

[1] https://github.com/cockpit-project/cockpit-machines/pull/1647