### PR TITLE
images: Remove bootc hack

### DIFF
--- a/images/centos-9-bootc
+++ b/images/centos-9-bootc
@@ -1,1 +1,1 @@
-centos-9-bootc-77cb5e9e41d02c8771d61fe0b817c988f2b05c33446fc4cbf06bea9ade5b4f74.qcow2
+centos-9-bootc-67c85c4209f0f5b76ed3dd7ccf6efcd113ee5b903ef0bf300bacaa5d2050d756.qcow2

--- a/images/scripts/lib/bootc.Containerfile
+++ b/images/scripts/lib/bootc.Containerfile
@@ -11,9 +11,5 @@ ADD lib/mcast1.nmconnection /usr/lib/NetworkManager/system-connections/
 # NM insists on tight permissions
 RUN chmod 600 /usr/lib/NetworkManager/system-connections/mcast1.nmconnection
 
-# HACK: workaround for https://github.com/osbuild/bootc-image-builder/issues/143
-# so that we can configure root password/ssh key
-RUN mkdir /var/roothome
-
-# HACK: workaround for https://github.com/osbuild/bootc-image-builder/issues/326
+# Make /usr/local writable for our testing: https://containers.github.io/bootc/filesystem.html#usrlocal
 RUN rm -rf /usr/local; ln -s ../var/usrlocal /usr/local


### PR DESCRIPTION
The /roothome bug was fixed a while ago.

/usr/local/ is meant to be not writable by default. The issue was closed with a documentation update, so adjust the comment.

 * [x] image-refresh centos-9-bootc