### PR TITLE
various machines/ssh_connection cleanups

### DIFF
--- a/machine/machine_core/cli.py
+++ b/machine/machine_core/cli.py
@@ -42,7 +42,7 @@ def cmd_cli() -> None:
 
     # print ssh command
     print("ssh -o ControlPath=%s -p %s %s@%s" %
-          (machine.ssh_master, machine.ssh_port, machine.ssh_user, machine.ssh_address))
+          (machine.ssh_control_path, machine.ssh_port, machine.ssh_user, machine.ssh_address))
     # print Cockpit web address
     print(f"http://{machine.web_address}:{machine.web_port}")
     # print marker that the VM is ready; tests can poll for this to wait for the VM

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -38,6 +38,7 @@ from lib.constants import TEST_DIR
 
 class SSHConnection:
     ssh_default_opts = (
+        "-F", "none",
         "-o", "BatchMode=yes",
         "-o", "IdentitiesOnly=yes",
         "-o", "PKCS11Provider=none",

--- a/machine/machine_core/ssh_connection.py
+++ b/machine/machine_core/ssh_connection.py
@@ -443,7 +443,6 @@ class SSHConnection:
         The directory of dest is created automatically.
         """
         assert dest
-        assert self.ssh_address
 
         self.execute(["mkdir", "-p", os.path.dirname(dest)])
         self.execute(f"cat {'>>' if append else '>'} {shlex.quote(dest)}", input=content)


### PR DESCRIPTION
This is mostly cleanups related to resolving the weird relationship between the `SSHConnection` and `Machine` classes: `Machine` derives from `SSHConnection` but we never ever create an instance of `SSHConnection` which is not also a `Machine`.

This batch of changes is related to cleaning up and removing redundancy from our handling of building `ssh` command-lines for our various APIs (spawn, execute, write, upload, download, etc.) and is a nice bunch of cleanups in any case.

I'm mostly sending these in now to get them tested and reviewed while I continue with further work.