### PR TITLE
images: Stop installing packages from unstable in debian-testing

### DIFF
--- a/images/debian-testing
+++ b/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-70fd0b64a9e6f2d5b4c15d19cf1d69ec5f0b667fa25a4af2abf840d3acb384f2.qcow2
+debian-testing-121001e51c225f9efcbc9c741141c58c132497fe2a983e7dd3bed9e6d473dbf0.qcow2

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -66,6 +66,7 @@ iproute2 \
 krb5-user \
 lastlog2 \
 libnss-myhostname \
+libpam-pwquality \
 ltrace \
 mdadm \
 nfs-server \

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -83,6 +83,7 @@ socat \
 sosreport \
 strace \
 systemd-coredump \
+systemd-cryptsetup \
 tang \
 targetcli-fb \
 tcsh \
@@ -159,6 +160,11 @@ Package: passwd
 Pin: version 1:4.13+dfsg1-4ubuntu3.1
 Pin-Priority: -1
 EOF
+fi
+
+# systemd-cryptsetup was split out in 256.1-2, older releases don't have it yet
+if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] || [ "$IMAGE" = "ubuntu-stable" ]; then
+    TEST_PACKAGES="${TEST_PACKAGES/systemd-cryptsetup /}"
 fi
 
 # smaller and faster initrd; see https://launchpad.net/bugs/1592684

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -135,24 +135,16 @@ if [ "$IMAGE" = "debian-testing" ]; then
     echo 'deb http://deb.debian.org/debian testing main' > /etc/apt/sources.list
     RELEASE=testing
 
-    # too buggy and uninstallable even in unstable, see https://tracker.debian.org/pkg/freeipa
-    IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client/}"
-
-    # HACK: some packages fell out of testing, get them from unstable
-    echo 'deb http://deb.debian.org/debian unstable main' >> /etc/apt/sources.list
-    cat <<EOF > /etc/apt/preferences.d/unstable
-Package: *
-Pin: release a=unstable
-Pin-Priority: -1
-
-Package: *sss*
-Pin: release a=unstable
-Pin-Priority: 10
-
-Package: *pcp*
-Pin: release a=unstable
-Pin-Priority: 10
-EOF
+    # some packages have been RC buggy for a long time and fell out of testing
+    # https://tracker.debian.org/pkg/freeipa
+    IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
+    # https://tracker.debian.org/pkg/sssd
+    IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/sssd-tools /}"
+    TEST_PACKAGES="${TEST_PACKAGES/sssd-dbus /}"
+    TEST_PACKAGES="${TEST_PACKAGES/sssd-proxy /}"
+    # https://tracker.debian.org/pkg/pcp
+    COCKPIT_DEPS="${COCKPIT_DEPS/libpcp3 /}"
+    COCKPIT_DEPS="${COCKPIT_DEPS/pcp /}"
 fi
 
 if [ "${IMAGE#ubuntu}" != "$IMAGE" ]; then
@@ -371,7 +363,7 @@ if [ "$IMAGE" = "ubuntu-stable" ]; then
 fi
 
 # pmlogger.service sometimes causes long shutdown hangs; disable all PCP services and timers
-systemctl --all --legend=false list-units 'pm*' | awk '{print $1}' | xargs systemctl disable
+systemctl --all --legend=false list-units 'pm*' | awk '{print $1}' | xargs --no-run-if-empty systemctl disable
 
 # reduce image size; don't keep old kernels
 sed -i '/linux/d' /etc/apt/apt.conf.d/01autoremove


### PR DESCRIPTION
pcp and sssd have been broken for a long time, and became entirely uninstallable from unstable due to the Python 3 transition. Stop the hack, and just drop the packages -- let's instead skip these cockpit tests on debian-testing, this is more honest.

Fixes #6566

 * [x] image-refresh debian-testing
 * [x] https://github.com/cockpit-project/cockpit/pull/20709
 * [x] investigate [`TestLogin.testExpired` regression](https://cockpit-logs.us-east-1.linodeobjects.com/pull-20709-103e643d-20240704-102645-debian-testing-other-bots%236579/log.html#64-2)