### PR TITLE
images: opensuse-tumbleweed add quay to unqualified-search-registries

### DIFF
--- a/images/scripts/opensuse-tumbleweed.setup
+++ b/images/scripts/opensuse-tumbleweed.setup
@@ -181,4 +181,8 @@ zypper clean
 # c-podman tests
 /var/lib/testvm/podman-images.setup
 
+# cockpit tests pull quay.io/cockpit/ws which fails because 
+# quay.io is not present in the unqualified-search-registries in /etc/containers/registries.conf 
+sed -i 's/"registry.opensuse.org"/"quay.io", "registry.opensuse.org"/' /etc/containers/registries.conf
+
 /var/lib/testvm/zero-disk.setup


### PR DESCRIPTION
Some cockpit tests pull in quay.io/cockpit/ws. On opensuse-tumbleweed quay.io is not in the normal unqualified-search-registries. This results in the tests failing. To solve this we update /etc/containers/registries.conf to include quay 