### PR TITLE
lib: allow manual RHEL-9-5/CentOS-10 testing in cockpit-files

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -159,7 +159,8 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         ],
         '_manual': [
             TEST_OS_DEFAULT,
-            'rhel-9-4',
+            'rhel-9-5',
+            'centos-10',
             'rhel-10-0',
         ],
     },


### PR DESCRIPTION
We might wanna add these by default for replacing gating tests failures. But first `_manual`, tests-trigger in a PR and then add `rhel-9-5`. (Since today our image has Cockpit 319)