### PR TITLE
testmap: Drop cockpit-composer RHEL 10

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -168,9 +168,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-40',
             'fedora-40/firefox',
             'centos-9-stream',
-            'centos-10',
             'rhel-9-6',
-            'rhel-10-0',
         ],
         '_manual': [
             'fedora-rawhide',


### PR DESCRIPTION
The package was removed from RHEL 10.

---

See https://github.com/cockpit-project/bots/pull/7403#issuecomment-2646202060