### PR TITLE
chore: echo userpass for remote access

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -36,7 +36,9 @@ SSH ACCESS
   $ ssh -p {ssh_port} -i bots/machine/identity {ssh_user}@{ssh_address}
 
 COCKPIT
-  http://{web_address}:{web_port}
+  https://{web_address}:{web_port}
+  Username: admin
+  Password: foobar
 """
 
 RESOLV_SCRIPT = """


### PR DESCRIPTION
This adds username and password in the remote message that is outputted when running something like `bots/vm-run`. We already have this listed in the documentation but it doesn't hurt to have in the terminal.

See https://github.com/cockpit-project/cockpit/pull/21541