### PR TITLE
machine_core: Support running cockpit/ws container on non-OSTree images

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -285,12 +285,7 @@ class Machine(ssh_connection.SSHConnection):
         """Restart Cockpit.
         """
         if self.ostree_image:
-            # HACK: podman restart is broken (https://bugzilla.redhat.com/show_bug.cgi?id=1780161)
-            # self.execute("podman restart `podman ps --quiet --filter ancestor=cockpit/ws`")
-            inspect_res = self.execute(f"podman inspect {self.get_cockpit_container()}")
-            tls = "--no-tls" not in inspect_res
-            self.stop_cockpit()
-            self.start_cockpit(tls=tls)
+            self.execute(f"podman restart {self.get_cockpit_container()}")
             self.wait_for_cockpit_running()
         else:
             self.execute("systemctl reset-failed 'cockpit*'; systemctl restart cockpit")

--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -244,7 +244,7 @@ class Machine(ssh_connection.SSHConnection):
     def get_cockpit_container(self) -> str:
         return self.execute("podman ps --quiet --all --filter name=ws").strip()
 
-    def start_cockpit(self, atomic_wait_for_host: str | None = None, tls: bool = False) -> None:
+    def start_cockpit(self, *, tls: bool = False) -> None:
         """Start Cockpit.
 
         Cockpit is not running when the test virtual machine starts up, to
@@ -257,7 +257,7 @@ class Machine(ssh_connection.SSHConnection):
             if not tls:
                 cmd += " -- --no-tls"
             self.execute(cmd)
-            self.wait_for_cockpit_running(atomic_wait_for_host or "localhost")
+            self.wait_for_cockpit_running()
         elif tls:
             self.execute("""
             systemctl stop --quiet cockpit.service


### PR DESCRIPTION
This will pave the way for testing Cockpit on RHEL 8 (https://github.com/cockpit-project/cockpit/pull/21154), where we use the cockpit/ws container instead of RPMs. But this isn't an OSTree image. Plus two cleanups.

I tested this locally, and with that I get some green tests. Let's make sure it doesn't break anything else.