### PR TITLE
test: strictly-type all of our test cases

### DIFF
--- a/lib/aio/jsonutil.py
+++ b/lib/aio/jsonutil.py
@@ -19,9 +19,15 @@ from enum import Enum
 from pathlib import Path
 from typing import ContextManager, TypeVar, Union
 
+# immutable
 JsonLiteral = str | float | bool | None
 JsonValue = Union['JsonObject', Sequence['JsonValue'], JsonLiteral]
 JsonObject = Mapping[str, JsonValue]
+
+# mutable
+JsonDocument = Union['JsonDict', 'JsonList', JsonLiteral]
+JsonDict = dict[str, JsonDocument]
+JsonList = list[JsonDocument]
 
 
 DT = TypeVar('DT')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,6 @@ warn_return_any = false
 module = [
     'task',
 
-    'test_github',
-    'test_issue_scan',
-    'test_task',
-    'test_test_failure_policy',
-    'test_tests_scan',
-
     'cockpit-lib-update',
     'image-refresh',
     'image-trigger',
@@ -74,7 +68,6 @@ select = [
     "RSE",     # flake8-raise
     "RUF",     # ruff rules
     "T10",     # flake8-debugger
-    "TC",      # flake8-type-checking
     "UP032",   # f-string
     "W",       # warnings (mostly whitespace)
     "YTT",     # flake8-2020

--- a/test/test_test_failure_policy.py
+++ b/test/test_test_failure_policy.py
@@ -47,7 +47,7 @@ Journal extracted to TestMultiMachine-testFrameNavigation-fedora-i386-127.0.0.2-
 
 
 class TestPolicy(unittest.TestCase):
-    def testKnownIssue(self):
+    def test_known_issue(self) -> None:
         script = os.path.join(BOTS_DIR, "test-failure-policy")
         cmd = [script, "--offline", "example"]
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
@@ -55,7 +55,7 @@ class TestPolicy(unittest.TestCase):
         self.assertEqual(output, "Known issue #9876\n")
         self.assertEqual(proc.returncode, 77)
 
-    def testAlreadyKnownIssue(self):
+    def test_already_known_issue(self) -> None:
         script = os.path.join(BOTS_DIR, "test-failure-policy")
         cmd = [script, "--offline", "--all", "bogus"]
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
@@ -63,7 +63,7 @@ class TestPolicy(unittest.TestCase):
         self.assertEqual(output, "Known issue #9876 in example\n")
         self.assertEqual(proc.returncode, 78)
 
-    def testRetry(self):
+    def test_retry(self) -> None:
         script = os.path.join(BOTS_DIR, "test-failure-policy")
         cmd = [script, "--offline", "example"]
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
@@ -82,7 +82,7 @@ machine_core.exceptions.Failure: Unable to reach machine fedora-33-127.0.0.2-240
         self.assertEqual(output, "due to failure of test harness or framework\n")
         self.assertEqual(proc.returncode, 1)
 
-    def testNoOp(self):
+    def test_no_op(self) -> None:
         script = os.path.join(BOTS_DIR, "test-failure-policy")
         cmd = [script, "--offline", "example"]
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
@@ -103,7 +103,7 @@ testlib.Error: Condition did not become true.
         self.assertEqual(output, "")
         self.assertEqual(proc.returncode, 0)
 
-    def testLineGlob(self):
+    def test_line_glob(self) -> None:
         script = os.path.join(BOTS_DIR, "test-failure-policy")
         cmd = [script, "--offline", "example"]
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)


### PR DESCRIPTION
...copy over a couple of jsonutil goodies from `cockpit` repo to get the job done.

Also: kill off the flake8-type-checking plugin for ruff.  I don't see a lot of value in TYPE_CHECKING blocks unless they're involved in resolution of cyclic dependencies, and you don't need a linter to find out about those cases...