### PR TITLE
testmap: Add cockpit rhel-9.6 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -65,6 +65,11 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             # all skipped
             *contexts('rhel-8-10-distropkg', COCKPIT_SCENARIOS - {'networking'}),
         ],
+        'rhel-9.6': [
+            # that branch does not yet have storage tests enabled for bootc
+            *contexts('centos-9-bootc', COCKPIT_SCENARIOS - {'storage'}),
+            *contexts('rhel-9-6', COCKPIT_SCENARIOS),
+        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-rawhide',


### PR DESCRIPTION
I just created https://github.com/cockpit-project/cockpit/tree/rhel-9.6 . The next step will be to send a PR to it and backport enough test fixes to make it green.