### PR TITLE
image-trigger: refresh rhel-10-1 every 30 days

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -62,7 +62,7 @@ REFRESH = {
     "rhel-9-7": REFRESH_30,
     "rhel-9-8": {},
     "rhel-10-0": REFRESH_30,
-    "rhel-10-1": {},
+    "rhel-10-1": REFRESH_30,
     "rhel-10-2": {},
     "services": REFRESH_30,
 }


### PR DESCRIPTION
We have no test scenario's for rhel-10-1 so we don't need to refresh it every week.