### PR TITLE
naughty: relax naughty for cockpit-podman 104 release

### DIFF
--- a/naughty/rhel-10/7716-checkpoint-restore-failure
+++ b/naughty/rhel-10/7716-checkpoint-restore-failure
@@ -1,7 +1,3 @@
-* Error (criu/vdso.c:*): vdso: Unexpected rt vDSO area bounds
-* Error (criu/vdso.c:*): vdso: Failed to fill self vdso symtable
-* Error (criu/kerndat.c:*): kerndat_vdso_fill_symtable failed when initializing kerndat.
-*
 Traceback (most recent call last):
   File "test/check-application", line *, in testCheckpointRestore
     b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in NOT_RUNNING)


### PR DESCRIPTION
This release does not yet include the criu dump and the issue does occur in package gating tests so needs a naughty.

---

:(