### PR TITLE
naughty: Remove obsolete #6220 naughty pattern

### DIFF
--- a/naughty/fedora-41/6620-selinux-init-netfilter-socket
+++ b/naughty/fedora-41/6620-selinux-init-netfilter-socket
@@ -1,5 +1,0 @@
-TestLogin.testSELinuxRestrictedUser)
-*
-*avc:  denied  { create } for  pid=1 comm=systemd scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=netlink_netfilter_socket permissive=0
-*
-testlib.Error: FAIL: Test completed, but found unexpected journal messages

--- a/naughty/fedora-42/6620-selinux-init-netfilter-socket
+++ b/naughty/fedora-42/6620-selinux-init-netfilter-socket
@@ -1,5 +1,0 @@
-TestLogin.testSELinuxRestrictedUser)
-*
-*avc:  denied  { create } for  pid=1 comm=systemd scontext=system_u:system_r:init_t:s0 tcontext=system_u:system_r:init_t:s0 tclass=netlink_netfilter_socket permissive=0
-*
-testlib.Error: FAIL: Test completed, but found unexpected journal messages


### PR DESCRIPTION
This was fixed last year, but as we typoed the issue number in the file name it never got auto-cleaned.

Fixes #6220

--

I.e. the naughty file names were 6**6**20 instead of 6**2**20.