### PR TITLE
avoid to use long ssh control path when there is long hostname - FIX COMMIT MESSAGE ON MERGE

### DIFF
--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -170,7 +170,7 @@ class SSHConnection:
     def _start_ssh_master(self) -> None:
         self._kill_ssh_master()
 
-        control = os.path.join(tempfile.gettempdir(), ".cockpit-test-resources", "ssh-%h-%p-%r-" + str(os.getpid()))
+        control = os.path.join(tempfile.gettempdir(), ".cockpit-test-resources", "ssh-%C-" + str(os.getpid()))
         os.makedirs(os.path.dirname(control), exist_ok=True)
 
         cmd = (


### PR DESCRIPTION
according to: https://stackoverflow.com/questions/35970686/ansible-ssh-error-unix-listener-too-long-for-unix-domain-socket using `%C` should create hash of hostname and timestamt to avoid to exceed limit of control path.

fixes: https://github.com/cockpit-project/bots/issues/6806