### PR TITLE
recreate-dependabot-pr: Fix label call

### DIFF
--- a/recreate-dependabot-pr
+++ b/recreate-dependabot-pr
@@ -72,7 +72,7 @@ def main() -> None:
             continue
         else:
             # Not mergeable and a dependabot PR, add a `node_modules` label and re-create the PR.
-            task.label(pull_details, ('node_modules'))  # type: ignore[no-untyped-call]
+            task.label(pull_details, ('node_modules',))  # type: ignore[no-untyped-call]
 
             # Stop at the first dependabot PR as we can only land one at a time.
             break


### PR DESCRIPTION
"labels" must be a list.

See https://github.com/cockpit-project/cockpit-files/pull/863#issuecomment-2525533559

---

I ran this locally and it worked on https://github.com/cockpit-project/cockpit-files/pull/865

 - [x] Requires #7196