### PR TITLE
naughty: Add rhel-8 pattern for failure to apply setroubleshoot solution

### DIFF
--- a/naughty/rhel-8/7967-sefix-failure
+++ b/naughty/rhel-8/7967-sefix-failure
@@ -1,0 +1,5 @@
+> warn: Unable to run fix: {"problem":null,"name":"org.freedesktop.DBus.Python.subprocess.CalledProcessError","message":"*/usr/share/setroubleshoot/SetroubleshootFixit.py*in run_fix*subprocess.CalledProcessError: Command '['sealert', '-f', *, '-P', dbus.String('restorecon')]' returned non-zero exit status 3.\n"}
+*
+  File "test/verify/check-selinux", line *, in testTroubleshootAlerts
+*
+wait_js_cond(ph_in_text("tbody:contains('read access on the file /root/.ssh/authorized_keys') .pf-v6-c-alert__title","Solution applied successfully")): Error: actual text: Danger alert:Solution failed


### PR DESCRIPTION
Downstream report: https://issues.redhat.com/browse/RHEL-102322
Known issue #7967

---

Addresses [this common flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-22171-b0a73073-20250704-125310-rhel-8-10-ws-container-other/log.html#41). Also see https://github.com/cockpit-project/cockpit/pull/22185#issue-3211647176