### PR TITLE
naughty: add nfs-server hang naughty for Fedora-rawhide

### DIFF
--- a/naughty/fedora-42/7088-nfs-server-hang
+++ b/naughty/fedora-42/7088-nfs-server-hang
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-nfs", line *, in testNfsBusy
+    m.execute("systemctl restart nfs-server")
+*
+RuntimeError: Timed out on 'systemctl restart nfs-server'


### PR DESCRIPTION
Manually tested, see
 
https://artifacts.dev.testing-farm.io/c24dbc1b-ea10-47e2-8907-6983cbfc96e4/work-storage-basict_5whswl/plans/all/storage-basic/execute/data/guest/default-0/test/browser/storage-basic-1/output.txt

https://artifacts.dev.testing-farm.io/4d3c5370-6022-464c-961c-d820cd9a3065/