### PR TITLE
naughty: Generalize Ubuntu 22.04 podman hang

### DIFF
--- a/naughty/ubuntu-2204/4829-podman-hang
+++ b/naughty/ubuntu-2204/4829-podman-hang
@@ -1,4 +1,5 @@
   File "test/check-application", line *, in testPruneUnusedContainers*
 *
-RuntimeError: Timed out on '
-            podman run --name inpod --pod pod -tid localhost/test-busybox sh -c 'exit 1''
+    self.execute("podman ps -a >&2", system=auth)
+*
+RuntimeError: Timed out on 'podman ps -a >&2'

--- a/naughty/ubuntu-2204/4829-podman-hang-2
+++ b/naughty/ubuntu-2204/4829-podman-hang-2
@@ -1,4 +1,0 @@
-  File "test/check-application", line *, in testPruneUnusedContainers*
-*
-RuntimeError: Timed out on '
-            podman run --name inpodrunning --pod pod -tid localhost/test-busybox sh -c 'sleep infinity''


### PR DESCRIPTION
This happens in other situations/code places. The commonality is that after the hang, our `podman ps -a` debug command hangs as well. This is a sure sign of podman being FUBAR, regardless of which particular step triggered the hang.

---

See [recent](https://cockpit-logs.us-east-1.linodeobjects.com/pull-2180-b04578e6-20250707-031916-ubuntu-2204/log.html) [failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-2178-259fb3e1-20250703-114646-ubuntu-2204/log.html) from the [weather report](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit-podman&days=7&test=%2Ftest%2Fcheck-application+TestApplication.testPruneUnusedContainersSystem).