### PR TITLE
naughty: Fix #6992 pattern

### DIFF
--- a/naughty/fedora-40/6992-firefox-hidden-canvas-bug
+++ b/naughty/fedora-40/6992-firefox-hidden-canvas-bug
@@ -1,5 +1,5 @@
 # testHistory (__main__.TestPages.testHistory)
 *
-> error: NS_ERROR_FAILURE:
+> error: NS_ERROR_FAILURE:*
 *
 AssertionError: Cockpit shows an Oops


### PR DESCRIPTION
There is some invisible whitespace after NS_ERROR_FAILURE, so adjust the glob.