### PR TITLE
used-tasks-tags: Print tags comma separated

### DIFF
--- a/used-tasks-tags
+++ b/used-tasks-tags
@@ -44,8 +44,7 @@ async def main() -> None:
                     print(f"Note: {repo}/{branch} uses tag {tag}", file=sys.stderr)
                     used_tags.add(tag)
 
-    for tag in sorted(used_tags):
-        print(tag)
+    print(",".join(sorted(used_tags)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
That way the output fits [1], and for human consumption it does not matter much.

[1] https://github.com/marketplace/actions/ghcr-io-cleanup-action