### PR TITLE
test: Give anaconda tests an additional fedora-wiki-staging secret

### DIFF
--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -345,7 +345,7 @@ class TestTestsScan(unittest.TestCase):
                     "labels": ["nightly"],
                 },
                 "command_subject": None,
-                "secrets": ["github-token", "image-download", "fedora-wiki"],
+                "secrets": ["github-token", "image-download", "fedora-wiki", "fedora-wiki-staging"],
                 "env": {
                     "COCKPIT_BOTS_REF": "main",
                     'TEST_REVISION': "112233",

--- a/tests-scan
+++ b/tests-scan
@@ -245,6 +245,7 @@ def cockpit_tasks(api: github.GitHub, contexts: Sequence[str], opts: argparse.Na
             secrets = ["github-token", "image-download"]
             if api.repo == "rhinstaller/anaconda-webui":
                 secrets.append("fedora-wiki")
+                secrets.append("fedora-wiki-staging")
 
             yield {
                 "job": {


### PR DESCRIPTION
This is for authentication to https://stg.fedoraproject.org/.