### PR TITLE
npm: Exclude .claude/ from node_modules/ tarballs

### DIFF
--- a/npm
+++ b/npm
@@ -50,14 +50,14 @@ cmd_download() {
         tee package.json >/dev/null
         npm install --ignore-scripts >&2 & wait -n    # allows the shell to catch SIGINT
         cp package.json node_modules/.package.json
-        tar --directory=node_modules --create .
+        tar --directory=node_modules --exclude=".claude" --create .
     '
 }
 
 cmd_install() {
     rm -rf node_modules
     mkdir node_modules
-    cmd_download < package.json | tar --directory node_modules --exclude '.git*' --extract
+    cmd_download < package.json | tar --directory node_modules --exclude '.git*' --exclude '.claude' --extract
     cp node_modules/.package-lock.json package-lock.json
 }
 


### PR DESCRIPTION
The npm packages es-abstract@1.24.1 and gettext-parser@9.0.0 were (accidentally) published to npmjs.org with .claude/settings.local.json files included. This undesirable and even an attack vector. Ignore them for our node git.

----

See my woes in https://github.com/cockpit-project/cockpit-machines/pull/2469#issuecomment-3701783631