### PR TITLE
images: Disable PerSourcePenalties on fedora-coreos

### DIFF
--- a/images/fedora-coreos
+++ b/images/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-coreos-d9b05856e40d3659934cc558cf453fa4822f167556fb8db52390e00e9762a904.qcow2
+fedora-coreos-8df78635d4a8e7ccb1309bca0f1ed0eaaef2aabb4fe7e9856ece2ca9dd9b437c.qcow2

--- a/images/scripts/ostree.setup
+++ b/images/scripts/ostree.setup
@@ -43,6 +43,10 @@ done
 
 ! test -e /etc/kdump.conf || echo "force_no_rebuild 1" >>/etc/kdump.conf
 
+# Disable PerSourcePenalties, they interfere with the rapid failed
+# logins performed by some tests.
+echo "PerSourcePenalties no" >/etc/ssh/sshd_config.d/99-no-penalties.conf
+
 # reduce image size
 rpm-ostree cleanup --repomd
 /var/lib/testvm/zero-disk.setup


### PR DESCRIPTION
Similar to commit 3681557f31.

 * [x] image-refresh fedora-coreos
 * [x] https://github.com/cockpit-project/cockpit-ostree/pull/734

Should fix [this flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21239-5e35fbb2-20241115-085502-fedora-coreos-other/log.html#52)