### PR TITLE
testmap: Run cockpit-files on rhel-9-5

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -149,10 +149,10 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             f'{TEST_OS_DEFAULT}/devel',
             'fedora-rawhide',
             'centos-10',
+            'rhel-9-5',
             'rhel-10-0',
         ],
         '_manual': [
-            'rhel-9-5',
         ],
     },
     'osbuild/cockpit-composer': {


### PR DESCRIPTION
Tests were fixed in
https://github.com/cockpit-project/cockpit-files/pull/713