### PR TITLE
naughty: Adjust #6769 pattern for Python 3.13

### DIFF
--- a/naughty/fedora-40/6769-kdump-initramfs-unpack-error
+++ b/naughty/fedora-40/6769-kdump-initramfs-unpack-error
@@ -2,4 +2,5 @@
 *
   File "check-kdump", line *, in testBasic
     self.assertIn("Kdump compressed dump",
+*
 AssertionError: 'Kdump compressed dump' not found in "/srv/kdump/var/crash/10.111.113.1*/vmcore: cannot open `/srv/kdump/var/crash/10.111.113.1*/vmcore' (No such file or directory)\n"

--- a/naughty/fedora-41/6769-kdump-initramfs-unpack-error
+++ b/naughty/fedora-41/6769-kdump-initramfs-unpack-error
@@ -2,4 +2,5 @@
 *
   File "check-kdump", line *, in testBasic
     self.assertIn("Kdump compressed dump",
+*
 AssertionError: 'Kdump compressed dump' not found in "/srv/kdump/var/crash/10.111.113.1*/vmcore: cannot open `/srv/kdump/var/crash/10.111.113.1*/vmcore' (No such file or directory)\n"

--- a/naughty/rhel-9/6769-kdump-initramfs-unpack-error
+++ b/naughty/rhel-9/6769-kdump-initramfs-unpack-error
@@ -2,4 +2,5 @@
 *
   File "check-kdump", line *, in testBasic
     self.assertIn("Kdump compressed dump",
+*
 AssertionError: 'Kdump compressed dump' not found in "/srv/kdump/var/crash/10.111.113.1*/vmcore: cannot open `/srv/kdump/var/crash/10.111.113.1*/vmcore' (No such file or directory)\n"


### PR DESCRIPTION
Python 3.13 has more detailed exception stack traces with additional ASCII art and info in between the affected code line and the error message.

----

Unblocks https://github.com/cockpit-project/cockpit/pull/21440 . I locally tested the ouput against `bots/test-failure-policy -o fedora-41`.