### PR TITLE
Revert "machine: drop useless graphics class member"

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -271,12 +271,14 @@ class VirtMachine(Machine):
         memory_mb: int | None = None,
         cpus: int | None = None,
         capture_console: bool = False,
+        graphics: bool = False,
         **kwargs: Any
     ):
         self.maintain = maintain
 
         self.memory_mb = memory_mb or VirtMachine.memory_mb or MEMORY_MB
         self.cpus = cpus or VirtMachine.cpus or 1
+        self.graphics = graphics
         if capture_console:
             console_file = tempfile.NamedTemporaryFile(suffix='.log', prefix='console-')
         else:


### PR DESCRIPTION
`vm-run` supports and sets this attribute.

This reverts commit 7331ff9da77eaa986593f16e4ab400f61fe47cba.

---

Fixes
```
❱❱❱ ./vm-run fedora-40
Traceback (most recent call last):
  File "/var/home/martin/upstream/bots/./vm-run", line 54, in <module>
    machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/martin/upstream/bots/machine/machine_core/machine_virtual.py", line 306, in __init__
    Machine.__init__(self, image=image, **kwargs)
TypeError: Machine.__init__() got an unexpected keyword argument 'graphics'


```