### PR TITLE
Revert "naughty: Close 8059: mdadm fails with "Unable to initialize sysfs" since 6.17.0 rc0"

### DIFF
--- a/naughty/fedora-43/8059-mdraid-init-sysfs
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs
@@ -1,0 +1,7 @@
+> warn: Error starting RAID array: Process reported exit code 1: mdadm: Unable to initialize sysfs
+*
+  File "/source/test/verify/check-storage-mdraid",*
+    b.wait_text(self.card_desc("MDRAID device", "State"), "Running")
+*
+testlib.Error: timeout
+wait_js_cond(ph_text_is("*","Running")): Error: actual text: Not running

--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso
@@ -1,0 +1,1 @@
+File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
@@ -1,0 +1,1 @@
+AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs

--- a/naughty/fedora-44/8059-mdraid-init-sysfs
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs
@@ -1,0 +1,7 @@
+> warn: Error starting RAID array: Process reported exit code 1: mdadm: Unable to initialize sysfs
+*
+  File "/source/test/verify/check-storage-mdraid",*
+    b.wait_text(self.card_desc("MDRAID device", "State"), "Running")
+*
+testlib.Error: timeout
+wait_js_cond(ph_text_is("*","Running")): Error: actual text: Not running

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso
@@ -1,0 +1,1 @@
+File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
@@ -1,0 +1,1 @@
+AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs


### PR DESCRIPTION
This reverts commit 7616a91b2df7813fa6f4e8355efa3de39f9cdefd.

We can only close this once the fix is present also in the Rawhide ISO, which is always a few days later than the package composes.

See https://github.com/cockpit-project/bots/pull/8182