### PR TITLE
opensuse tumebleweed: don't install libvirt-daemon-driver-interface

### DIFF
--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -32,7 +32,6 @@ libvirt-daemon-driver-qemu \
 libvirt-daemon-driver-network \
 libvirt-daemon-driver-nodedev \
 libvirt-daemon-driver-storage-core \
-libvirt-daemon-driver-interface \
 libvirt-daemon-driver-storage-disk \
 libvirt-daemon-qemu \
 libvirt-client \


### PR DESCRIPTION
The maintainers of libvirt in opensuse have with the latest libvirt unconditionally disable building the interface driver this means the package `libvirt-daemon-driver-interface` is no longer in the repos. image-refresh is able to update the image with this change

 - [ ] image-refresh opensuse-tumbleweed