### PR TITLE
images: Add ubuntu-2404

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -52,6 +52,7 @@ REFRESH = {
     "fedora-rawhide-live-boot": REFRESH_30,
     "opensuse-tumbleweed": {},
     "ubuntu-2204": {},
+    "ubuntu-2404": {},
     "ubuntu-stable": {},
     "rhel-8-8": REFRESH_30,
     "rhel-8-10": {},

--- a/images/scripts/debian.setup
+++ b/images/scripts/debian.setup
@@ -105,7 +105,7 @@ if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] ; then
 fi
 
 # introduced in util-linux 2.40.1-5
-if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] || [ "$IMAGE" = "ubuntu-stable" ]; then
+if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] || [ "$IMAGE" = "ubuntu-2404" ] || [ "$IMAGE" = "ubuntu-stable" ]; then
     TEST_PACKAGES="${TEST_PACKAGES/lastlog2/}"
 fi
 
@@ -169,7 +169,7 @@ EOF
 fi
 
 # systemd-cryptsetup was split out in 256.1-2, older releases don't have it yet
-if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] || [ "$IMAGE" = "ubuntu-stable" ]; then
+if [ "$IMAGE" = "debian-stable" ] || [ "$IMAGE" = "ubuntu-2204" ] || [ "$IMAGE" = "ubuntu-2404" ] || [ "$IMAGE" = "ubuntu-stable" ]; then
     TEST_PACKAGES="${TEST_PACKAGES/systemd-cryptsetup /}"
 fi
 
@@ -362,7 +362,7 @@ if [ "$RELEASE" = "testing" ]; then
 fi
 
 # HACK: https://launchpad.net/bugs/2040483
-if [ "$IMAGE" = "ubuntu-stable" ]; then
+if [ "$IMAGE" = "ubuntu-2404" ] || [ "$IMAGE" = "ubuntu-stable" ]; then
     mkdir -p /etc/containers/containers.conf.d
     printf '[CONTAINERS]\napparmor_profile=""\n' > /etc/containers/containers.conf.d/disable-apparmor.conf
 fi

--- a/images/scripts/ubuntu-2404.bootstrap
+++ b/images/scripts/ubuntu-2404.bootstrap
@@ -1,0 +1,3 @@
+#! /bin/sh -ex
+
+exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "https://cloud-images.ubuntu.com/daily/server/noble/current/noble-server-cloudimg-amd64.img"

--- a/images/scripts/ubuntu-2404.setup
+++ b/images/scripts/ubuntu-2404.setup
@@ -1,0 +1,1 @@
+debian.setup

--- a/images/ubuntu-2404
+++ b/images/ubuntu-2404
@@ -1,0 +1,1 @@
+ubuntu-2404-be8df2ade87690b0e8681eede5adfe781fe7ae7bf56a6d41684a3ae058544ac3.qcow2

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -66,6 +66,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         '_manual': [
             'fedora-rawhide',
             'opensuse-tumbleweed',
+            'ubuntu-2404',
         ],
     },
     'cockpit-project/starter-kit': {
@@ -115,6 +116,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'centos-10',
             'fedora-rawhide',
             'opensuse-tumbleweed',
+            'ubuntu-2404',
         ],
     },
     'cockpit-project/cockpit-machines': {
@@ -139,6 +141,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'centos-10',
             'fedora-rawhide',
             'rhel-10-0',
+            'ubuntu-2404',
         ],
     },
     'cockpit-project/cockpit-files': {

--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -221,13 +221,13 @@ class Machine(ssh_connection.SSHConnection):
             allowed.append('----')
             allowed.append('type=(PROCTITLE|SYSCALL|EXECVE|PATH|CWD).*')
 
-        if self.image in ["debian-testing", "ubuntu-stable"]:
+        if self.image in ["debian-testing", "ubuntu-2404", "ubuntu-stable"]:
             # https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/1989073
             allowed.append('audit.* apparmor="DENIED" operation="open" class="file" '
                            'profile=".*" name="/sys/devices/system/cpu/possible" .* '
                            'comm="qemu-system-x86" requested_mask="r" denied_mask="r".*')
 
-        if self.image in ["debian-testing", "ubuntu-stable"]:
+        if self.image in ["debian-testing", "ubuntu-2404", "ubuntu-stable"]:
             # https://bugs.debian.org/1053706
             allowed.append(r"Process.*\(w\) .*dumped core.")
             # yes, this ignores all crash info; we can't help it

--- a/naughty/ubuntu-2404/2485-ipa-leave-crash
+++ b/naughty/ubuntu-2404/2485-ipa-leave-crash
@@ -1,0 +1,7 @@
+warn*: Failed to leave domain: Running ipa-client-install failed
+*
+Traceback (most recent call last):
+  File "test/verify/check-system-realms", line *, in testQualifiedUsers
+    b.wait_not_present("#realms-leave-dialog")
+*
+testlib.Error: timeout

--- a/naughty/ubuntu-2404/4915-libvirt-getstats-timeout
+++ b/naughty/ubuntu-2404/4915-libvirt-getstats-timeout
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*", line *, in testVsock
+*
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Shut off"))*

--- a/naughty/ubuntu-2404/5364-apparmor-sysfs-zoned
+++ b/naughty/ubuntu-2404/5364-apparmor-sysfs-zoned
@@ -1,0 +1,1 @@
+apparmor="DENIED" operation="open" class="file" profile="libvirt*" name="/sys/*/queue/zoned" * comm="qemu-system-x86" requested_mask="r" denied_mask="r"

--- a/naughty/ubuntu-2404/5434-udisks2-lvm2-on-luks-broken
+++ b/naughty/ubuntu-2404/5434-udisks2-lvm2-on-luks-broken
@@ -1,0 +1,2 @@
+  File "check-storage-lvm2", line *, in testLvmOnLuks
+    b.wait_in_text(self.card_desc("LVM2 logical volume", "Physical volumes"), bn(disk))

--- a/naughty/ubuntu-2404/6064-apparmor-ryslog-systemd-sessions
+++ b/naughty/ubuntu-2404/6064-apparmor-ryslog-systemd-sessions
@@ -1,0 +1,1 @@
+apparmor="DENIED" operation="open" class="file" profile="rsyslogd" name="/run/systemd/sessions/" * requested_mask="r" denied_mask="r"

--- a/naughty/ubuntu-2404/6223-apparmor-rsyslog-ipv6
+++ b/naughty/ubuntu-2404/6223-apparmor-rsyslog-ipv6
@@ -1,0 +1,2 @@
+*apparmor="DENIED" operation="open" class="file" profile="rsyslogd" name="/proc/sys/net/ipv6/conf/all/disable_ipv6" * comm="rsyslogd" requested_mask="r" denied_mask="r"*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages


### PR DESCRIPTION
This is the current LTS, and we'll support it for a while. Right now this is an exact copy of "ubuntu-stable", but introducing this will allow us to move ubuntu-stable to the upcoming 24.10, and also phase out ubuntu-2204.

 * [x] image-refresh ubuntu-2404

cockpit-podman should just work (triggered it manually here, will add to auto testmap after this lands). cockpit and machines need some adjustments first, see https://github.com/cockpit-project/cockpit/pull/20946 and https://github.com/cockpit-project/cockpit-machines/pull/1786