### PR TITLE
naughty: Add pattern for another tracer/dnf5 crash

### DIFF
--- a/naughty/fedora-40/7209-tracer-crash-outofrange
+++ b/naughty/fedora-40/7209-tracer-crash-outofrange
@@ -1,0 +1,4 @@
+> error: Tracer failed: *"exit_status":-6,*,"message":"terminate called after throwing an instance of 'std::out_of_range*libdnf5*
+*
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+Process *python3) of user 0 terminated abnormally without generating a coredump.


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2282104
Known issue #7209

Takes care of [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21419-7ba1bd20-20241211-082944-fedora-40-other/log.html) and [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21419-7ba1bd20-20241211-034403-fedora-40-other/log.html) mess.