### PR TITLE
machine: don't try to restart a non-existing container

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -287,8 +287,10 @@ class Machine(ssh_connection.SSHConnection):
         """Restart Cockpit.
         """
         if self.ws_container:
-            self.execute(f"podman restart {self.get_cockpit_container()}")
-            self.wait_for_cockpit_running()
+            cockpit_container = self.get_cockpit_container()
+            if cockpit_container != "":
+                self.execute(f"podman restart {cockpit_container}")
+                self.wait_for_cockpit_running()
         else:
             self.execute("systemctl reset-failed 'cockpit*'; systemctl restart cockpit")
 


### PR DESCRIPTION
Now that Fedora-Cores rebased on Fedora 41 no longer enables multihost support by default. Enabling this and blanket restarting the container in TestMultiMachines.testEdit fails as the ws container is not running yet.