### PR TITLE
naughty: Add pattern for F40 SELinux update breaking libvirt migration

### DIFF
--- a/naughty/fedora-40/6678-selinux-libvirt-ssh
+++ b/naughty/fedora-40/6678-selinux-libvirt-ssh
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/check-machines-migrate", line *, in test*
+    self._testMigrationGeneric(*
+  File "test/check-machines-migrate", line *, in _testMigrationGeneric
+    b.wait_not_present("#migrate-modal")
+*
+testlib.Error: timeout


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2301910
Known issue #6678

Fixes https://github.com/cockpit-project/cockpit-machines/issues/1743