### PR TITLE
images: add fedora-42-boot and fedora-42-anaconda-payload for anaconda-webui repository

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -45,6 +45,7 @@ REFRESH = {
     "fedora-40": {},
     "fedora-41": {},
     "fedora-42": {},
+    "fedora-42-boot": {},
     "fedora-coreos": {},
     "fedora-rawhide": {},
     "fedora-rawhide-boot": {},

--- a/images/fedora-42-anaconda-payload
+++ b/images/fedora-42-anaconda-payload
@@ -1,0 +1,1 @@
+fedora-42-anaconda-payload-8af5c1ede83d570e085a66519bf85c81cb5e6622105e690306646407b63d126a.tar.gz

--- a/images/fedora-42-boot
+++ b/images/fedora-42-boot
@@ -1,0 +1,1 @@
+fedora-42-boot-2fce79425e8820106b2f0aff95c6d83d487680efff6b5fced5d7afa9665d4bc3.iso

--- a/images/scripts/fedora-42-anaconda-payload.bootstrap
+++ b/images/scripts/fedora-42-anaconda-payload.bootstrap
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eux
+
+OUTPUT="$1"
+
+PYTHONPATH=. python3 images/scripts/create-anaconda-payload --image=fedora-42 --output=$OUTPUT

--- a/images/scripts/fedora-42-boot.bootstrap
+++ b/images/scripts/fedora-42-boot.bootstrap
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eux
+
+OUTPUT="$1"
+
+URL='https://download.fedoraproject.org/pub/fedora/linux/development/42/Server/x86_64/os/images/boot.iso'
+
+curl -L "$URL" -o "$OUTPUT"

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -223,6 +223,8 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     },
     'rhinstaller/anaconda-webui': {
         'main': [
+            *contexts('fedora-42-boot', ANACONDA_SCENARIOS),
+            *contexts('fedora-42-boot', ['efi'], ANACONDA_SCENARIOS),
             *contexts('fedora-rawhide-boot', ANACONDA_SCENARIOS),
             *contexts('fedora-rawhide-boot', ['efi'], ANACONDA_SCENARIOS),
         ],
@@ -255,9 +257,16 @@ IMAGE_REFRESH_TRIGGERS = {
     "fedora-rawhide": [
         *contexts("fedora-rawhide-boot", ANACONDA_SCENARIOS, repo='rhinstaller/anaconda-webui'),
     ],
+    # Anaconda builds in fedora-42 and runs tests in fedora-42-boot
+    "fedora-42": [
+        *contexts("fedora-42-boot", ANACONDA_SCENARIOS, repo='rhinstaller/anaconda-webui'),
+    ],
     # Anaconda payload updates can affect tests
     "fedora-rawhide-anaconda-payload": [
         *contexts("fedora-rawhide-boot", ANACONDA_SCENARIOS, repo='rhinstaller/anaconda-webui'),
+    ],
+    "fedora-42-anaconda-payload": [
+        *contexts("fedora-42-boot", ANACONDA_SCENARIOS, repo='rhinstaller/anaconda-webui'),
     ],
 }
 


### PR DESCRIPTION
Image refresh for fedora-42-boot and fedora-42-anaconda-payload
 * [x] image-refresh fedora-42-boot
 * [x] image-refresh fedora-42-anaconda-payload