### PR TITLE
images: Explicitly install criu on RHEL

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -173,6 +173,7 @@ echo foobar | passwd --stdin root
 # them to not spontaneously change from one test run to the next when
 # the distribution repository is updated.
 COCKPIT_DEPS="\
+criu \
 device-mapper-multipath \
 firewalld \
 glib-networking \


### PR DESCRIPTION
It used to be pulled in as a recommendation of crun/podman, but those two are already in the cloudimage we use for bootstrapping, and we don't get to control whether criu is installed or not.

Let's just do that explicitly.

- [ ] image-refresh rhel-9-6
