### PR TITLE
tests-trigger: add support for wildcard matches

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -331,12 +331,12 @@ def projects() -> Iterable[str]:
 
 
 def get_default_branch(repo: str) -> str:
+    """Get the default branch.  Currently this is always 'main' but it might
+    change if we add repositories with a branch like 'devel' or so."""
     branches = REPO_BRANCH_CONTEXT[repo]
     if 'main' in branches:
         return 'main'
-    if 'master' in branches:
-        return 'master'
-    raise ValueError(f"repo {repo} does not contain main or master branch")
+    raise ValueError(f"repo {repo} does not contain main branch")
 
 
 def tests_for_project(project: str) -> Mapping[str, Sequence[str]]:

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -15,8 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import fnmatch
 import itertools
-import os.path
 from collections.abc import Iterable, Mapping, Sequence
 
 from lib.constants import TEST_OS_DEFAULT
@@ -372,6 +372,24 @@ def tests_for_image(image: str) -> Sequence[str]:
             break
 
     return list(tests)
+
+
+def tests_for_fnmatch(pattern: str) -> Sequence[str]:
+    """Return all contexts which match the given pattern."""
+
+    # Iterate all scenarios on all repositories, excluding _manual
+    tests = set()
+    for repo, branch_contexts in REPO_BRANCH_CONTEXT.items():
+        for branch, contexts in branch_contexts.items():
+            if branch.startswith('_'):
+                continue
+            for context in contexts:
+                c = context + '@' + repo
+                if branch != get_default_branch(repo):
+                    c += "/" + branch
+                tests.add(c)
+
+    return [test for test in tests if fnmatch.fnmatch(test, pattern)]
 
 
 def tests_for_po_refresh(project: str) -> Sequence[str]:

--- a/tests-trigger
+++ b/tests-trigger
@@ -40,7 +40,9 @@ def trigger_pull(api: github.GitHub, opts: argparse.Namespace) -> int:
     if opts.context:
         contexts = set[str]()
         for cntx in opts.context:
-            if cntx.startswith("image:"):
+            if '*' or '?' in cntx:
+                contexts.update(testmap.tests_for_fnmatch(cntx))
+            elif cntx.startswith("image:"):
                 contexts.update(testmap.tests_for_image(cntx.split(':', 1)[1]))
             elif testmap.is_valid_context(cntx, api.repo):
                 if opts.bots_pr:
@@ -99,7 +101,8 @@ def main() -> int:
     parser.add_argument('target', help='The pull request number to trigger, '
                                        'or - for the upstream of the current branch')
     parser.add_argument('context', nargs='*', help='The github task context(s) to trigger; can also be '
-                                                   '"image:<imagename>" to trigger all tests related to that image')
+                                                   '"image:<imagename>" to trigger all tests related to that image '
+                                                   'or a wildcard pattern to trigger all matching tests')
     opts = parser.parse_args()
 
     api = github.GitHub(repo=opts.repo)


### PR DESCRIPTION
This can be helpful if you want to trigger something like '*/networking@*', for example.
