### PR TITLE
images: Add libcriu2 dependency for tumbleweed

### DIFF
--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -20,6 +20,7 @@ printf 'dictcheck = 0\nminlen = 6\n' >> /etc/security/pwquality.conf
 #
 COCKPIT_DEPS="\
 criu \
+libcriu2 \
 device-mapper \
 glibc-locale \
 glib-networking \


### PR DESCRIPTION
Add a missing libcriu2 dependency for tumbleweed that's required for podman testing