### PR TITLE
testmap: Enable fedora-42 on cockpit-machines

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -131,6 +131,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'ubuntu-2404',
             'ubuntu-stable',
             'fedora-41',
+            'fedora-42',
             f'{TEST_OS_DEFAULT}/devel',
             f'{TEST_OS_DEFAULT}/firefox',
             'opensuse-tumbleweed',
@@ -143,7 +144,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         ],
         '_manual': [
             'centos-10',
-            'fedora-42',
             'fedora-rawhide',
         ],
     },

--- a/naughty/fedora-42/7405-attach-hostdev-cgroup-bpf
+++ b/naughty/fedora-42/7405-attach-hostdev-cgroup-bpf
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "check-machines-hostdevs", line *, in testHostDevAddSingleDevice
+    HostDevAddDialog(self, "system", dev_type="usb_device").execute()
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#vm-subVmTest1-hostdevs-dialog")): Error: condition did not become true

--- a/naughty/fedora-42/7405-attach-hostdev-cgroup-bpf-2
+++ b/naughty/fedora-42/7405-attach-hostdev-cgroup-bpf-2
@@ -1,0 +1,5 @@
+error: failed to load cgroup BPF prog: Operation not permitted
+*
+Traceback (most recent call last):
+  File "check-machines-hostdevs", line *, in testHostDevicesList
+    m.execute("virsh attach-device --domain subVmTest1 --file /tmp/usbhostedxml")


### PR DESCRIPTION
machines is more complex, but most of its tests run in packit already. So we may be lucky!