### PR TITLE
test-failure-policy: Restrict GitHub post to the last 30 lines

### DIFF
--- a/test-failure-policy
+++ b/test-failure-policy
@@ -192,6 +192,9 @@ def update_known_issue(api: github.GitHub, number: int, err: str, context: str) 
     if revision:
         occ = f"{occ} | revision {revision}"
 
+    # comments are limited to 65.000 characters, but some tests ouputs can be quite large
+    err = '\n'.join(err.splitlines()[-30:])
+
     comments = api.issue_comments(number)
 
     # try to find an existing comment to update; extract the traceback from the


### PR DESCRIPTION
GitHub comments are limited to 65.000 characters. But some test outputs are larger than that, e.g. when they contain VM console dumps. We also don't really need posting the full log to the naughty, it just needs to be enough to identify the failure.

Thus restrict the comment to the last 30 lines of the output, which contain the traceback or unexpected message.

This avoids "422 Unprocessable Entity" errors and thus failure to track the ongoing presence of a naughty.

Closes #7166

---


PR #7166 claims that #6769 is obsolete, but it [really isn't](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18897-f108cae7-20241130-082400-fedora-41-expensive/log.html). See https://github.com/cockpit-project/bots/pull/7166#pullrequestreview-2471326576 . I tested this locally with my token, and it now [successfully posted a comment](https://github.com/cockpit-project/bots/issues/6769#issuecomment-2510857139).