### PR TITLE
test: Make RE match a raw string

### DIFF
--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -143,7 +143,7 @@ async def api(service: GitHubService) -> AsyncIterator[GitHub]:
 async def test_github_404(service: GitHubService, api: GitHub) -> None:
     # Make sure 4xx errors get raised immediately without retries
     service.add('x', status=404, reason='Not Found')
-    with pytest.raises(aiohttp.ClientResponseError, match='404.*Not Found'):
+    with pytest.raises(aiohttp.ClientResponseError, match=r'404.*Not Found'):
         assert await api.get('x') == {}
     service.assert_hits(1, 1)
 


### PR DESCRIPTION
Fixes new warning with ruff 0.8.6:

> test/test_aio.py:146:59: RUF043 Pattern passed to `match=` contains metacharacters but is neither escaped nor raw


---

This [started to happen](https://github.com/cockpit-project/bots/actions/runs/13214962336/job/36893123499?pr=7407) today, presumably due to the tasks container refresh.