### PR TITLE
image-upload: Fail hard if S3 credentials are missing

### DIFF
--- a/image-upload
+++ b/image-upload
@@ -38,8 +38,7 @@ def upload(store: str, source: str, public: bool, prune: bool = False) -> bool:
 
     if not s3.is_key_present(url):
         # No credentials?  That's not going to work...
-        sys.stderr.write(f"image-upload: no credentials for {dest}")
-        return False
+        raise SystemExit(f"image-upload: no credentials for {dest}")
 
     # Start building the command
     cmd = ["curl", "--no-progress-meter", "--fail", "--upload-file", source, *get_curl_ca_arg(url.netloc)]


### PR DESCRIPTION
When uploading to multiple stores and one fails due to a network error, this is tolerable -- so image-upload succeeds in that case.

But for the last months our CI machines were lacking the S3 token for the local minio image cache on rhos-01-1, which is both systemic (and we need to know about it!) and also expensive: Each of our ~ 40 bots will re-download images from the primary Linode S3 store instead of the local cache.

---

See [recent image refreshes](https://cockpit-logs.us-east-1.linodeobjects.com/image-refresh-rhel-9-4-556028b2-20250713-224521/log.html):

> image-upload: no credentials for http://10.0.203.107/images/rhel-9-4-7f510475164ab04a8160e3b34e20e33ab0be1a4efc453507bf7f173397d0c8de.qcow2

This went unnoticed since around May 28. I fixed that now by running `maintenance/sync-secrets.yml` (which sets up the correct link), I don't know how it disappeared.