### PR TITLE
images: Drop explicit libssh2 dependency on opensuse-tumbleweed

### DIFF
--- a/images/opensuse-tumbleweed
+++ b/images/opensuse-tumbleweed
@@ -1,1 +1,1 @@
-opensuse-tumbleweed-bdc1e83611bc09bae5b77c7e740fbbab9e0a8b1e7c36c900762659e41c513616.qcow2
+opensuse-tumbleweed-9bcce01e8c1270261e25fea0c1e7ea0cd2332c865bd06311927895b945602c6c.qcow2

--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -26,7 +26,6 @@ glibc-locale \
 glib-networking \
 json-glib \
 kexec-tools \
-libssh2-1 \
 libvirt-daemon-config-network \
 libvirt-daemon-driver-qemu \
 libvirt-daemon-driver-network \


### PR DESCRIPTION
This has never been necessary, as the image pre-installs the whole `cockpit` package, which pulls it in as a dependency. This build/runtime dependency was dropped in
https://github.com/cockpit-project/cockpit/pull/19441

 * [x] image-refresh opensuse-tumbleweed