### PR TITLE
testmap: add centos-10 to sub-man

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -177,6 +177,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     },
     'candlepin/subscription-manager': {
         'main': [
+            'centos-10',
             'rhel-9-5',
             'rhel-10-0',
             'fedora-39',
@@ -207,6 +208,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     'candlepin/subscription-manager-cockpit': {
         'main': [
             'centos-9-stream/subscription-manager-1.29',
+            'centos-10',
             'rhel-9-5/subscription-manager-1.29',
             'rhel-10-0',
             'fedora-39',


### PR DESCRIPTION
Test also centos-10 for the "main" branches of sub-man and sub-man-cockpit, which already test on rhel-10-0. This way, we can spot changes coming from CentOS Stream, and compare the behaviour of centos-10 with rhel-10-x.