### PR TITLE
lib/testmap: add a /firefox scenario for c-files

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -155,6 +155,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-41',
             'fedora-42',
             f'{TEST_OS_DEFAULT}/devel',
+            f'{TEST_OS_DEFAULT}/firefox',
             'fedora-rawhide',
             'centos-10',
             'rhel-8-10/ws-container',


### PR DESCRIPTION
We recently found out about a regression with newer versions of Firefox only because the run happened to fail on Testing Farm, which seems a bit too accidental.  Add a scenario for it, explicitly.