### PR TITLE
stores: designate one of our S3 buckets "private"

### DIFF
--- a/image-download
+++ b/image-download
@@ -47,7 +47,7 @@ from lib import s3
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
 from lib.network import get_curl_ca_arg, redhat_network
-from lib.stores import PUBLIC_STORES, REDHAT_STORES
+from lib.stores import PRIVATE_STORES, PUBLIC_STORES, REDHAT_STORES
 from lib.testmap import get_test_image
 
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
@@ -133,7 +133,11 @@ def download(dest: str, force: bool, state: bool, quiet: bool, stores: Sequence[
     name = os.path.basename(dest)
 
     if not stores:
-        stores = list(PUBLIC_STORES)
+        # Due to AI scraper-bot mitigation all public stores currently require
+        # an access token: if we don't have one, then don't bother.
+        stores = [
+            store for store in (*PUBLIC_STORES, *PRIVATE_STORES) if s3.is_key_present(urllib.parse.urlparse(store))
+        ]
         if redhat_network():
             stores += REDHAT_STORES
         image_upload_store = os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE')
@@ -142,6 +146,11 @@ def download(dest: str, force: bool, state: bool, quiet: bool, stores: Sequence[
             # testing.  Compare with image-upload which *only* uploads to this
             # store, if it's present.
             stores += [image_upload_store]
+
+    # Could be that we have no stores due to missing tokens.  Print a helpful message for new contributors.
+    if not stores:
+        sys.exit("Due to excessive bandwidth usage caused by AI scrapers, it's not currently possible to download "
+                 "testing images without a token.  Please ask in the Cockpit Matrix channel if you need a token.")
 
     # The time condition for If-Modified-Since
     exists = not force and os.path.exists(dest)

--- a/image-upload
+++ b/image-upload
@@ -29,7 +29,7 @@ from lib import s3
 from lib.constants import BOTS_DIR, IMAGES_DIR
 from lib.directories import get_images_data_dir
 from lib.network import get_curl_ca_arg, redhat_network
-from lib.stores import PUBLIC_STORES, REDHAT_STORES
+from lib.stores import PRIVATE_STORES, PUBLIC_STORES, REDHAT_STORES
 
 
 def upload(store: str, source: str, public: bool, prune: bool = False) -> bool:
@@ -95,10 +95,7 @@ def main() -> None:
         sources.append(source)
 
     for source in sources:
-        # Temporarily make all images private, until we figure out if it's images or logs which cause
-        # so much traffic these days (AI scrapers?)
-        # public = not os.path.basename(source).startswith('rhel')
-        public = False
+        public = not os.path.basename(source).startswith('rhel')
 
         stores = args.store
         if not stores:
@@ -108,7 +105,12 @@ def main() -> None:
                 # adds this to the list, if it's present.
                 stores = [image_upload_store]
         if not stores:
-            stores = list(PUBLIC_STORES)
+            stores = list(PRIVATE_STORES)
+            if public:
+                # NB: We currently have a well-known S3 token which is capable
+                # of accessing all data uploaded to these buckets, regardless
+                # of ACL.  Only upload public images here.
+                stores += PUBLIC_STORES
             if redhat_network():
                 stores += REDHAT_STORES
         success = False

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -21,8 +21,12 @@ from lib.directories import xdg_config_home
 
 # hosted on public internet
 PUBLIC_STORES: Sequence[str] = (
-    "https://cockpit-images.eu-central-1.linodeobjects.com/",
     "https://cockpit-images.us-east-1.linodeobjects.com/",
+)
+
+# hosted on the public internet, only accessible with a private token
+PRIVATE_STORES: Sequence[str] = (
+    "https://cockpit-images.eu-central-1.linodeobjects.com/",
 )
 
 # hosted behind the Red Hat VPN


### PR DESCRIPTION
Our attempts to mitigate scraper bots by restricting all access to images is causing significant grief for new contributors: having to privately message a few designated members of the Cockpit team in order to get an S3 token to be able to start testing your first contribution isn't particularly friendly or scalable.

One solution would be to generate a well-known "public" secret key for downloading images.  The idea is that the scraper bots would not be smart enough to use this key, but casual contributors would still be able to come across it easily enough.  One issue with this approach is that Linode's S3 ACLs are not sufficiently powerful to allow us to specify that this key can only download the public (read: not RHEL) images: we can only control access at the bucket level.

As a workaround, we can take advantage of the fact that we currently have two more-or-less equal S3 buckets and arbitrarily designate the EU one as "private" and the US one as "public".  We can upload the RHEL images to only the "private" EU mirror and then give "public" access to the US mirror for all the other images.

What happens with the new "public" secret key is currently up for debate.  For the time being, let's keep it as a well-known secret passed around Cockpit developers and shared freely with anyone who asks.  At some point we may also consider to publish it in a README or even integrate it into the downloader script directly.