### PR TITLE
naughty: Add second pattern for #8021 lastlog2 regression

### DIFF
--- a/naughty/fedora-43/8021-selinux-lastlog2-2
+++ b/naughty/fedora-43/8021-selinux-lastlog2-2
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "test/verify/check-users", line *, in testBasic
+    b.wait_in_text("#accounts-list tbody tr:contains('paul')", m.execute("date +'%b %-d, %Y'").strip())
+*
+testlib.Error: timeout
+wait_js_cond(ph_in_text("#accounts-list tbody tr:contains('paul')","*")): Error: actual text: paul*Never logged inpaul


### PR DESCRIPTION
This breaks Cockpit's TestAccounts.testBasic as well.

---

See [example log](https://artifacts.dev.testing-farm.io/5f287881-e45c-4058-8134-75dcce64614d/work-mainbfuvuq3v/plans/all/main/execute/data/guest/default-0/test/browser/main-1/output.txt). With this, rawhide should go green again on TF.