### PR TITLE
Revert "images: Temporarily pull grafana container from quay.io mirror"

### DIFF
--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -176,15 +176,12 @@ apps:
   - type: performancecopilot-pcp-app
 EOF
 
-# TEMP HACK: https://quay.io/repository/cockpit/grafana has a copy of the 2025-01-29 docker.io/bitnami/grafana image
 podman run -d --rm --name grafana -p 3000:3000 \
     -v /root/grafana.ini:/opt/bitnami/grafana/conf/grafana.ini:ro,z \
     -v grafana-data-plugins:/opt/bitnami/grafana/data/plugins \
     -e GF_SECURITY_ADMIN_PASSWORD=foobar \
     -e GF_INSTALL_PLUGINS="redis-datasource,performancecopilot-pcp-app" \
-    quay.io/cockpit/grafana
-
-podman tag quay.io/cockpit/grafana docker.io/bitnami/grafana
+    docker.io/bitnami/grafana
 
 # wait until set up completed
 until curl http://localhost:3000; do sleep 5; done


### PR DESCRIPTION
We don't have any mechanism to keep our grafana mirror up to date. In most cases we can afford some retries, just in that particular case we couldn't.

This reverts commit ead7a20fb1ac6137d3de2673ff4d76ea99096928.

 - [ ] image-refresh services