### PR TITLE
vm-run: don't pass graphics argument

### DIFF
--- a/vm-run
+++ b/vm-run
@@ -53,7 +53,7 @@ try:
 
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,
                                  networking=network.host(restrict=args.no_network),
-                                 memory_mb=args.memory, cpus=args.cpus, graphics=args.graphics)
+                                 memory_mb=args.memory, cpus=args.cpus)
 
     # Check that image is downloaded
     if not os.path.exists(machine.image_file):


### PR DESCRIPTION
Commit 7331ff9da77eaa986593f removed the useless graphics option, but didn't remove it from vm-run.