### PR TITLE
testmap: updates to sub-man & sub-man-cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -178,47 +178,40 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     },
     'candlepin/subscription-manager': {
         'main': [
-            'rhel-9-0',
-            'rhel-9-2',
-            'rhel-9-3',
-            'rhel-9-4',
+            'rhel-9-5',
             'fedora-39',
             'fedora-40',
         ],
         'subscription-manager-1.28': [
-            'rhel-8-4',
-            'rhel-8-6',
             'rhel-8-8',
-            'rhel-8-9',
-        ],
-        'subscription-manager-1.28.29': [
-            'rhel-8-6',
+            'rhel-8-10',
         ],
         'subscription-manager-1.28.36': [
             'rhel-8-8',
         ],
-        'subscription-manager-1.29.26': [
-            'rhel-9-0',
+        'subscription-manager-1.29': [
+            'rhel-9-2',
+            'rhel-9-4',
+            'rhel-9-5',
         ],
         'subscription-manager-1.29.33': [
             'rhel-9-2',
         ],
+        'subscription-manager-1.29.40': [
+            'rhel-9-4',
+        ],
         '_manual': [
-            'rhel-8-10',
-            'rhel-9-5',
             'rhel-10-0',
         ],
     },
     'candlepin/subscription-manager-cockpit': {
         'main': [
-            'centos-9-stream',
-            'rhel-9-3',
-            'rhel-9-4',
+            'centos-9-stream/subscription-manager-1.29',
+            'rhel-9-5/subscription-manager-1.29',
             'fedora-39',
             'fedora-40',
         ],
         '_manual': [
-            'rhel-9-5',
             'rhel-10-0',
         ],
     },
@@ -248,8 +241,8 @@ IMAGE_REFRESH_TRIGGERS = {
         *contexts('debian-stable', COCKPIT_SCENARIOS, repo='cockpit-project/cockpit'),
         *contexts('rhel-9-4', COCKPIT_SCENARIOS, repo='cockpit-project/cockpit'),
         "rhel-8-10@cockpit-project/cockpit/rhel-8",
-        "rhel-8-8@candlepin/subscription-manager/subscription-manager-1.28",
-        "rhel-9-4@candlepin/subscription-manager-cockpit",
+        "rhel-8-10@candlepin/subscription-manager/subscription-manager-1.28",
+        "rhel-9-5@candlepin/subscription-manager-cockpit",
     ],
     # Anaconda builds in fedora-rawhide and runs tests in fedora-rawhide-boot
     "fedora-rawhide": [


### PR DESCRIPTION
Long-awaited and almost forgotten updates for subscription-manager and
subscription-manager-cockpit:
- sub-man/main: this branch now tracks the work for RHEL 10.x, so drop
  almost the RHEL 9 OSes (leaving the most recent one to help for
  backporting); rhel-10-0 will be added later when a fixed image is
  available
- sub-man/1.28: drop EOL & out of EUS OSes from there; add 8.10, which
  is what the branch tracks now
- sub-man/1.28.29: drop, as it is out of EUS
- sub-man/1.29: new branch that tracks the work for RHEL 9.x, so add the
  supported RHEL 9 OSes to it
- sub-man/1.29.26: drop, as it is out of EUS
- sub-man/1.29.40: new branch to track the work for RHEL 9.4.z
- sub-man-cockpit/main: add the latest version of RHEL 9.x, and modifiy
  CS 9 to use the right upstream branch for EL9
- drop almost all the manual OSes for sub-man & sub-man-cockpit,
  leaving RHEL 10, as every OS there is now in supported branches

Update also the triggered versions for the "service" image: bump to the latest versions of RHEL 9 & RHEL 8.