### PR TITLE
logs: round overall test progress percentage

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -184,7 +184,7 @@
                     id="progress-sm-example-description"
                 >Test progress</div>
                 <div class="pf-v6-c-progress__status" aria-hidden="true">
-                    <span class="pf-v6-c-progress__measure">{{finished}}/{{total}} ({{percentage_done}}%)</span>
+                    <span class="pf-v6-c-progress__measure">{{finished}}/{{total}} ({{Math.floor(percentage_done)}}%)</span>
                 </div>
                 <div
                     class="pf-v6-c-progress__bar"


### PR DESCRIPTION
Round the progress percentage down to a non-fractioned number.

Fixes:

<img width="225" height="111" alt="Screenshot From 2025-07-30 13-14-03" src="https://github.com/user-attachments/assets/ae8000a5-8d91-4a99-971b-45734af5b368" />
