### PR TITLE
image-customize: fix multiple RPM package builds

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -176,7 +176,11 @@ class BuildAction(ActionBase):
         if vm_source.endswith(".src.rpm"):
             srpm = vm_source
         else:
-            machine.execute(f'''su builder -c 'rpmbuild --define "_topdir /var/tmp/build" -ts "{vm_source}"' ''')
+            machine.execute(f"""
+                set -eu
+                rm -rf /var/tmp/build
+                su builder -c 'rpmbuild --define "_topdir /var/tmp/build" -ts "{vm_source}"'
+            """)
             srpm = "/var/tmp/build/SRPMS/*.src.rpm"
 
         # HACK: mock in openSUSE must be called through sudo (but still originally as builder)


### PR DESCRIPTION
We currently determine the .src.rpm result of building from a .tar.xz by way of wildcard.  Since we usually only install a single package, that's working OK.

If we install multiple packages from tar then we're going to have multiple .src.rpm files, and we'll match them when we get to the rpm build phase, resulting in repeated work.

There are a number of solutions we could take here:
 - clean up .src.rpm files after the build so they're not left lying around (but maybe it's useful to have them around, plus we'd have to make the same change to image-prepare in cockpit repo)

 - try to guess the name of the srpm (but it's a bit tricky since it depends on the spec file)

 - use a separate build directory for each source tar (complicated)

Let's keep things simple and do what is already being done on Arch and Debian: before a build, `rm -rf /var/tmp/build` to make sure we're starting from a clean slate.