### PR TITLE
used-tasks-tags: Add

### DIFF
--- a/used-tasks-tags
+++ b/used-tasks-tags
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Determine all tasks container tags that are used in our projects.
+# Used for cleaning up obsolete tasks tags.
+
+import asyncio
+import re
+import sys
+
+from lib import testmap
+from lib.aio.base import SubjectSpecification
+from lib.aio.github import GitHub
+from lib.directories import xdg_config_home
+
+
+async def main() -> None:
+    used_tags = set()
+
+    # avoid rate limiting with token
+    try:
+        with open(xdg_config_home("cockpit-dev/github-token")) as f:
+            token = f.read().strip()
+    except FileNotFoundError:
+        print("No GitHub token found, rate limiting may apply", file=sys.stderr)
+        token = None
+
+    async with GitHub({"clone-url": "dummy", "api-url": "https://api.github.com/", "post": False,
+                       "token": token, "user-agent": "cockpit-bots"}) as github:
+        for repo, branches in testmap.REPO_BRANCH_CONTEXT.items():
+            for branch in branches:
+                if branch.startswith("_"):
+                    continue
+
+                subject = await github.resolve_subject(SubjectSpecification({"repo": repo, "branch": branch}))
+                content = await github.read_file(subject, ".cockpit-ci/container")
+                if content is None:
+                    print(f"Note: {repo}/{branch} has no .cockpit-ci/container", file=sys.stderr)
+                    continue
+                m = re.match(r"ghcr\.io/([^/]+)/([^:]+):([\w\-\.]+)", content.strip())
+                if m:
+                    tag = m.group(3)
+                    print(f"Note: {repo}/{branch} uses tag {tag}", file=sys.stderr)
+                    used_tags.add(tag)
+
+    for tag in sorted(used_tags):
+        print(tag)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
This is useful to determine which repo/branch uses which tag, which tags
we need to keep and conversely, which ones we can clean up.

---

See https://github.com/cockpit-project/cockpituous/pkgs/container/tasks/versions , we are accumulating lots of cruft. I'm going to use https://github.com/marketplace/actions/ghcr-io-cleanup-action with this script to compute `exclude-tags` (plus keep the most recent 5 versions)