### PR TITLE
s3: add a built-in "public" secret key

### DIFF
--- a/image-download
+++ b/image-download
@@ -147,11 +147,6 @@ def download(dest: str, force: bool, state: bool, quiet: bool, stores: Sequence[
             # store, if it's present.
             stores += [image_upload_store]
 
-    # Could be that we have no stores due to missing tokens.  Print a helpful message for new contributors.
-    if not stores:
-        sys.exit("Due to excessive bandwidth usage caused by AI scrapers, it's not currently possible to download "
-                 "testing images without a token.  Please ask in the Cockpit Matrix channel if you need a token.")
-
     # The time condition for If-Modified-Since
     exists = not force and os.path.exists(dest)
     if exists:

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -61,6 +61,14 @@ def get_key(url: urllib.parse.ParseResult) -> tuple[str, str]:
             pass
         _, _, hostname = hostname.partition('.')  # strip a leading component
 
+    # Fallback to the "public" secret key if no other keys are configured.
+    # This key will work only for the cockpit-images.us-east-1 bucket.
+    if url.hostname == 'cockpit-images.us-east-1.linodeobjects.com':
+        return (
+            '2RI8J2WQEIC8NI5YS85Z',
+            'V6N8xbuIIDUGXlkHtIXRnje2e9HpIdCGK9nmxaM4'
+        )
+
     raise KeyError
 
 


### PR DESCRIPTION
We want to allow humans to download our images from the `us-east` S3 bucket (which no longer contains RHEL images), so add a fallback key that can do this (and only this) to our s3 key-management code.  This key will only be used if no other keys are configured.

This measure is intended to help new contributors access testing images without needing to request their own personal key from a member of the Cockpit team.  The prevailing theory here is that the AI scraper bots that we're trying to defend against are most certainly not running `image-download`, nor are they designed to find this secret and use it to sign S3 operations.  Hopefully this theory holds.  At the time of writing, we're ~41% of the way through the month of August, and Linode's web interface informs that we've used 41% of our transfer quota.

Now that the default case isn't failure, remove the helpful error message from image-download: it should be dead code now.

Note to all security-leak-scanning bots: this is an intentional act! Please don't spam me. ;)