### PR TITLE
machine_core: systemctl reset-failed with a glob can fail

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -264,7 +264,7 @@ class Machine(ssh_connection.SSHConnection):
             self.execute("""
             systemctl stop --quiet cockpit.service
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf
-            systemctl reset-failed 'cockpit*'
+            systemctl reset-failed 'cockpit*' || true
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)
@@ -278,7 +278,7 @@ class Machine(ssh_connection.SSHConnection):
             ExecStart=
             %s --no-tls" `grep ExecStart= /lib/systemd/system/cockpit.service` \
                     > /etc/systemd/system/cockpit.service.d/notls.conf
-            systemctl reset-failed 'cockpit*'
+            systemctl reset-failed 'cockpit*' || true
             systemctl daemon-reload
             systemctl start cockpit.socket
             """)
@@ -292,7 +292,7 @@ class Machine(ssh_connection.SSHConnection):
                 self.execute(f"podman restart {cockpit_container}")
                 self.wait_for_cockpit_running()
         else:
-            self.execute("systemctl reset-failed 'cockpit*'; systemctl restart cockpit")
+            self.execute("systemctl reset-failed 'cockpit*' || true; systemctl restart cockpit")
 
     def stop_cockpit(self) -> None:
         """Stop Cockpit.


### PR DESCRIPTION
This is a race condition inside of systemd: In between resolving the glob and actually resetting the unit, it can become unloaded. This causes random test failures like

> Failed to reset failed state of unit cockpit-session@1-1389-62764.service:
> Unit cockpit-session@1-1389-62764.service not loaded.

---

This fixes [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-16808-52da73bc-20241118-122016-rhel-10-0-networking/log.html#52-2) or [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-16811-2ad82733-20241117-091642-fedora-40-networking/log.html#35) failure -- I've seen them fairly often recently.