### PR TITLE
Revert "naughty: Close 7707: fedora-rawhide-boot: Blivet is ignoring a partition on MDRAID with "parted disk not found""

### DIFF
--- a/naughty/fedora-43/7707-blivet-parted-disk-not-found
+++ b/naughty/fedora-43/7707-blivet-parted-disk-not-found
@@ -1,0 +1,2 @@
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#cockpit-storage-integration-check-storage-dialog","'biosboot' partition on MDRAID device SOMERAID found. Bootloader partitions on MDRAID devices are not supported.")):*


### PR DESCRIPTION
This reverts commit 9e45af86f46771fb15cccb941ab5f8ad45da9363.

Sorry this issue still occurs: https://cockpit-logs.us-east-1.linodeobjects.com/pull-853-7053d18d-20250602-103417-fedora-rawhide-boot-cockpit/log.html