### PR TITLE
testmap: Move cockpit-podman rhel-8-10 to container/beiboot

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -111,7 +111,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-42',
             'fedora-coreos',
             'opensuse-tumbleweed',
-            'rhel-8-10',
+            'rhel-8-10/ws-container',
             'rhel-9-7',
             'rhel-10-1',
             'ubuntu-2204',


### PR DESCRIPTION
Let's deprecate the "native rpm" rhel-8-10 scenario. We won't ever update RHEL 8 to the current upstream versions. Instead, let's make sure that RHEL 8 keeps working with the recent cockpit/ws container in beiboot mode.

See https://github.com/cockpit-project/cockpit-podman/commit/fab65b245d3