### PR TITLE
image-customize: Support -node release tarballs in Debian source packages

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -152,6 +152,13 @@ class BuildAction(ActionBase):
             version=$(dpkg-parsechangelog -SVersion)
             # cut off Debian revision
             ln -s '{vm_source}' ../${{source}}_${{version%-*}}.orig.tar.xz
+            # if there is a -node tarball, include that
+            node_tar="$(dirname {vm_source})/${{source}}-node-${{version%-*}}.tar.xz"
+            if [ -e "$node_tar" ]; then
+                ln -s "$node_tar" ../${{source}}_${{version%-*}}.orig-node.tar.xz
+                mkdir node
+                tar -C node --strip-components=1 -xf "$node_tar"
+            fi
 
             dpkg-buildpackage -S -us -uc -nc""")
 


### PR DESCRIPTION
When there is a project-node-version.tar.xz next to the project-version.tar.xz upstream release tarball [1], include it into the Debian source package as additional tarball. That will enable the Debian package build to build the dist/ bundle from sources.

There's a gotcha here: We want the directory to be `node_modules/`, but additional source tarball names can't have `_` in the name. So we call and unpack it into `node`, and leave it to debian/rules to create a symlink.

[1] our projects do that with `--upload $(NODE_CACHE):/var/tmp/`

-----

I have a cockpit-files branch on top of https://github.com/cockpit-project/cockpit-files/pull/1203 which utilizes that . I am now able to `TEST_OS=debian-trixie make vm` and get dist/ rebuilt with Debian's packaged esbuild (thanks to PR #8355)!