### PR TITLE
test-failure-policy: Ignore `window.` prefix for ph_* test helper functions

### DIFF
--- a/test-failure-policy
+++ b/test-failure-policy
@@ -146,6 +146,9 @@ def normalize_traceback(trace: str) -> str:
     trace = re.sub(r'audit\([0-9.:]+\)', 'audit(0)', trace)
     trace = re.sub(r'\b(pid|ino)=[0-9]+ ', r'\1=0 ', trace)
 
+    # testlib API change: move ph_*() test-functions to window object
+    trace = re.sub(r'\bwindow.ph_', r'ph_', trace)
+
     # in Python 3, testlib.Error is shown with namespace
     trace = re.sub(r'testlib\.Error', 'Error', trace)
     return trace


### PR DESCRIPTION
We will soon move cockpit's test-functions.js helpers to the `window` object, so that they become compatible with Webdriver's script preloading API. This affects all naughty patterns which include any of the `ph_*()` function calls (i.e. most patterns). Until this all lands and settles down, avoid mass-changing all the patterns and just remove the `window.` prefix for the comparison.

Note that the naughties also apply to old project branches.

---

I tested locally that this works. Once this lands, I'll send a cockpit PR to actually do that move -- it's intrusive but simple, and I want it out of the way. Then https://github.com/cockpit-project/cockpit/pull/20832 should become much greener.