### PR TITLE
setup-deploy-keys: cockpit-files access to node-cache

### DIFF
--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -77,6 +77,7 @@ deploy_to osbuild/cockpit-composer-weblate \
 # cockpit-files
 deploy_to cockpit-project/cockpit-files \
     --deploy-from \
+        cockpit-project/cockpit-files/npm-update/SELF_DEPLOY_KEY \
         cockpit-project/cockpit-files/self/DEPLOY_KEY
 
 deploy_to cockpit-project/cockpit-files-weblate \
@@ -88,6 +89,8 @@ deploy_to cockpit-project/node-cache \
     --deploy-from \
         cockpit-project/cockpit/npm-update/NODE_CACHE_DEPLOY_KEY \
         cockpit-project/cockpit/node-cache/DEPLOY_KEY \
+        cockpit-project/cockpit-files/npm-update/SELF_DEPLOY_KEY \
+        cockpit-project/cockpit-files/node-cache/SELF_DEPLOY_KEY \
         cockpit-project/cockpit-machines/npm-update/NODE_CACHE_DEPLOY_KEY \
         cockpit-project/cockpit-machines/node-cache/DEPLOY_KEY \
         cockpit-project/cockpit-podman/npm-update/NODE_CACHE_DEPLOY_KEY \


### PR DESCRIPTION
We just merged the post-dependabot workflow for updating the node-cache, so add its environment (`npm-update`) plus add the `node-cache` environment as well — we don't use it yet, but we will use it once we start making releases, hopefully soon.

 - [x] run it