### PR TITLE
testmap: Move sub-man to RHEL 9.7/10.1

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -190,8 +190,8 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     'candlepin/subscription-manager': {
         'main': [
             'centos-10',
-            'rhel-9-6',
-            'rhel-10-0',
+            'rhel-9-7',
+            'rhel-10-1',
             'fedora-40',
             'fedora-41',
             'fedora-42',
@@ -223,16 +223,14 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'rhel-10-0',
         ],
         '_manual': [
-            'rhel-9-7',
-            'rhel-10-1',
         ],
     },
     'candlepin/subscription-manager-cockpit': {
         'main': [
             'centos-9-stream/subscription-manager-1.29',
             'centos-10',
-            'rhel-9-6/subscription-manager-1.29',
-            'rhel-10-0',
+            'rhel-9-7/subscription-manager-1.29',
+            'rhel-10-1',
             'fedora-40',
             'fedora-41',
             'fedora-42',


### PR DESCRIPTION
9.6/10.0 is done from a developer's PoV.

---

@pkoprda @ptoscano Can you please check this? There are already stable branches set up for 9-6 and 10-0, but I don't know if you need something else here.

Also, I'd like to clean up rhel-9-5 (non-EUS release, and 9.6 is around the corner) and fedora-40 (soon EOL) from the test map and the images from our CI. Any objections?

Thanks!