### PR TITLE
testmap: Enable cockpit-podman on RHEL 10

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -110,6 +110,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel-8-10',
             'rhel-9-4',
             'rhel-9-5',
+            'rhel-10-0',
             'rhel4edge',
             'ubuntu-2204',
             'ubuntu-stable',
@@ -118,7 +119,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'centos-10',
             'fedora-rawhide',
             'opensuse-tumbleweed',
-            'rhel-10-0',
         ],
     },
     'cockpit-project/cockpit-machines': {


### PR DESCRIPTION
We are over the initial "everything is broken" hump, and start to regularly land our releases in RHEL 10. Let's shift left the gating failures.

---

@jelly I don't have a strong feeling about this either way. I mostly lean towards "let's enable it if it works, and pull the plug again if it becomes too much of a burden". WDYT?