### PR TITLE
testmap: move subman-cockpit to the cockpit org

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -223,7 +223,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'fedora-43',
         ],
     },
-    'candlepin/subscription-manager-cockpit': {
+    'cockpit-project/subscription-manager-cockpit': {
         'main': [
             'centos-9-stream/subscription-manager-1.29',
             'centos-10',


### PR DESCRIPTION
This got moved last night.  Update it in the testmap as well.