### PR TITLE
machine_core: Fix and clean up start_cockpit()

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -260,24 +260,26 @@ class Machine(ssh_connection.SSHConnection):
             self.wait_for_cockpit_running(atomic_wait_for_host or "localhost")
         elif tls:
             self.execute("""
-            rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
-            systemctl reset-failed 'cockpit*' &&
-            systemctl daemon-reload &&
-            systemctl stop --quiet cockpit.service &&
+            systemctl stop --quiet cockpit.service
+            rm -f /etc/systemd/system/cockpit.service.d/notls.conf
+            systemctl reset-failed cockpit.socket 2>/dev/null || true
+            systemctl reset-failed cockpit.service 2>/dev/null || true
+            systemctl daemon-reload
             systemctl start cockpit.socket
             """)
         else:
             self.execute("""
-            mkdir -p /etc/systemd/system/cockpit.service.d/ &&
-            rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
+            systemctl stop --quiet cockpit.service
+            mkdir -p /etc/systemd/system/cockpit.service.d/
+            rm -f /etc/systemd/system/cockpit.service.d/notls.conf
             printf "[Service]
             ExecStartPre=-/bin/sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'
             ExecStart=
             %s --no-tls" `grep ExecStart= /lib/systemd/system/cockpit.service` \
-                    > /etc/systemd/system/cockpit.service.d/notls.conf &&
-            systemctl reset-failed 'cockpit*' &&
-            systemctl daemon-reload &&
-            systemctl stop --quiet cockpit.service &&
+                    > /etc/systemd/system/cockpit.service.d/notls.conf
+            systemctl reset-failed cockpit.socket 2>/dev/null || true
+            systemctl reset-failed cockpit.service 2>/dev/null || true
+            systemctl daemon-reload
             systemctl start cockpit.socket
             """)
 


### PR DESCRIPTION
Explicitly `reset-failed` our two main cockpit units. Globbing does not always work, and tests like `TestLogin.testClientCertAuthentication` which restart cockpit in fast succession still ran into "Failed with result 'start-limit-hit'."

Stop the service before daemon-reload, which is more robust.

Since commit b7d0edba5d026 we don't need the `&&` any more, and they are in fact actively harmful. Drop them.

---

This should fix the [downstream gating failure](https://dashboard.osci.redhat.com/#/details/brew-build-63204955?focus=osci.brew-build.tier0.functional) (sorry RH internal link). The [TF journal artifact](https://artifacts.osci.redhat.com/testing-farm/ee0b95d4-1f20-465f-8d12-3b20d9ec050b/work-main6dzrwp30/plans/all/main/execute/data/guest/default-0/test/browser/main-1/data/TestLogin-testClientCertAuthentication-rhel-10-0-10.88.0.1-22-FAIL.log.gz) gives it away.