### PR TITLE
Revert "naughty: Close 6178: pmproxy crash at startup in libpcp_web.so.1"

### DIFF
--- a/naughty/ubuntu-stable/6178-pmproxy-web-crash
+++ b/naughty/ubuntu-stable/6178-pmproxy-web-crash
@@ -1,0 +1,3 @@
+TestHistoryMetrics.testPmProxySettings*
+*FAIL: Test completed, but found unexpected journal messages:
+Process * (pmproxy) of user 997 dumped core.


### PR DESCRIPTION
This still happens.

This reverts commit 21f5deaa7fbee543b24dd444550c9562a32f9caf.

---

See Weather report. [example 1](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22277-2c173552-20250804-025510-ubuntu-stable-other/log.html), [example 2](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-8078-0d57aaf0-20250805-231513-ubuntu-stable-other-cockpit-project-cockpit/log.html).

I already reopened #6178.