### PR TITLE
logs: Always show init section

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -24,10 +24,10 @@
 
         /* Filters start */
         /* Only show failed */
-        body.c-filter-only-failed .test-entry:not(.failed:not(.skipped,.retried)) {
+        body.c-filter-only-failed .test-entry:not(.failed:not(.skipped,.retried),#initialization) {
             display: none;
         }
-        body.c-filter-only-failed-retried .test-entry:not(.failed:not(.skipped), .retried) {
+        body.c-filter-only-failed-retried .test-entry:not(.failed:not(.skipped), .retried, #initialization) {
             display: none;
         }
         /* Filters end */


### PR DESCRIPTION
Init section is important no matter which type of tests you are looking
for. Lets make it show for all tabs no matter the filtering.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
