### PR TITLE
Revert "naughty: Close 8059: mdadm fails with "Unable to initialize sysfs" since 6.17.0 rc0"

### DIFF
--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso
@@ -1,0 +1,1 @@
+File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-43/8059-mdraid-init-sysfs-iso-alternative
@@ -1,0 +1,1 @@
+AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso
@@ -1,0 +1,1 @@
+File "*test/helpers/storage.py", line *, in create_raid_device

--- a/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
+++ b/naughty/fedora-44/8059-mdraid-init-sysfs-iso-alternative
@@ -1,0 +1,1 @@
+AssertionError: Critical error encountered during installation: org.fedoraproject.Anaconda.Error: Process reported exit code 1: mdadm: Unable to initialize sysfs


### PR DESCRIPTION
This reverts commit a537d581bdab2647f3e4e0238a4a6e1400f9818b.

This issue should not have been closed, it still happens, see https://github.com/cockpit-project/bots/pull/8389#issuecomment-3472480158