### PR TITLE
test: Drop unnecessary async function keyword

### DIFF
--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 import re
 import time
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -126,7 +126,7 @@ def test_lru_cache() -> None:
 
 
 @pytest.fixture
-async def service() -> AsyncIterator[GitHubService]:
+def service() -> Iterator[GitHubService]:
     server = GitHubService()
     with aioresponses() as mock:
         mock.post(re.compile(''), callback=server.post, repeat=True)


### PR DESCRIPTION
Spotted by latest ruff:

> test/test_aio.py:129:11: RUF029 Function `service` is declared `async`, but doesn't `await` or use `async` features.

---

I did a tasks container refresh this morning, and [this started to happen](https://github.com/cockpit-project/bots/actions/runs/9788588710/job/27026908806?pr=6576)