### PR TITLE
tests-scan: prioritise /devel scenario

### DIFF
--- a/tests-scan
+++ b/tests-scan
@@ -66,8 +66,10 @@ def is_internal_context(context: str) -> bool:
 
 
 def queue_test(entry: QueueEntry, dq: distributed_queue.DistributedQueue) -> None:
-    queue = 'rhel' if is_internal_context(entry['job']['context']) else 'public'
-    properties = pika.BasicProperties(priority=distributed_queue.BASELINE_PRIORITY)
+    context = entry['job']['context']
+    queue = 'rhel' if is_internal_context(context) else 'public'
+    priority = distributed_queue.MAX_PRIORITY if '/devel' in context else distributed_queue.BASELINE_PRIORITY
+    properties = pika.BasicProperties(priority=priority)
     dq.channel.basic_publish('', queue, json.dumps(entry), properties=properties)
     logging.info("Published job: %s", json.dumps(entry["job"]))
 


### PR DESCRIPTION
Add back a very simple priority scheme: any test that hsa '/devel' in the name runs first.  We want to do this because the '/devel' scenarios take longer, so we want to get them running ASAP.