### PR TITLE
naughty: Fix pattern for #6992

### DIFF
--- a/naughty/fedora-40/6992-firefox-hidden-canvas-bug
+++ b/naughty/fedora-40/6992-firefox-hidden-canvas-bug
@@ -1,5 +1,3 @@
-# testHistory (__main__.TestPages.testHistory)
-*
 > error: NS_ERROR_FAILURE:
 *
 AssertionError: Cockpit shows an Oops


### PR DESCRIPTION
The text that it is matched against does not include the test name header...

This is not great, now we catch all Firefox internal errors that don't otherwise make the test fail...