### PR TITLE
images: Explicitly install nfs-kernel-server on openSUSE

### DIFF
--- a/images/opensuse-tumbleweed
+++ b/images/opensuse-tumbleweed
@@ -1,1 +1,1 @@
-opensuse-tumbleweed-9bcce01e8c1270261e25fea0c1e7ea0cd2332c865bd06311927895b945602c6c.qcow2
+opensuse-tumbleweed-1b3ce6a0c4eb19a58356d16968621fdd0076d3f713fb7817edbe6e7459268b4e.qcow2

--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -68,6 +68,7 @@ libvirt-daemon-driver-storage-logical \
 libxml2-tools \
 ltrace \
 nginx \
+nfs-kernel-server \
 podman \
 redis \
 socat \


### PR DESCRIPTION
It used to be pulled in indirectly but not any longer, apparently.

 * [x] image-refresh opensuse-tumbleweed