### PR TITLE
task: Fix get_origin_repo() .git extension matching

### DIFF
--- a/task/github.py
+++ b/task/github.py
@@ -126,7 +126,7 @@ def get_origin_repo() -> str | None:
     except subprocess.CalledProcessError:
         return None
     url = res.decode('utf-8').strip()
-    m = re.fullmatch(r"(git@github.com:|https://github.com/)(.*?)(\\.git)?", url)
+    m = re.fullmatch(r"(git@github.com:|https://github.com/)(.*?)(\.git)?", url)
     if m:
         return m.group(2).rstrip("/")
     raise RuntimeError("Not a GitHub repo: %s" % url)


### PR DESCRIPTION
This got broken in commit 0283f67188241d, I forgot to unescape the backslash.

---

This broke the tasks-container-update workflows, see https://github.com/cockpit-project/cockpit-podman/pull/1932.

I tested this in the debug run, and it [worked again](https://github.com/cockpit-project/cockpit-podman/actions/runs/12230868520/job/34112888699) and produced https://github.com/cockpit-project/cockpit-podman/pull/1933 (that's not valid, it has the wrong base branch -- just a demo)