### PR TITLE
naughty: Reinstate #118

### DIFF
--- a/naughty/fedora-43/118-selinux-rpcbind-name_bind
+++ b/naughty/fedora-43/118-selinux-rpcbind-name_bind
@@ -1,0 +1,1 @@
+* type=1400 audit(*): avc:  denied  { name_bind } * comm="rpcbind"

--- a/naughty/fedora-44/118-selinux-rpcbind-name_bind
+++ b/naughty/fedora-44/118-selinux-rpcbind-name_bind
@@ -1,0 +1,1 @@
+* type=1400 audit(*): avc:  denied  { name_bind } * comm="rpcbind"


### PR DESCRIPTION
This came back in Fedora 43 and 44.

Reverts commit 24303e9f453a.

----

We unfortunately don't (yet?) see this in our CI, but it breaks tons of stratis revdeps tests, like in https://github.com/stratis-storage/stratisd/pull/3899 or https://github.com/stratis-storage/stratisd/pull/3898