### PR TITLE
naughty: add targetcli Python 3.14 exception

### DIFF
--- a/naughty/fedora-43/7919-targetcli-exception
+++ b/naughty/fedora-43/7919-targetcli-exception
@@ -1,0 +1,1 @@
+ModuleNotFoundError: No module named 'rtslib_fb.utils'; 'rtslib_fb' is not a package


### PR DESCRIPTION
Doesn't hurt that much, but not that hard to get rid off example of the failure:

https://artifacts.dev.testing-farm.io/895de1ad-921f-434f-89c9-6b23d5fd016f/#artifacts-/plans/all/basic