### PR TITLE
naughty: add naughty for Fedora 42 kdump issue

### DIFF
--- a/naughty/fedora-42/7629-kdump-initrd-generation-3
+++ b/naughty/fedora-42/7629-kdump-initrd-generation-3
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "test/verify/check-kdump", line *, in testBasic
+*
+wait_js_cond(!ph_is_present(".pf-v6-c-alert__title")): Error: condition did not become true


### PR DESCRIPTION
@tomasmatus this still needs reporting and figuring out why crashkernel is not set