### PR TITLE
naughty: add pattern for failing installation when using RAID1 on partition level with LVM

### DIFF
--- a/naughty/fedora-43/7531-anaconda-raid-with-lvm
+++ b/naughty/fedora-43/7531-anaconda-raid-with-lvm
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "*check-storage-mountpoints-raid-e2e", line *, in testLVMOnRAID
+*
+    raise AssertionError('Error during installation')
+AssertionError: Error during installation


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2351580


Example of such failing test: https://cockpit-logs.us-east-1.linodeobjects.com/pull-688-cf15c5cc-20250311-114255-fedora-rawhide-boot-expensive/log.html#6-2