### PR TITLE
images: Install systemd-experimental

### DIFF
--- a/images/opensuse-tumbleweed
+++ b/images/opensuse-tumbleweed
@@ -1,1 +1,0 @@
-opensuse-tumbleweed-dc9c38579160cc3fdc38a7bcd79f2f55476661ee344ae27078cc24da86859de8.qcow2

--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -98,6 +98,7 @@ ntfsprogs \
 multipath-tools \
 systemd-coredump \
 kdump \
+systemd-experimental \
 "
 
 NETWORK_PACKAGES="\


### PR DESCRIPTION
/usr/lib/systemd/system-generators/systemd-ssh-generator is required by the testing framework without it the guest never listens to the vsock meaning we can never connect to it. On opensuse it is now provided by the systemd-experimental package.

 - [ ] image-refresh opensuse-tumbleweed