### PR TITLE
naughty: kdump issues now also affect Fedora-41

### DIFF
--- a/naughty/fedora-41/7629-kdump-initrd-generation
+++ b/naughty/fedora-41/7629-kdump-initrd-generation
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-kdump", line *, in testBasic
+    b.wait_not_present(pathInput)

--- a/naughty/fedora-41/7765-kdump-crashkernel-size
+++ b/naughty/fedora-41/7765-kdump-crashkernel-size
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-kdump", line *, in testBasic
+    m.execute("until systemctl is-active kdump; do sleep 1; done")
+*
+RuntimeError: Timed out on 'until systemctl is-active kdump; do sleep 1; done'

--- a/naughty/fedora-41/7765-kdump-crashkernel-size-2
+++ b/naughty/fedora-41/7765-kdump-crashkernel-size-2
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-kdump", line *, in testBasic
+    b.wait_visible(".pf-v6-c-switch__input:checked")


### PR DESCRIPTION
Caught in our updates-testing scenario https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-c3930d90-20250515-013216-fedora-41-updates-testing/log.html