### PR TITLE
naughty: Rawhide is now Fedora 43

### DIFF
--- a/naughty/fedora-42/3683-selinux-agetty-clhm
+++ b/naughty/fedora-42/3683-selinux-agetty-clhm
@@ -1,0 +1,2 @@
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+audit: type=1400 audit*: avc:  denied  { read } for * comm="agetty" name="22_clhm_*.issue" * scontext=system_u:system_r:getty_t:s0-s0:c0.c1023 tcontext=system_u:object_r:NetworkManager_dispatcher_console_var_run_t:s0*

--- a/naughty/fedora-42/4796-stratis-runs-clevis-too-early
+++ b/naughty/fedora-42/4796-stratis-runs-clevis-too-early
@@ -1,0 +1,2 @@
+  File "check-storage-stratis", line *, in testBasic
+    b.wait_text(self.card_row_col("Stratis filesystems", 1, 1), "fsys1")  # should be started after boot

--- a/naughty/fedora-42/6678-selinux-libvirt-ssh
+++ b/naughty/fedora-42/6678-selinux-libvirt-ssh
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/check-machines-migrate", line *, in test*
+    self._testMigrationGeneric(*
+  File "test/check-machines-migrate", line *, in _testMigrationGeneric
+    b.wait_not_present("#migrate-modal")
+*
+testlib.Error: timeout

--- a/naughty/fedora-42/6769-kdump-initramfs-unpack-error
+++ b/naughty/fedora-42/6769-kdump-initramfs-unpack-error
@@ -1,0 +1,6 @@
+[*] Initramfs unpacking failed: write error
+*
+  File "check-kdump", line *, in testBasic
+    self.assertIn("Kdump compressed dump",
+*
+AssertionError: 'Kdump compressed dump' not found in "/srv/kdump/var/crash/10.111.113.1*/vmcore: cannot open `/srv/kdump/var/crash/10.111.113.1*/vmcore' (No such file or directory)\n"

--- a/naughty/fedora-42/6792-swtpm-and-selinux-again-sigh
+++ b/naughty/fedora-42/6792-swtpm-and-selinux-again-sigh
@@ -1,0 +1,5 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-create", line *, in testConfigureBeforeInstall
+    testlib.wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)

--- a/naughty/fedora-42/6792-swtpm-and-selinux-again-sigh-2
+++ b/naughty/fedora-42/6792-swtpm-and-selinux-again-sigh-2
@@ -1,0 +1,5 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-create", line *, in testConfigureBeforeInstallBiosTPM
+    b.wait_in_text(f"#vm-{vmName}-system-state", "Running")

--- a/naughty/fedora-42/6792-swtpm-and-selinux-again-sigh-3
+++ b/naughty/fedora-42/6792-swtpm-and-selinux-again-sigh-3
@@ -1,0 +1,6 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-settings", line *, in testMultipleSettings
+*
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Running")): Error: actual text: Shut off

--- a/naughty/fedora-42/6992-firefox-hidden-canvas-bug
+++ b/naughty/fedora-42/6992-firefox-hidden-canvas-bug
@@ -1,0 +1,5 @@
+# testHistory (__main__.TestPages.testHistory)
+*
+> error: NS_ERROR_FAILURE:*
+*
+AssertionError: Cockpit shows an Oops

--- a/naughty/fedora-42/7139-tracer-segfaults-in-the-past-1
+++ b/naughty/fedora-42/7139-tracer-segfaults-in-the-past-1
@@ -1,0 +1,3 @@
+# testBasic (__main__.TestHistoryMetrics.testBasic)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-42/7139-tracer-segfaults-in-the-past-2
+++ b/naughty/fedora-42/7139-tracer-segfaults-in-the-past-2
@@ -1,0 +1,3 @@
+# testEvents (__main__.TestHistoryMetrics.testEvents)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-42/7139-tracer-segfaults-in-the-past-3
+++ b/naughty/fedora-42/7139-tracer-segfaults-in-the-past-3
@@ -1,0 +1,3 @@
+# testCPUUsage (__main__.TestMultiCPU.testCPUUsage)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-42/7352-selinux-nbd-connect
+++ b/naughty/fedora-42/7352-selinux-nbd-connect
@@ -1,0 +1,6 @@
+> error: spawn 'vm creation' returned error: *internal error: process exited while connecting to monitor*nbdkit*
+Traceback (most recent call last):
+  File "test/check-machines-create", line *, in testCreateUrlSource
+*
+testlib.Error: timeout
+wait_js_cond(ph_text_is("#vm-subVmTestCreate8-system-state","Running")): Error: #vm-subVmTestCreate8-system-state not found

--- a/naughty/fedora-43/3683-selinux-agetty-clhm
+++ b/naughty/fedora-43/3683-selinux-agetty-clhm
@@ -1,0 +1,2 @@
+testlib.Error: FAIL: Test completed, but found unexpected journal messages:
+audit: type=1400 audit*: avc:  denied  { read } for * comm="agetty" name="22_clhm_*.issue" * scontext=system_u:system_r:getty_t:s0-s0:c0.c1023 tcontext=system_u:object_r:NetworkManager_dispatcher_console_var_run_t:s0*

--- a/naughty/fedora-43/4796-stratis-runs-clevis-too-early
+++ b/naughty/fedora-43/4796-stratis-runs-clevis-too-early
@@ -1,0 +1,2 @@
+  File "check-storage-stratis", line *, in testBasic
+    b.wait_text(self.card_row_col("Stratis filesystems", 1, 1), "fsys1")  # should be started after boot

--- a/naughty/fedora-43/5434-udisks2-lvm2-on-luks-broken
+++ b/naughty/fedora-43/5434-udisks2-lvm2-on-luks-broken
@@ -1,0 +1,2 @@
+  File "check-storage-lvm2", line *, in testLvmOnLuks
+    b.wait_in_text(self.card_desc("LVM2 logical volume", "Physical volumes"), bn(disk))

--- a/naughty/fedora-43/6678-selinux-libvirt-ssh
+++ b/naughty/fedora-43/6678-selinux-libvirt-ssh
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/check-machines-migrate", line *, in test*
+    self._testMigrationGeneric(*
+  File "test/check-machines-migrate", line *, in _testMigrationGeneric
+    b.wait_not_present("#migrate-modal")
+*
+testlib.Error: timeout

--- a/naughty/fedora-43/6769-kdump-initramfs-unpack-error
+++ b/naughty/fedora-43/6769-kdump-initramfs-unpack-error
@@ -1,0 +1,6 @@
+[*] Initramfs unpacking failed: write error
+*
+  File "check-kdump", line *, in testBasic
+    self.assertIn("Kdump compressed dump",
+*
+AssertionError: 'Kdump compressed dump' not found in "/srv/kdump/var/crash/10.111.113.1*/vmcore: cannot open `/srv/kdump/var/crash/10.111.113.1*/vmcore' (No such file or directory)\n"

--- a/naughty/fedora-43/6792-swtpm-and-selinux-again-sigh
+++ b/naughty/fedora-43/6792-swtpm-and-selinux-again-sigh
@@ -1,0 +1,5 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-create", line *, in testConfigureBeforeInstall
+    testlib.wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)

--- a/naughty/fedora-43/6792-swtpm-and-selinux-again-sigh-2
+++ b/naughty/fedora-43/6792-swtpm-and-selinux-again-sigh-2
@@ -1,0 +1,5 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-create", line *, in testConfigureBeforeInstallBiosTPM
+    b.wait_in_text(f"#vm-{vmName}-system-state", "Running")

--- a/naughty/fedora-43/6792-swtpm-and-selinux-again-sigh-3
+++ b/naughty/fedora-43/6792-swtpm-and-selinux-again-sigh-3
@@ -1,0 +1,6 @@
+*internal error: Could not run '/usr/bin/swtpm_setup'.*
+*
+Traceback (most recent call last):
+  File "check-machines-settings", line *, in testMultipleSettings
+*
+wait_js_cond(ph_in_text("#vm-subVmTest1-system-state","Running")): Error: actual text: Shut off

--- a/naughty/fedora-43/6992-firefox-hidden-canvas-bug
+++ b/naughty/fedora-43/6992-firefox-hidden-canvas-bug
@@ -1,0 +1,5 @@
+# testHistory (__main__.TestPages.testHistory)
+*
+> error: NS_ERROR_FAILURE:*
+*
+AssertionError: Cockpit shows an Oops

--- a/naughty/fedora-43/7139-tracer-segfaults-in-the-past-1
+++ b/naughty/fedora-43/7139-tracer-segfaults-in-the-past-1
@@ -1,0 +1,3 @@
+# testBasic (__main__.TestHistoryMetrics.testBasic)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-43/7139-tracer-segfaults-in-the-past-2
+++ b/naughty/fedora-43/7139-tracer-segfaults-in-the-past-2
@@ -1,0 +1,3 @@
+# testEvents (__main__.TestHistoryMetrics.testEvents)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-43/7139-tracer-segfaults-in-the-past-3
+++ b/naughty/fedora-43/7139-tracer-segfaults-in-the-past-3
@@ -1,0 +1,3 @@
+# testCPUUsage (__main__.TestMultiCPU.testCPUUsage)
+*
+Process * (python3) of user 0 terminated abnormally

--- a/naughty/fedora-43/7352-selinux-nbd-connect
+++ b/naughty/fedora-43/7352-selinux-nbd-connect
@@ -1,0 +1,6 @@
+> error: spawn 'vm creation' returned error: *internal error: process exited while connecting to monitor*nbdkit*
+Traceback (most recent call last):
+  File "test/check-machines-create", line *, in testCreateUrlSource
+*
+testlib.Error: timeout
+wait_js_cond(ph_text_is("#vm-subVmTestCreate8-system-state","Running")): Error: #vm-subVmTestCreate8-system-state not found

--- a/naughty/fedora-rawhide
+++ b/naughty/fedora-rawhide
@@ -1,1 +1,1 @@
-fedora-42
+fedora-43

--- a/naughty/fedora-rawhide-boot
+++ b/naughty/fedora-rawhide-boot
@@ -1,1 +1,1 @@
-fedora-41
+fedora-43


### PR DESCRIPTION
Copy current Fedora 41 naughties to Fedora 42 (so that we can start testing cockpit there) and 43 (we are after branching), and update the rawhide symlinks.

---

This will fix the [LUKS LVM2](https://artifacts.dev.testing-farm.io/0e3b415f-33e6-4173-9d89-45e021a261d7/) "regression", I just wasted 1.5 hours [trying to track it down](https://github.com/orgs/cockpit-project/projects/4/views/1?pane=issue&itemId=96901643) :cry: 