### PR TITLE
testmap: Declare cockpit centos-9-bootc test

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -66,6 +66,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
+            'centos-9-bootc',
             'fedora-rawhide',
             'opensuse-tumbleweed',
         ],


### PR DESCRIPTION
We soon want to introduce a proper bootc deployment test: https://issues.redhat.com/browse/COCKPIT-1237