### PR TITLE
s3: set charset=utf-8 on fallback mime type

### DIFF
--- a/lib/aio/s3.py
+++ b/lib/aio/s3.py
@@ -161,7 +161,7 @@ class S3Destination(Destination, contextlib.AsyncExitStack):
 
     def write(self, filename: str, data: bytes) -> None:
         content_type, content_encoding = mimetypes.guess_type(filename)
-        headers = {**self.session.headers, 'Content-Type': content_type or 'text/plain'}
+        headers = {**self.session.headers, 'Content-Type': content_type or 'text/plain; charset=utf-8'}
         if content_encoding:
             headers['Content-Encoding'] = content_encoding
 


### PR DESCRIPTION
HTTP/1.1 says that latin1 is the default, so let's make sure we specify UTF-8.  We could do that for all `text/*` types, but HTML can take care of itself and we don't otherwise encounter many other text documents during testing.

This is mostly about seeing non-ascii characters showing up incorrectly in the main log file — the usual thing where the "—" ends up looking more like `â€”`.

example: https://cockpit-logs.us-east-1.linodeobjects.com/pull-535-5b0ef423-20240620-055912-fedora-40/log