### PR TITLE
naughty: Bring back #7145 criu vDSO bounds regression

### DIFF
--- a/naughty/fedora-41/7145-criu-vdso-bounds
+++ b/naughty/fedora-41/7145-criu-vdso-bounds
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/check-application", line *, in testCheckpointRestore
+    b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in NOT_RUNNING)
+*
+testlib.Error: timed out waiting for predicate to become true


### PR DESCRIPTION
Fedora 41 is getting a new kernel [1] which again breaks container checkpointing in the same way as rawhide did in December [2].

Reactivate the naughty and apply it to Fedora 41 this time.

Closes https://github.com/cockpit-project/cockpit-podman/issues/2015

[1] https://bodhi.fedoraproject.org/updates/FEDORA-2025-f476a8c306
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2328985