### PR TITLE
Revert "naughty: Close 8059: mdadm fails with "Unable to initialize sysfs" since 6.17.0 rc0"

### DIFF
--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso
@@ -1,0 +1,1 @@
+File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
@@ -1,0 +1,1 @@
+AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso
@@ -1,0 +1,1 @@
+File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
@@ -1,0 +1,1 @@
+AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs


### PR DESCRIPTION
This partitally reverts commit 21af6a0f5f924d83ab63f10e0b3c94d10a88ff9c.

The `naughty/fedora-X/8059-mdraid-init-sysfs` file was not put back, since the bug is affecting only anaconda tests and this naughty was only relevant to cockpit storage tests.