### PR TITLE
naughty: copy kdump issues to rhel-10

### DIFF
--- a/naughty/rhel-10/7765-kdump-crashkernel-size
+++ b/naughty/rhel-10/7765-kdump-crashkernel-size
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-kdump", line *, in testBasic
+    m.execute("until systemctl is-active kdump; do sleep 1; done")
+*
+RuntimeError: Timed out on 'until systemctl is-active kdump; do sleep 1; done'

--- a/naughty/rhel-10/7765-kdump-crashkernel-size-2
+++ b/naughty/rhel-10/7765-kdump-crashkernel-size-2
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-kdump", line *, in testBasic
+    b.wait_visible(".pf-v6-c-switch__input:checked")


### PR DESCRIPTION
The crashkernel=2G issue also affects rhel-10.

---

See https://github.com/cockpit-project/cockpit/pull/22005