### PR TITLE
images: rhel: move stratisd-tools to test packages

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -195,7 +195,6 @@ subscription-manager \
 sos \
 stratis-cli \
 stratisd \
-stratisd-tools \
 tuned \
 udisks2 \
 udisks2-lvm2 \
@@ -234,6 +233,7 @@ nmap-ncat \
 qemu-kvm \
 socat \
 strace \
+stratisd-tools \
 tang \
 targetcli \
 tcsh \
@@ -247,7 +247,7 @@ wireguard-tools \
 
 # No stratisd-tools in rhel-10-0/rhel-9-6 and lower
 if [ "$IMAGE" = "rhel-10-0" ] || [ "${IMAGE#rhel-9-[0246]}" != "$IMAGE" ] || [ "${IMAGE#rhel-8*}" != "$IMAGE" ]; then
-    COCKPIT_DEPS="${COCKPIT_DEPS/stratisd-tools /}"
+    TEST_PACKAGES="${TEST_PACKAGES/stratisd-tools /}"
 fi
 
 if [ "${IMAGE#rhel*}" != "$IMAGE" ]; then


### PR DESCRIPTION
This package is used to create V1 pools on a stratis version which defaults to V2 pools and only used in our tests.