### PR TITLE
naughty: Add pattern for rawhide lastlog2 SELinux regression

### DIFF
--- a/naughty/fedora-43/8021-selinux-lastlog2
+++ b/naughty/fedora-43/8021-selinux-lastlog2
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "verify/check-users", line *, in testUserPasswords
+    b.wait_in_text("#account-last-login", year)
+*
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#account-last-login","202*")): Error: actual text: Never

--- a/naughty/fedora-coreos
+++ b/naughty/fedora-coreos
@@ -1,1 +1,1 @@
-fedora-39
+fedora-42


### PR DESCRIPTION
Known issue #8021
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2382799

----

Addresses last night's [rawhide regression](https://artifacts.dev.testing-farm.io/d4f17433-c0de-4500-a514-91c5e21a44c7/), see bugzilla for details.