### PR TITLE
naughty: Add pattern for RHEL 10 SELinux sysadm_u libvirt-dbus regression

### DIFF
--- a/naughty/rhel-10/7309-selinux-virtdbus-sysadm_u
+++ b/naughty/rhel-10/7309-selinux-virtdbus-sysadm_u
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/check-machines-lifecycle", line *, in testBasicSysadmU
+*
+  File "test/check-machines-lifecycle", line *, in _testBasic
+    self.waitVmRow("subVmTest1")
+*
+testlib.Error: timeout


### PR DESCRIPTION
Downstream report: https://issues.redhat.com/browse/RHEL-73914
Known issue #7309

See https://github.com/cockpit-project/cockpit-machines/pull/1975