### PR TITLE
testmap: Enable rhel-10-0 for c-machines

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -136,6 +136,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel-8-10',
             'rhel-9-5',
             'rhel-9-6',
+            'rhel-10-0',
         ],
         'rhel-8': [
             'rhel-8-10',
@@ -143,7 +144,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         '_manual': [
             'centos-10',
             'fedora-rawhide',
-            'rhel-10-0',
         ],
     },
     'cockpit-project/cockpit-files': {

--- a/naughty/rhel-10/6792-swtpm-and-selinux-again-sigh
+++ b/naughty/rhel-10/6792-swtpm-and-selinux-again-sigh
@@ -1,0 +1,5 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-create", line *, in testConfigureBeforeInstall
+    testlib.wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)

--- a/naughty/rhel-10/6792-swtpm-and-selinux-again-sigh-2
+++ b/naughty/rhel-10/6792-swtpm-and-selinux-again-sigh-2
@@ -1,0 +1,5 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-create", line *, in testConfigureBeforeInstallBiosTPM
+    b.wait_in_text(f"#vm-{vmName}-system-state", "Running")


### PR DESCRIPTION
The "wild west" days are over, and RHEL 10 is nearing its beta release. We need to properly test c-machines there as we release to it.