### PR TITLE
testmap: add devel scenario for sub-man-cockpit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -221,6 +221,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'centos-10',
             'rhel-9-8/subscription-manager-1.29',
             'rhel-10-2',
+            'rhel-10-2/devel',
             'fedora-42',
         ],
         '_manual': [


### PR DESCRIPTION
Add fedora-42/devel but also rhel-10-2/devel to test if code coverage runs on RHEL. Sub-man-c has some code that is only used on RHEL so it would be nice to collect test coverage of it.