### PR TITLE
machine_core: Revert unit resetting in start_cockpit()

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -262,8 +262,7 @@ class Machine(ssh_connection.SSHConnection):
             self.execute("""
             systemctl stop --quiet cockpit.service
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf
-            systemctl reset-failed cockpit.socket 2>/dev/null || true
-            systemctl reset-failed cockpit.service 2>/dev/null || true
+            systemctl reset-failed 'cockpit*'
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)
@@ -277,8 +276,7 @@ class Machine(ssh_connection.SSHConnection):
             ExecStart=
             %s --no-tls" `grep ExecStart= /lib/systemd/system/cockpit.service` \
                     > /etc/systemd/system/cockpit.service.d/notls.conf
-            systemctl reset-failed cockpit.socket 2>/dev/null || true
-            systemctl reset-failed cockpit.service 2>/dev/null || true
+            systemctl reset-failed 'cockpit*'
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)


### PR DESCRIPTION
Commit 2a94280e67a4e was wrong: cockpit.service pulls in a lot of other
units, such as cockpit-ws-user.service, cockpit-motd.service, or
cockpit-wsinstance-http.socket. Now *these* run into restart limit hits.

Unfortunately systemd's restart limit hit tracking is very
unpredictable/broken right now [1], so this is hard to
reproduce/investigate.

Revert to the previous approach with the glob, even though that
is known to be insufficient.

We can't use `systemctl reset-failed` without argument, as at least one
test sets up a failed unit and tests that state on the Services page.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2303828

----

[RHEL downstream gating](https://artifacts.osci.redhat.com/testing-farm/c1bf0d71-4a06-4f24-ae47-33a9a377a008/) *still* failed, see the [journal](https://artifacts.osci.redhat.com/testing-farm/c1bf0d71-4a06-4f24-ae47-33a9a377a008/work-mainckkyzd7o/plans/all/main/execute/data/guest/default-0/test/browser/main-1/data/TestLogin-testClientCertAuthentication-rhel-10-0-10.88.0.1-22-FAIL.log.gz). I've tried for a full hour to reproduce this locally on our rhel-10-0 image, but in vain :crying_cat_face:, even with totally silly attempts like

```diff
--- test/verify/check-static-login
+++ test/verify/check-static-login
@@ -755,6 +755,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
     def testClientCertAuthentication(self):
         m = self.machine
 
+        for _i in range(20):
+            m.start_cockpit(tls=True)
+            m.execute(['curl', '-k', 'https://localhost:9090/cockpit/login'])
+            m.stop_cockpit()
+        return
+
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):
             # on Debian/Ubuntu, an unconfigured sssd fails to start, so only restart it at the end if it was running before
             # also, sssd is split into several services

```
and removing *all* `reset-failed` from bots. It *still* succeeds on both fedora-40 and rhel-10-0.

 So I again have to do this blindly.