### PR TITLE
naughty: Close 8059: mdadm fails with "Unable to initialize sysfs" since 6.17.0 rc0

### DIFF
--- a/images/fedora-rawhide-boot
+++ b/images/fedora-rawhide-boot
@@ -1,1 +1,1 @@
-fedora-rawhide-boot-c184b580cd4d8e7ec49626611bbe19899258af6ad5265eb8fd3dff8d1842352a.iso
+fedora-rawhide-boot-645c9f6dcc72b4bd1a8179b19e41c46abb2d96d36a93c8674a311cb49e8a0781.iso

--- a/naughty/fedora-43/8059-mdraid-init-sysfs
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs
@@ -1,7 +1,0 @@
-> warn: Error starting RAID array: Process reported exit code 1: mdadm: Unable to initialize sysfs
-*
-  File "/source/test/verify/check-storage-mdraid",*
-    b.wait_text(self.card_desc("MDRAID device", "State"), "Running")
-*
-testlib.Error: timeout
-wait_js_cond(ph_text_is("*","Running")): Error: actual text: Not running

--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso
@@ -1,1 +1,0 @@
-File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
@@ -1,1 +1,0 @@
-AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs

--- a/naughty/fedora-44/8059-mdraid-init-sysfs
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs
@@ -1,7 +1,0 @@
-> warn: Error starting RAID array: Process reported exit code 1: mdadm: Unable to initialize sysfs
-*
-  File "/source/test/verify/check-storage-mdraid",*
-    b.wait_text(self.card_desc("MDRAID device", "State"), "Running")
-*
-testlib.Error: timeout
-wait_js_cond(ph_text_is("*","Running")): Error: actual text: Not running

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso
@@ -1,1 +1,0 @@
-File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
@@ -1,1 +1,0 @@
-AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs


### PR DESCRIPTION
Known issue which has not occurred in 26 days

mdadm fails with "Unable to initialize sysfs" since 6.17.0 rc0

Fixes #8059

Closes #8180