### PR TITLE
naughty: autonaughty a bridge crash on arch

### DIFF
--- a/naughty/arch/6531-endpoint-traceback
+++ b/naughty/arch/6531-endpoint-traceback
@@ -1,0 +1,9 @@
+*TestFiles.testSorting*
+asyncio-ERROR: Exception in callback None()
+handle: <Handle cancelled>
+Traceback (most recent call last):
+*
+self.router.endpoints[self].remove(channel)
+*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+asyncio-ERROR: Exception in callback None()


### PR DESCRIPTION
A particular set of events in a testcase in cockpit-files is causing this to turn up almost all the time — but only on arch.

Known issue https://github.com/cockpit-project/bots/issues/6531 See also https://github.com/cockpit-project/cockpit/issues/20635