### PR TITLE
Revert "naughty: add pattern for failing installation when using RAID1 on partition level with LVM"

### DIFF
--- a/naughty/fedora-43/7531-anaconda-raid-with-lvm
+++ b/naughty/fedora-43/7531-anaconda-raid-with-lvm
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "*check-storage-mountpoints-raid-e2e", line *, in testLVMOnRAID
-*
-    raise AssertionError('Error during installation')
-AssertionError: Error during installation


### PR DESCRIPTION
This reverts commit b1dd3c4a593841d462187addb7bcfef8c226a608.

This was actually wrong test configuration: https://github.com/rhinstaller/anaconda-webui/pull/693