### PR TITLE
machine_core: Retry ws container removal

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -298,7 +298,14 @@ class Machine(ssh_connection.SSHConnection):
         """Stop Cockpit.
         """
         if self.ws_container:
-            self.execute(f"echo {self.get_cockpit_container()} | xargs --no-run-if-empty podman rm -f")
+            clean = f"echo {self.get_cockpit_container()} | xargs --no-run-if-empty podman rm -f"
+            try:
+                self.execute(clean)
+            except subprocess.CalledProcessError:
+                # HACK: this sometimes fails the first time due to
+                # netavark: failed to delete container veth eth0: Netlink error: No such device
+                # if it didn't actually succeed, it should work the second time
+                self.execute(clean)
         else:
             self.execute("systemctl stop cockpit.socket cockpit.service")
 


### PR DESCRIPTION
On current Fedora CoreOS, removing the container sometimes fails with

> netavark: failed to delete container veth eth0: Netlink error: No such device

but the removal works anyway. This is some race condition with Cockpit's networking tests which juggle veths that confuse netavark.

If it fails, retry it once (and then it must succeed).

----

This fixes [this battery of failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21391-fe0cac92-20241206-075953-fedora-coreos-networking/log.html) which happen when running some networking tests the second time (due to affected retries). Reproduces 100% locally with

```
TEST_OS=fedora-coreos test/verify/check-networkmanager-bond TestBonding.testRename $RUNC -stv
```
and then running it a second time.