### PR TITLE
images: drop debian-stable

### DIFF
--- a/images/debian-stable
+++ b/images/debian-stable
@@ -1,1 +1,0 @@
-debian-stable-e96bbf15f7fe47168106b95264ecfa71169c398c89cea421e078e1bacb36b542.qcow2

--- a/images/scripts/debian-stable.bootstrap
+++ b/images/scripts/debian-stable.bootstrap
@@ -1,7 +1,0 @@
-#! /bin/sh -ex
-
-RELEASE=bookworm
-RELEASENUM=12
-LATEST_DAILY=$(curl -s https://cloud.debian.org/images/cloud/$RELEASE/daily/ | sed -n '/<a href=/ { s/^.*href="//; s_/".*$__; p }'| sort -nu | tail -n1)
-
-exec $(dirname $0)/lib/cloudimage.bootstrap "$1" "https://cloud.debian.org/images/cloud/$RELEASE/daily/$LATEST_DAILY/debian-${RELEASENUM}-genericcloud-amd64-daily-${LATEST_DAILY}.qcow2"

--- a/images/scripts/debian-stable.setup
+++ b/images/scripts/debian-stable.setup
@@ -1,1 +1,0 @@
-debian.setup


### PR DESCRIPTION
Nothing is running this image anymore, so it's time.

Bye bye, bookworm. 🥲