### PR TITLE
tests-scan: Drop Firefox hack

### DIFF
--- a/tests-scan
+++ b/tests-scan
@@ -58,8 +58,7 @@ def build_policy(repo: str, requested_contexts: Collection[str]) -> Policy:
 
 
 def is_internal_context(context: str) -> bool:
-    # HACK: CentOS CI doesn't like firefox, browser fails to start way too often
-    for pattern in ["rhel", "edge", "vmware", "openstack", "/firefox"]:
+    for pattern in ["rhel"]:
         if pattern in context:
             return True
     return False


### PR DESCRIPTION
Firefox tests run fine on our current infrastructure, and we only have one type of runner anyway. Stop stuffing them into the "rhel" queue.

Also drop the obsolete "edge", "vmware", and "openstack" matches, we haven't had these tests for years.