### PR TITLE
run-queue: Automatically prune the test results database

### DIFF
--- a/run-queue
+++ b/run-queue
@@ -74,8 +74,12 @@ def consume_webhook_queue(dq: distributed_queue.DistributedQueue) -> ConsumeResu
             sha = pull_request['head']['sha']
             db = os.path.join(get_images_data_dir(), "test-results.db")
             body = {
-                "command": (f"./store-tests --db {db} --repo {repo} {sha} && "
-                            f"./prometheus-stats --db {db} --s3 {os.path.join(LOG_STORE, 'prometheus')}")
+                "command": (
+                    f"./store-tests --db {db} --repo {repo} {sha} && "
+                    # prune the db if it gets too big; 14 days weighs about 15 MB
+                    f"if [ $(stat +%c {db}) -gt 25000000 ]; then ./prometheus-stats --db {db} --prune 14; fi &&"
+                    f"./prometheus-stats --db {db} --s3 {os.path.join(LOG_STORE, 'prometheus')}"
+                )
             }
             dq.channel.basic_publish('', 'statistics', json.dumps(body),
                                      properties=pika.BasicProperties(priority=distributed_queue.MAX_PRIORITY))


### PR DESCRIPTION
If test-results.db gets too big (> 25 MB), prune it to the last 14 days. We are occasionally doing this manually, but not often enough -- it routinely grows to > 100 MB, which makes the weather report take ages to load.

The database shrinks to about 15 MB after being freshly pruned, so 25 MB gives enough margin to avoid running the pruning too often (as it's a bit expensive).

---

I tuned this with getting https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/test-results.db (currently 170 MB). Running `./prometheus-stats --db /tmp/test-results.db --prune 14` shrinks it to 15 MB.

I just made a backup at https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/test-results.db.20250117 in case anything goes wrong.