### PR TITLE
testmap: drop cockpit-composer

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -179,14 +179,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'arch'
         ],
     },
-    'osbuild/cockpit-composer': {
-        'main': [
-            'centos-9-stream',
-            'rhel-9-6',
-        ],
-        '_manual': [
-        ],
-    },
     'candlepin/subscription-manager': {
         'main': [
             'centos-10',


### PR DESCRIPTION
This has a flaky red test since a while, and the repository has been archived since a few weeks.  Time to stop testing this one.