### PR TITLE
machine: drop useless graphics class member

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -269,14 +269,12 @@ class VirtMachine(Machine):
         memory_mb: int | None = None,
         cpus: int | None = None,
         capture_console: bool = False,
-        graphics: bool = False,
         **kwargs: Any
     ):
         self.maintain = maintain
 
         self.memory_mb = memory_mb or VirtMachine.memory_mb or MEMORY_MB
         self.cpus = cpus or VirtMachine.cpus or 1
-        self.graphics = graphics
         if capture_console:
             console_file = tempfile.NamedTemporaryFile(suffix='.log', prefix='console-')
         else:


### PR DESCRIPTION
Since the cleanup of Windows support in
b4ac348460bc63088a9588b7b87fae24de0b6e3a graphics basically controls nothing anymore and a graphics console is now launched with a `vm-run` `--graphics` option.