### PR TITLE
naughty: Add pattern for rawhide kernel RAID regression

### DIFF
--- a/naughty/fedora-43/8059-mdraid-init-sysfs
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs
@@ -1,0 +1,7 @@
+> warn: Error starting RAID array: Process reported exit code 1: mdadm: Unable to initialize sysfs
+*
+  File "/source/test/verify/check-storage-mdraid",*
+    b.wait_text(self.card_desc("MDRAID device", "State"), "Running")
+*
+testlib.Error: timeout
+wait_js_cond(ph_text_is("*","Running")): Error: actual text: Not running


### PR DESCRIPTION
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2385871
Known issue #8059

----

Fixes [Cockpit rawhide storage tests](https://artifacts.dev.testing-farm.io/20ab7624-6194-44d7-abc6-52544e40cf16/). We only run them on TF, not in our CI. Checked against [test log](https://artifacts.dev.testing-farm.io/20ab7624-6194-44d7-abc6-52544e40cf16/work-storage-basici56wajdw/plans/all/storage-basic/execute/data/guest/default-0/test/browser/storage-basic-1/output.txt) with `bots/test-failure-policy -o fedora-rawhide`.