### PR TITLE
machine_core: Explicitly reset cockpit.socket in start_cockpit()

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -265,6 +265,8 @@ class Machine(ssh_connection.SSHConnection):
             systemctl stop --quiet cockpit.service
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf
             systemctl reset-failed 'cockpit*'
+            # unpredictable, see https://bugzilla.redhat.com/show_bug.cgi?id=2303828
+            systemctl reset-failed cockpit.socket 2>/dev/null || true
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)
@@ -279,6 +281,7 @@ class Machine(ssh_connection.SSHConnection):
             %s --no-tls" `grep ExecStart= /lib/systemd/system/cockpit.service` \
                     > /etc/systemd/system/cockpit.service.d/notls.conf
             systemctl reset-failed 'cockpit*'
+            systemctl reset-failed cockpit.socket 2>/dev/null || true
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)


### PR DESCRIPTION
testClientCertAuthentication(), with its rapid start/stop of cockpit.socket, still runs into start-limit-hit errors. This is unfortunately wildly unpredictable [1].

Commit 2a94280e67a4 attempted to fix this, but it was wrong and reverted in commit 314032a66d2.

To be more robust, combine the current and 2a94280e67a4 approach and use both the glob (covering all loaded units) and also explicitly cockpit.socket (covering the unloaded case).

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2303828

-----

This still [keeps failing in RHEL 10 gating tests](https://artifacts.osci.redhat.com/testing-farm/deb4a51e-c7f1-440d-9033-f89b21cafb51/), but *nowhere else*, so this is a nuisance to debug. This commit is now very defensive and at least should not break anything. We'll see if it actually works in the next downstream release.