### PR TITLE
image-create: Remove old image before installing new one

### DIFF
--- a/image-create
+++ b/image-create
@@ -165,6 +165,10 @@ class MachineBuilder:
 
         name = self.machine.image + "-" + sha + self.suffix
         data_file = os.path.join(data_dir, name)
+        if os.path.exists(data_file):
+            # shutil.move has trouble when the destination exists but
+            # has too restrictive permissions to be overwritten.
+            os.unlink(data_file)
         shutil.move(self.machine.image_file if (self.iso or self.payload) else rebuild, data_file)
 
         if not self.iso and not self.payload:


### PR DESCRIPTION
Otherwise, shutil.move might try to overwrite it and fail with a confusing permission error.  This happens when the new image is the same as the old image, a "payload" or "iso", and /var/tmp and /cache are on different filesystems.

Fixes #7680

 * [x] image-refresh fedora-42-boot