### PR TITLE
Enable VM console capturing by default

### DIFF
--- a/image-create
+++ b/image-create
@@ -37,7 +37,6 @@ parser.add_argument('-v', '--verbose', action='store_true', help='Display verbos
 parser.add_argument('-s', '--sit', action='store_true', help='Sit and wait if setup script fails')
 parser.add_argument('-n', '--no-save', action='store_true', help='Don\'t save the new image')
 parser.add_argument('-u', '--upload', action='store_true', help='Upload the image after creation')
-parser.add_argument('--capture-console', action='store_true', help='Capture VM console to stderr')
 parser.add_argument('--no-build', action='store_true', dest='no_build',
                     help="Don't build packages and create the vm without build capabilities")
 parser.add_argument("--store", default=None, help="Where to send images")
@@ -191,7 +190,6 @@ try:
         memory_mb = 2048
 
     machine = testvm.VirtMachine(verbose=args.verbose,
-                                 capture_console=args.capture_console,
                                  image=args.image,
                                  memory_mb=memory_mb,
                                  maintain=True)

--- a/image-refresh
+++ b/image-refresh
@@ -60,7 +60,7 @@ def image_refresh(image: str, **kwargs: Any) -> int | tuple[int, str]:
             old_image = None
 
         # create the new image
-        run('./image-create', '--verbose', '--capture-console', image,
+        run('./image-create', '--verbose', image,
             env={**os.environ, 'VIRT_BUILDER_NO_CACHE': "yes"})
 
         # upload the new image

--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -270,7 +270,7 @@ class VirtMachine(Machine):
         maintain: bool = False,
         memory_mb: int | None = None,
         cpus: int | None = None,
-        capture_console: bool = False,
+        capture_console: bool = True,
         **kwargs: Any
     ):
         self.maintain = maintain

--- a/vm-run
+++ b/vm-run
@@ -53,7 +53,8 @@ try:
 
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,
                                  networking=network.host(restrict=args.no_network),
-                                 memory_mb=args.memory, cpus=args.cpus)
+                                 memory_mb=args.memory, cpus=args.cpus,
+                                 capture_console=False)
 
     # Check that image is downloaded
     if not os.path.exists(machine.image_file):


### PR DESCRIPTION
Commit d60055284 added an opt-in for console capturing. However, we keep forgetting to specify that, so that we end up with VM boot failures without knowing why. https://github.com/cockpit-project/cockpit/issues/21165

Flip the default to "True" and opt out of console capturing in `vm-run`. The latter is the only situation where we care about an interactive console.

---

This should shed some light on [these failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-e6db1ad8-20241030-013154-fedora-40-daily/log.html#75), see the referenced issue.