### PR TITLE
images: Use z-stream build root for rhel-8-8

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -385,7 +385,11 @@ if [ "$DO_BUILD" -eq 1 ]; then
             zversion=""
         else
             # RHEL 8 and 9
-            zversion=".0"
+            if [ "$IMAGE" = "rhel-8-8" ]; then
+                zversion=".0-z"
+            else
+                zversion=".0"
+            fi
         fi
         cat <<EOF > /etc/mock/default.cfg
 config_opts['chroothome'] = '/builddir'


### PR DESCRIPTION
See https://issues.redhat.com/browse/RHELBLD-16607

Fixes #7507

 - [ ] image-refresh rhel-8-8