### PR TITLE
images: work around ssh's "UNKNOWN" DNS lookups

### DIFF
--- a/images/scripts/arch.setup
+++ b/images/scripts/arch.setup
@@ -184,6 +184,11 @@ pacman -R --noconfirm cloud-init
 # https://github.com/cockpit-project/bots/issues/3901#issuecomment-1260579703
 systemctl disable systemd-time-wait-sync.service
 
+# https://gitlab.archlinux.org/archlinux/packaging/packages/openssh/-/issues/16
+# https://github.com/openssh/openssh-portable/pull/388
+# https://github.com/openssh/openssh-portable/pull/593
+echo 100::55:4e4b:4e4f:574e UNKNOWN | tee -a /etc/hosts
+
 # Reduce image size, clear package cache (/var/cache/pacman/pkg)
 rm -f /var/cache/pacman/pkg/*
 

--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -171,6 +171,10 @@ echo 'GRUB_CMDLINE_LINUX_DEFAULT=""' >> /etc/default/grub
 echo 'GRUB_CMDLINE_LINUX="no_timer_check net.ifnames=0 console=tty1 console=ttyS0,115200n8"' >> /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
+# https://github.com/openssh/openssh-portable/pull/388
+# https://github.com/openssh/openssh-portable/pull/593
+echo 100::55:4e4b:4e4f:574e UNKNOWN | tee -a /etc/hosts
+
 # reduce image size
 zypper clean
 


### PR DESCRIPTION
Fedora and Debian already carry patches to help mitigate this, but Arch and OpenSUSE are affected: when connecting from vhost, ssh incorrectly tells PAM and libaudit that the remote host is called "UNKNOWN".  Both of those components then attempt to perform lookups on this address and fail.

We can work around that in our images by adding an `/etc/hosts` entry for UNKNOWN to shortcut the lookup.  My first impulse was to use `::` here but `/etc/hosts` is also used for reverse DNS lookups and this might change the meaning of `::` for somebody, so let's use a completely bogus address that would never appear anywhere else.

 - [ ] image-refresh opensuse-tumbleweed
 - [ ] image-refresh arch