### PR TITLE
testmap: Drop cockpit-composer from Fedora

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -168,15 +168,10 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     },
     'osbuild/cockpit-composer': {
         'main': [
-            'fedora-40',
-            'fedora-40/firefox',
             'centos-9-stream',
             'rhel-9-6',
         ],
         '_manual': [
-            'fedora-rawhide',
-            'fedora-41',
-            'fedora-42',
         ],
     },
     'candlepin/subscription-manager': {


### PR DESCRIPTION
cockpit-composer was replaced with
https://github.com/osbuild/image-builder-frontend, see https://github.com/osbuild/cockpit-composer/ README.

Fedora 40 is EOL soon, and c-composer won't be updated there any more.

---

Just talked this over with @ochosi and @croissanne in chat, but will let them confirm anyway. After this lands, we can drop the fedora-40 image.