### PR TITLE
naughty: Add pattern for RHEL 9 NetworkManager SELinux issue

### DIFF
--- a/naughty/rhel-9/7374-selinux-nmmeta
+++ b/naughty/rhel-9/7374-selinux-nmmeta
@@ -1,0 +1,2 @@
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+*avc:  denied  { create } for  * comm="NetworkManager" name="*.nmmeta~" scontext=system_u:system_r:NetworkManager_t:s0 tcontext=system_u:object_r:NetworkManager_etc_rw_t:s0 tclass=lnk_file permissive=0


### PR DESCRIPTION
Downstream report: https://issues.redhat.com/browse/RHEL-76966 
Known issue #7374

----

Fixes [these two failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-21559-045df1ef-20250130-100950-centos-9-bootc-networking/log.html) in https://github.com/cockpit-project/cockpit/pull/21559