### PR TITLE
Image refresh for fedora-41

### DIFF
--- a/images/fedora-41
+++ b/images/fedora-41
@@ -1,1 +1,1 @@
-fedora-41-da4cd3726c1ce5fffbbd4197b60217cec113f41c34c781999e2b6cbf8b9c941d.qcow2
+fedora-41-e03fb18f54da51a06a34b4a34d9780bc8d645ee9add82ce928e52cf0b3a1baae.qcow2

--- a/naughty/fedora-41/7137-nfs-rpc-statd-crash
+++ b/naughty/fedora-41/7137-nfs-rpc-statd-crash
@@ -1,3 +1,2 @@
-*nsm_atomic_write*
 *Error: FAIL: Test completed, but found unexpected journal messages:
-Process * (rpc.statd) of user 0 dumped core.
+Process * (rpc.statd) of user 0 terminated abnormally with signal 6/ABRT*

--- a/naughty/fedora-41/7139-tracer-segfaults-in-the-past-1
+++ b/naughty/fedora-41/7139-tracer-segfaults-in-the-past-1
@@ -1,0 +1,3 @@
+# testBasic (__main__.TestHistoryMetrics.testBasic)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-41/7139-tracer-segfaults-in-the-past-2
+++ b/naughty/fedora-41/7139-tracer-segfaults-in-the-past-2
@@ -1,0 +1,3 @@
+# testEvents (__main__.TestHistoryMetrics.testEvents)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-41/7139-tracer-segfaults-in-the-past-3
+++ b/naughty/fedora-41/7139-tracer-segfaults-in-the-past-3
@@ -1,0 +1,3 @@
+# testCPUUsage (__main__.TestMultiCPU.testCPUUsage)
+*
+Process * (python3) of user 0 terminated abnormally


### PR DESCRIPTION
Image refresh for fedora-41
 * [x] image-refresh fedora-41
 * [x] https://github.com/cockpit-project/cockpit/issues/21301
 * [x] https://github.com/cockpit-project/cockpit/pull/21321 and land https://bodhi.fedoraproject.org/updates/FEDORA-2024-cbf666ab6a ; or https://github.com/candlepin/subscription-manager-cockpit/pull/84
 * [x] https://github.com/cockpit-project/cockpit-machines/pull/1914
 * [x] https://github.com/cockpit-project/cockpit-machines/pull/1925