### PR TITLE
testmap: Enable centos-9-bootc storage scenario for Cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -42,8 +42,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     'cockpit-project/cockpit': {
         'main': [
             *contexts('arch', COCKPIT_SCENARIOS),
-            # cockpit-storaged not yet installed and tests not yet enabled
-            *contexts('centos-9-bootc', COCKPIT_SCENARIOS - {'storage'}),
+            *contexts('centos-9-bootc', COCKPIT_SCENARIOS),
             *contexts('debian-stable', COCKPIT_SCENARIOS),
             *contexts('debian-testing', COCKPIT_SCENARIOS),
             *contexts('ubuntu-2204', COCKPIT_SCENARIOS),


### PR DESCRIPTION
Fixed in https://github.com/cockpit-project/cockpit/pull/22270