### PR TITLE
naughty: add alternative naughty for mdraid kernel rawhide regression

### DIFF
--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso
@@ -1,0 +1,1 @@
+mdadm: No arrays found in config file or automatically


### PR DESCRIPTION
This matches the failure in the installation environment.

Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2385871 Known issue #8059