### PR TITLE
naughty: Adjust #4829 pattern

### DIFF
--- a/naughty/ubuntu-2204/4829-podman-hang-6
+++ b/naughty/ubuntu-2204/4829-podman-hang-6
@@ -4,6 +4,6 @@
 testlib.Error: timeout
 *
   File "test/check-application", line *, in tearDown
-    self.execute(auth, "podman ps -a >&2")
+    self.execute("podman ps -a >&2", system=auth)
 *
 RuntimeError: Timed out on 'podman ps -a >&2'


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit-podman/commit/b135d5b4a6a changed the way `podman ps -a` gets called, `auth` is now a kwarg.

---

Fixes [this flake](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2191-aef58409-20250716-052816-ubuntu-2204/log.html).