### PR TITLE
testmap: Enable rhel-10-0 on starter-kit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -79,11 +79,11 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'centos-10',
             'fedora-rawhide',
             'opensuse-tumbleweed',
+            'rhel-10-0',
         ],
         '_manual': [
             'centos-9-bootc',
             'rhel-9-5',
-            'rhel-10-0',
         ]
     },
     'cockpit-project/cockpit-ostree': {


### PR DESCRIPTION
This gives us some minimal initial gating of rhel-10-0 refreshes.