### PR TITLE
Fix locally configured image stores

### DIFF
--- a/image-download
+++ b/image-download
@@ -46,8 +46,8 @@ from collections.abc import Iterator, Sequence
 from lib import s3
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
-from lib.network import get_curl_ca_arg, redhat_network
-from lib.stores import PRIVATE_STORES, PUBLIC_STORES, REDHAT_STORES
+from lib.network import get_curl_ca_arg
+from lib.stores import LOCAL_STORES, PRIVATE_STORES, PUBLIC_STORES
 from lib.testmap import get_test_image
 
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
@@ -136,10 +136,9 @@ def download(dest: str, force: bool, state: bool, quiet: bool, stores: Sequence[
         # Due to AI scraper-bot mitigation all public stores currently require
         # an access token: if we don't have one, then don't bother.
         stores = [
-            store for store in (*PUBLIC_STORES, *PRIVATE_STORES) if s3.is_key_present(urllib.parse.urlparse(store))
+            store for store in (*LOCAL_STORES, *PUBLIC_STORES, *PRIVATE_STORES)
+            if s3.is_key_present(urllib.parse.urlparse(store))
         ]
-        if redhat_network():
-            stores += REDHAT_STORES
         image_upload_store = os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE')
         if image_upload_store:
             # NB: This is an *addition* to the built-in stores, used for

--- a/image-upload
+++ b/image-upload
@@ -28,8 +28,8 @@ import urllib.parse
 from lib import s3
 from lib.constants import BOTS_DIR, IMAGES_DIR
 from lib.directories import get_images_data_dir
-from lib.network import get_curl_ca_arg, redhat_network
-from lib.stores import PRIVATE_STORES, PUBLIC_STORES, REDHAT_STORES
+from lib.network import get_curl_ca_arg
+from lib.stores import LOCAL_STORES, PRIVATE_STORES, PUBLIC_STORES
 
 
 def upload(store: str, source: str, public: bool, prune: bool = False) -> bool:
@@ -105,14 +105,12 @@ def main() -> None:
                 # adds this to the list, if it's present.
                 stores = [image_upload_store]
         if not stores:
-            stores = list(PRIVATE_STORES)
+            stores = list(LOCAL_STORES) + list(PRIVATE_STORES)
             if public:
                 # NB: We currently have a well-known S3 token which is capable
                 # of accessing all data uploaded to these buckets, regardless
                 # of ACL.  Only upload public images here.
                 stores += PUBLIC_STORES
-            if redhat_network():
-                stores += REDHAT_STORES
         success = False
         for store in stores:
             success |= upload(store, source, public, prune=args.prune_s3)

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -29,21 +29,15 @@ PRIVATE_STORES: Sequence[str] = (
     "https://cockpit-images.eu-central-1.linodeobjects.com/",
 )
 
-# hosted behind the Red Hat VPN
-REDHAT_STORES: Sequence[str] = (
-    # e2e down for maintenance
-    # "https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com/images/",
-)
-
-# local stores
+# locally configured stores in ~/.config/cockpit-dev/image-stores or $COCKPIT_IMAGE_STORES_FILE
 try:
     with open(xdg_config_home('cockpit-dev', 'image-stores', envvar='COCKPIT_IMAGE_STORES_FILE')) as fp:
         data = fp.read().strip()
-        if data:
-            PUBLIC_STORES = (*PUBLIC_STORES, *data.split("\n"))
 except FileNotFoundError:
     # that config file is optional
-    pass
+    data = ""
+
+LOCAL_STORES: Sequence[str] = data.splitlines()
 
 
 LOG_STORE = "https://cockpit-logs.us-east-1.linodeobjects.com/"

--- a/test/test_stores.py
+++ b/test/test_stores.py
@@ -1,0 +1,54 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import importlib
+import os
+import unittest.mock
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("file_content,expected_stores", [
+    # configured stores
+    (
+        """https://example.com/store1/
+https://example.com/store2/
+
+""",
+        ["https://example.com/store1/", "https://example.com/store2/"]
+    ),
+    # empty config file
+    ("", []),
+    # whitespace-only
+    ("   \n   \n   ", []),
+    # absent config file
+    (None, [])
+])
+def test_local_stores(tmp_path: Path, file_content: str | None, expected_stores: list[str]) -> None:
+    """Test LOCAL_STORES with different config file scenarios."""
+    config_file = tmp_path / "image-stores"
+
+    if file_content is not None:
+        config_file.write_text(file_content)
+
+    with unittest.mock.patch.dict(os.environ, {"COCKPIT_IMAGE_STORES_FILE": str(config_file)}):
+        # Reload the module to pick up the new environment variable
+        import lib.stores
+        importlib.reload(lib.stores)
+
+        assert lib.stores.LOCAL_STORES == expected_stores


### PR DESCRIPTION
Commit 53f047eadad71 caused a regression: rhel* images were not uploaded to the locally configured stores any more, i.e. our minio S3 cache on the PSI cluster. That causes a lot of excess Linode S3 traffic (~ 120 GB per image refresh). We want to always upload images to the locally configured stores, let's assume the admin knows what they are doing.

That breakage wasn't obvious, as previously the locally configured stores were just slapped onto `PUBLIC_STORES`. Make this more explicit by putting them into `LOCAL_STORES` instead.

In return, drop `REDHAT_STORES`. It has been empty for a long time, and we don't plan to re-add it any time soon.

Add unit tests for parsing the local store config.

----

See a recent RHEL image refresh in #8159. The [log](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/image-refresh-rhel-10-1-53a7d344-20250825-224249/log.html) shows that it only got uploaded to eu-central:

```
Saving...

+ ./image-upload --prune-s3 rhel-10-1
Uploading to https://cockpit-images.eu-central-1.linodeobjects.com/rhel-10-1-5db567bd173e1bcfa396e4a43df6ef3ff945db5788f141e985e172fe1ed6a16b.qcow2
```

That's the worst possible setup: all 43 bots in PSI have to download that file individually across the pond.

----

Testing image refreshes, see [below for analysis](https://github.com/cockpit-project/bots/pull/8160#issuecomment-3222728851) :heavy_check_mark: 

 * [x] image-refresh cirros
 * [x] image-refresh rhel-9-2