### PR TITLE
naughty: add another instance of the ssh selinux regression

### DIFF
--- a/naughty/fedora-44/8506-selinux-ssh-regression-2
+++ b/naughty/fedora-44/8506-selinux-ssh-regression-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-users", line *, in testBasic
+    self.assertIn(m.execute("passwd -S root").split()[1], ["P", "PS"])
+*
+IndexError: list index out of range


### PR DESCRIPTION
This time disallowing setuid binaries from being run in an non-interactive session.

See https://artifacts.dev.testing-farm.io/3c25eff5-5187-4708-99b9-9cd946c57898/