### PR TITLE
lib: kill podman run --init if podman rm fails

### DIFF
--- a/lib/aio/job.py
+++ b/lib/aio/job.py
@@ -150,8 +150,10 @@ async def run_container(job: Job, subject: Subject, ctx: JobContext, log: LogStr
                     raise Failure(f'Container exited with code {returncode}')
 
             finally:
-                await run([*ctx.container_cmd, 'rm', '--force', '--time=0', f'--cidfile={tmpdir}/cidfile'],
-                          stdout=asyncio.subprocess.DEVNULL)  # don't show container ID output
+                ret = await run([*ctx.container_cmd, 'rm', '--force', '--time=0', f'--cidfile={tmpdir}/cidfile'],
+                              stdout=asyncio.subprocess.DEVNULL)  # don't show container ID output
+                if ret != 0:
+                    container.kill()
 
 
 async def run_job(job: Job, ctx: JobContext) -> None:

--- a/lib/aio/spawn.py
+++ b/lib/aio/spawn.py
@@ -36,10 +36,11 @@ async def spawn(args: Sequence[str], **kwargs: Any) -> AsyncIterator[asyncio.sub
         logger.debug('spawn: pid %r exited, %r', pid, status)
 
 
-async def run(args: Sequence[str], **kwargs: Any) -> None:
+async def run(args: Sequence[str], **kwargs: Any) -> int:
     logger.debug('run(%r)', args)
     process = await asyncio.create_subprocess_exec(*args, **kwargs)
     pid = process.pid
     logger.debug('run: waiting for pid %r', pid)
     status = await process.wait()
     logger.debug('run: pid %r exited, %r', pid, status)
+    return status


### PR DESCRIPTION
In CI `podman run` sometimes fails to stop a container with:

Error: reading CIDFile: open /tmp/tmpw4b91s99/cidfile: no such file or directory

The job-runner is then stuck in `gather_and_cancel` waiting on `task.cancel()` for `create_container` as this is stuck due to a bug kill the process.

`create_container` itself hangs on:

futex(0x5575a9ff4580, FUTEX_WAIT_PRIVATE, 0, NULL) = 0 futex(0xc00077c148, FUTEX_WAKE_PRIVATE, 1) = 1