### PR TITLE
lib: testmap: introduce new DNF scenario

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from lib.constants import TEST_OS_DEFAULT
 
 COCKPIT_SCENARIOS = {'networking', 'storage', 'expensive', 'other'}
-ANACONDA_SCENARIOS = {'efi', 'cockpit', 'storage', 'expensive', 'other'}
+ANACONDA_SCENARIOS = {'efi', 'cockpit', 'dnf', 'storage', 'expensive', 'other'}
 
 
 def contexts(image: str, *scenarios: Iterable[str], repo: str | None = None) -> Sequence[str]:


### PR DESCRIPTION
We need to spawn VMs with different initial KS file for the DNF payload, therefore we need a seperate scenario.