### PR TITLE
image-upload: Temporarily make all images private

### DIFF
--- a/image-upload
+++ b/image-upload
@@ -96,7 +96,10 @@ def main() -> None:
         sources.append(source)
 
     for source in sources:
-        public = not os.path.basename(source).startswith('rhel')
+        # Temporarily make all images private, until we figure out if it's images or logs which cause
+        # so much traffic these days (AI scrapers?)
+        # public = not os.path.basename(source).startswith('rhel')
+        public = False
 
         stores = args.store
         if not stores:


### PR DESCRIPTION
See <https://issues.redhat.com/browse/COCKPIT-1288>. We are getting ridiculous amounts of traffic on S3, and suspect AI scrapers or similar things. This comes either from the logs or from image downloads, and as Linode does not have per-bucket statistics we need to first find out which one it is.

Start with making images private, which is both much easier and also more promising as they are much bigger than test logs.

---

I already made the existing images private:

```
s3cmd setacl s3://cockpit-images --acl-private --recursive
```

I can easily revert that if necessary.