### PR TITLE
naughty: Add alternative pattern for #6178

### DIFF
--- a/naughty/ubuntu-stable/6178-pmproxy-web-crash-2
+++ b/naughty/ubuntu-stable/6178-pmproxy-web-crash-2
@@ -1,0 +1,3 @@
+TestHistoryMetrics.testPmProxySettings*
+*FAIL: Test completed, but found unexpected journal messages:
+Process * (pmproxy) of terminated abnormally with signal 11/SEGV*


### PR DESCRIPTION
systemd-coredump shows both messages ("dumped core" and "terminated abnormally"). Let's not predict which one happens first, so just add both patterns.

---

Addresses our current top flake, [example](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-22359-640655e3-20250825-105056-ubuntu-stable-other/log.html)

<img width="609" height="182" alt="image" src="https://github.com/user-attachments/assets/b6cab544-2df2-4ff4-ac1c-8e59914dc765" />

Unfortunately this doesn't happen *at all* locally, I tried 50 iterations.