### PR TITLE
image-upload: make images private again

### DIFF
--- a/image-upload
+++ b/image-upload
@@ -113,7 +113,9 @@ def main() -> None:
                 stores += PUBLIC_STORES
         success = False
         for store in stores:
-            success |= upload(store, source, public, prune=args.prune_s3)
+            # Temporarily make all images private, until we figure out if it's
+            # images or logs which cause so much traffic these days (AI scrapers?)
+            success |= upload(store, source, public=False, prune=args.prune_s3)
 
         if not success:
             sys.exit('Failed to upload to any image store')


### PR DESCRIPTION
53f047eadad7 ("stores: designate one of our S3 buckets "private"") has some more brokenness.  It changed this:

```diff
-        # Temporarily make all images private, until we figure out if it's images or logs which cause
-        # so much traffic these days (AI scrapers?)
-        # public = not os.path.basename(source).startswith('rhel')
-        public = False
+        public = not os.path.basename(source).startswith('rhel')
```

without also changing this:

```diff
-            success |= upload(store, source, public, prune=args.prune_s3)
+            success |= upload(store, source, public=False, prune=args.prune_s3)
```

I remember making the first change and thinking "oh, I'll just change that down below" but apparently never got around to it.

On the other hand, our quota doesn't seem to be getting destroyed at the moment, so maybe this is some kind of proof that it was always the CI logs that were the problem, not the images.  Or maybe, since the only public place that the URLs for the images appear is in the CI logs, blocking access to the CI logs has helped images indirectly as well.

In any case, the code is broken, so let's fix it.