### PR TITLE
Image refresh for centos-9-bootc

### DIFF
--- a/images/centos-9-bootc
+++ b/images/centos-9-bootc
@@ -1,1 +1,1 @@
-centos-9-bootc-45933c33faa108ab9b1ed7761e10406afd579e49bcf086b9aa0c897ab6b3af48.qcow2
+centos-9-bootc-d80f0721282e49fec497b9cdd9831e96681839ffecda183da4ee535faa47c119.qcow2


### PR DESCRIPTION
Image refresh for centos-9-bootc
 * [x] image-refresh centos-9-bootc
 * [x] https://github.com/cockpit-project/cockpit-ostree/pull/663