### PR TITLE
naughty: Add pattern for libvirt pool volume regression

### DIFF
--- a/naughty/fedora-42/7405-attach-volume-cgroup-bpf
+++ b/naughty/fedora-42/7405-attach-volume-cgroup-bpf
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "test/check-machines-disks", line *, in testAddDiskSCSI
+*
+  File "test/check-machines-disks", line *, in verify_disk_added
+    b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-dialog-modal-window")
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#vm-subVmTest1-disks-adddisk-dialog-modal-window")): Error: condition did not become true

--- a/naughty/fedora-42/7405-attach-volume-cgroup-bpf-2
+++ b/naughty/fedora-42/7405-attach-volume-cgroup-bpf-2
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "test/check-machines-disks", line *, in testAddDiskPool
+*
+  File "test/check-machines-disks", line *, in verify_disk_added
+    b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-dialog-modal-window")
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#vm-subVmTest1-disks-adddisk-dialog-modal-window")): Error: condition did not become true

--- a/naughty/fedora-43/7405-attach-volume-cgroup-bpf
+++ b/naughty/fedora-43/7405-attach-volume-cgroup-bpf
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "test/check-machines-disks", line *, in testAddDiskSCSI
+*
+  File "test/check-machines-disks", line *, in verify_disk_added
+    b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-dialog-modal-window")
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#vm-subVmTest1-disks-adddisk-dialog-modal-window")): Error: condition did not become true

--- a/naughty/fedora-43/7405-attach-volume-cgroup-bpf-2
+++ b/naughty/fedora-43/7405-attach-volume-cgroup-bpf-2
@@ -1,0 +1,8 @@
+Traceback (most recent call last):
+  File "test/check-machines-disks", line *, in testAddDiskPool
+*
+  File "test/check-machines-disks", line *, in verify_disk_added
+    b.wait_not_present(f"#vm-{self.vm_name}-disks-adddisk-dialog-modal-window")
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#vm-subVmTest1-disks-adddisk-dialog-modal-window")): Error: condition did not become true


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2344342
Known issue #7405

---

See https://github.com/cockpit-project/cockpit-machines/pull/2024#issuecomment-2642550917 ff. for debugging details. This clears up https://artifacts.dev.testing-farm.io/f2eb2479-873c-4e21-8c15-195ff09acae1/ , I locally validated it against the TF logs with `bots/test-failure-policy -o fedora-42`.

After that I can resume https://github.com/cockpit-project/cockpit-machines/pull/2024
