### PR TITLE
naughty: Add pattern for sos crash in Rawhide

### DIFF
--- a/naughty/fedora-41/6514-sos-pipes
+++ b/naughty/fedora-41/6514-sos-pipes
@@ -1,0 +1,6 @@
+> error: Failed to call sos report: {"problem":null,"exit_status":1,"exit_signal":null,"message":""}
+*
+  File "test/verify/check-sosreport", line *
+    b.wait_not_present("#sos-dialog")
+*
+testlib.Error: timeout


### PR DESCRIPTION
Known issue #6514
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2292625

---

Handles [recent cockpit rawhide failure](https://artifacts.dev.testing-farm.io/501826fa-1daf-4016-8afb-29d2b2183f4a/)