### PR TITLE
images: Add python3-pcp to rhel-8-10 image

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -253,11 +253,6 @@ if [ "${IMAGE#rhel-8*}" != "$IMAGE" ]; then
     TEST_PACKAGES="${TEST_PACKAGES/wireguard-tools /}"
 fi
 
-# RHEL 8 still uses the C pcp bridge
-if [ "${IMAGE#rhel-8*}" != "$IMAGE" ]; then
-    COCKPIT_DEPS="${COCKPIT_DEPS/python3-pcp /}"
-fi
-
 # vdo not available on centos/rhel 10
 if  [ "$IMAGE" = "centos-10" ] || [ "${IMAGE#rhel-10}" != "$IMAGE" ]; then
     TEST_PACKAGES="${TEST_PACKAGES/ kmod-kvdo / }"


### PR DESCRIPTION
With that we can enable the metrics tests in the rhel-8-10/ws-container cockpit scenario.

 - [ ] image-refresh rhel-8-10