### PR TITLE
naughty: copy checkpoint restore issue to Fedora-rawhide

### DIFF
--- a/naughty/fedora-43/7716-checkpoint-restore-failure
+++ b/naughty/fedora-43/7716-checkpoint-restore-failure
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/check-application", line *, in testCheckpointRestore
+    b.wait(lambda: self.getContainerAttr("swamped-crate", "State") in NOT_RUNNING)
+    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "*", line *, in wait
+    raise Error('timed out waiting for predicate to become true')
+testlib.Error: timed out waiting for predicate to become true


### PR DESCRIPTION
Should have done that as well when copying to fedora-42/41 ... now it affects our reverse dependency testing in podman https://artifacts.dev.testing-farm.io/d8c8fd27-db60-412f-933f-88aee05596ec/