### PR TITLE
testmap: don't return forge: repos from projects()

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -341,7 +341,7 @@ def is_valid_context(context: str, repo: str) -> bool:
 
 def projects() -> Iterable[str]:
     """Return all projects for which we run tests."""
-    return REPO_BRANCH_CONTEXT.keys()
+    return (repo for repo in REPO_BRANCH_CONTEXT if ':' not in repo)
 
 
 def get_default_branch(repo: str) -> str:


### PR DESCRIPTION
This function gets called by the webhook which is breaking badly because of these.  Just drop them for now.