### PR TITLE
create-anaconda-payload: provide an RPM instead of tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 *.qcow2
 *.tar.??
+*.rpm
 *.xz
 *~
 /*.log

--- a/image-create
+++ b/image-create
@@ -60,7 +60,7 @@ class MachineBuilder:
         if self.iso:
             self.suffix = ".iso"
         elif self.payload:
-            self.suffix = ".tar.gz"
+            self.suffix = ".rpm"
         else:
             self.suffix = ".qcow2"
 

--- a/image-prune
+++ b/image-prune
@@ -64,7 +64,7 @@ def get_images_in_branches(merge_target: str, *branch_patterns: str, cwd: str = 
         _rev, _kind, ref = ref_line.split()
         logger.debug('Considering images changed in %s...', ref)
         for patch_line in git('diff', f'{merge_target}...{ref}', '--', 'images/', cwd=cwd).splitlines():
-            if match := re.search(r'^\+([-0-9a-z]+-[0-9a-f]+.(qcow2|iso|tar.gz))', patch_line):
+            if match := re.search(r'^\+([-0-9a-z]+-[0-9a-f]+.(qcow2|iso|rpm))', patch_line):
                 image = match.group(1)
                 logger.debug('  - %s', image)
                 yield image
@@ -121,7 +121,7 @@ class ImageCache:
 
         # Sort by mtime, oldest first.
         for mtime, image in sorted(self.list_files()):
-            if not image.endswith(('.iso', 'tar.gz', '.qcow2', '.partial')):
+            if not image.endswith(('.iso', '.rpm', '.qcow2', '.partial')):
                 logger.debug('Skipping file %s with unknown extension', image)
                 continue
 

--- a/images/fedora-rawhide-anaconda-payload
+++ b/images/fedora-rawhide-anaconda-payload
@@ -1,1 +1,1 @@
-fedora-rawhide-anaconda-payload-96860b749e8c6802e28e38a4a7bdee2c90bdd9680553606ef823400f2e5180d0.tar.gz
+fedora-rawhide-anaconda-payload-535b4ba7c68e1ea2b8a5741357bb22d21172faf66fc73ab4034603254c0c7a97.rpm

--- a/images/scripts/create-anaconda-payload
+++ b/images/scripts/create-anaconda-payload
@@ -55,8 +55,47 @@ lvm2
 
 KICKSTART_PATH = "/tmp/payload.ks"
 
+WEBUI_PAYLOAD_SPEC = """
+Name: webui_payload
+Version: 1
+Release: 1
+Summary: Inject what's needed to Web UI image.
+License: GPL-2.0-or-later
 
-def build_payload(image: str, output: str) -> None:
+%description
+Inject what's needed to Web UI image.
+
+%source0 webui-payload.tar.gz
+
+%prep
+
+# we have no source, so nothing here
+cp /root/webui-payload.tar.gz .
+
+%build
+cat > interactive-defaults.ks <<EOF
+liveimg --url='file://live.tar.gz'
+EOF
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+mkdir -p %{buildroot}/usr/share/anaconda/
+
+install -m 755 webui-payload.tar.gz %{buildroot}/live.tar.gz
+
+# The interactive-defaults.ks file is normally shipped by anaconda,
+# but we need to override it for the testing purposes only
+install -m 755 interactive-defaults.ks %{buildroot}/usr/share/anaconda/interactive-defaults.ks
+
+%files
+/live.tar.gz
+/usr/share/anaconda/interactive-defaults.ks
+
+%changelog
+"""
+
+
+def build_payload_rpm(image: str, output: str) -> None:
     subprocess.check_call([os.path.join(BOTS_DIR, "image-download"), image])
     machine = testvm.VirtMachine(image=image, memory_mb=4096)
     try:
@@ -72,9 +111,19 @@ def build_payload(image: str, output: str) -> None:
         )
 
         # Change directory to /mnt/sysimage/ and create archive
-        machine.execute("cd /mnt/sysimage && tar --selinux --acls --xattrs -zcvf /root/payload.tar.gz *", timeout=100)
+        machine.execute(
+            "cd /mnt/sysimage && tar --selinux --acls --xattrs -zcvf /root/webui-payload.tar.gz *",
+            timeout=100
+        )
 
-        machine.download("/root/payload.tar.gz", output)
+        # Create the payload RPM Spec file
+        machine.write("/root/webui-payload.spec", WEBUI_PAYLOAD_SPEC)
+
+        # Build the RPM
+        machine.execute("rpmbuild -bb /root/webui-payload.spec", timeout=300)
+
+        # Download the RPM
+        machine.download("/root/rpmbuild/RPMS/x86_64/webui_payload-1-1.x86_64.rpm", output)
     finally:
         machine.stop()
 
@@ -88,7 +137,7 @@ def main() -> None:
     if not args.output:
         raise RuntimeError("Output path not specified")
 
-    build_payload(args.image, args.output)
+    build_payload_rpm(args.image, args.output)
 
 
 main()


### PR DESCRIPTION
Image refresh for fedora-rawhide-anaconda-payload

 * [x] image-refresh fedora-rawhide-anaconda-payload

The RPM is better usable by anaconda CI as it will install the payload through interactive defaults file.