### PR TITLE
naughty: Add pattern for RHEL 10 virtproxyd SELinux denial

### DIFF
--- a/naughty/rhel-10/6414-selinux-virtproxyd
+++ b/naughty/rhel-10/6414-selinux-virtproxyd
@@ -1,0 +1,3 @@
+*TestMachinesVirtualization.testLibvirt*
+testlib.Error: FAIL: Test completed, but found unexpected browser errors:
+error: Failed to get libvirt version from the dbus API: .*internal error: Cannot find start time for pid.*


### PR DESCRIPTION
Downstream report: https://issues.redhat.com/browse/RHEL-37822
Known issue #6414

---

See https://github.com/cockpit-project/cockpit-machines/pull/1647#issuecomment-2124577327 , [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1647-1f7cea0d-20240522-111059-centos-10/log.html#62)
