### PR TITLE
Add centos-10-bootc to OSTREE_IMAGES

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -18,7 +18,7 @@
 import os
 
 # Images which are OSTree based
-OSTREE_IMAGES = ("centos-9-bootc", "fedora-coreos")
+OSTREE_IMAGES = ("centos-9-bootc", "centos-10-bootc", "fedora-coreos")
 
 LIB_DIR = os.path.dirname(__file__)
 BOTS_DIR = os.path.dirname(LIB_DIR)


### PR DESCRIPTION
This will enable running CentOS 10 bootc tests properly.

----

Addresses the failures of a [c10-image-mode TF run](https://artifacts.dev.testing-farm.io/833a80ee-c8ce-4744-bc07-5a3b861128fc/work-mainzr6m8xbw/plans/all/main/execute/data/guest/default-0/test/browser/main-1/output.txt) from https://github.com/cockpit-project/cockpit/pull/22237