### PR TITLE
Revert "machine_core: Explicitly reset cockpit.socket in start_cockpit()"

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -265,8 +265,6 @@ class Machine(ssh_connection.SSHConnection):
             systemctl stop --quiet cockpit.service
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf
             systemctl reset-failed 'cockpit*'
-            # unpredictable, see https://bugzilla.redhat.com/show_bug.cgi?id=2303828
-            systemctl reset-failed cockpit.socket 2>/dev/null || true
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)
@@ -281,7 +279,6 @@ class Machine(ssh_connection.SSHConnection):
             %s --no-tls" `grep ExecStart= /lib/systemd/system/cockpit.service` \
                     > /etc/systemd/system/cockpit.service.d/notls.conf
             systemctl reset-failed 'cockpit*'
-            systemctl reset-failed cockpit.socket 2>/dev/null || true
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)


### PR DESCRIPTION
This was unfortunately *still* not enough. We need to hack Cockpit's testClientCertAuthentication() more directly.

This reverts commit 07785f857fff1ff122fc77df2c6c6aa799759f0e.

---

See [failed RHEL gating test](https://artifacts.osci.redhat.com/testing-farm/f4a46ac7-49ff-4b38-846f-957d5dcfbd98/), I'll send a cockpit PR instead to robustify this.