### PR TITLE
naughty: copy podman checkpoint restore issue to Fedora

### DIFF
--- a/naughty/fedora-41/7716-checkpoint-restore-failure
+++ b/naughty/fedora-41/7716-checkpoint-restore-failure
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/check-application", line *, in testCheckpointRestore
+    b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in NOT_RUNNING)
+    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "*", line *, in wait
+    raise Error('timed out waiting for predicate to become true')
+testlib.Error: timed out waiting for predicate to become true

--- a/naughty/fedora-42/7716-checkpoint-restore-failure
+++ b/naughty/fedora-42/7716-checkpoint-restore-failure
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/check-application", line *, in testCheckpointRestore
+    b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in NOT_RUNNING)
+    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "*", line *, in wait
+    raise Error('timed out waiting for predicate to become true')
+testlib.Error: timed out waiting for predicate to become true


### PR DESCRIPTION
This has now also made it to podman-next.

---

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-0-d410ddda-20250515-023845-fedora-41-podman-next/log.html