### PR TITLE
testmap: some update for sub-man & sub-man-cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -180,7 +180,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     'candlepin/subscription-manager': {
         'main': [
             'centos-10',
-            'rhel-9-5',
             'rhel-9-6',
             'rhel-10-0',
             'fedora-39',
@@ -198,6 +197,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel-9-2',
             'rhel-9-4',
             'rhel-9-5',
+            'rhel-9-6',
         ],
         'subscription-manager-1.29.33': [
             'rhel-9-2',
@@ -212,7 +212,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         'main': [
             'centos-9-stream/subscription-manager-1.29',
             'centos-10',
-            'rhel-9-5/subscription-manager-1.29',
             'rhel-9-6/subscription-manager-1.29',
             'rhel-10-0',
             'fedora-39',


### PR DESCRIPTION
- drop `rhel-9-5` from sub-man/main, as that branch tracks RHEL 10, and there is already `rhel-9-6` to check for backports
- add `rhel-9-6` to sub-man/1.29, as that branch tracks RHEL 9.6
- drop `rhel-9-5` from sub-man-cockpit/main, as there is already `rhel-9-6`