### PR TITLE
lib/testmap: drop redundant fedora-42 _manual entries

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -118,7 +118,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         ],
         '_manual': [
             'centos-10',
-            'fedora-42',
             'fedora-rawhide',
             'opensuse-tumbleweed',
         ],
@@ -162,7 +161,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel-10-0',
         ],
         '_manual': [
-            'fedora-42',
         ],
     },
     'osbuild/cockpit-composer': {


### PR DESCRIPTION
f583e4966bc0 ("testmap: Enable fedora-42 on c-files and c-podman") added `fedora-42` to `main` but forgot to drop it from `_manual`.