### PR TITLE
testmap: Retire cockpit rhel-9.6 branch

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -65,11 +65,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             # all skipped
             *contexts('rhel-8-10-distropkg', COCKPIT_SCENARIOS - {'networking'}),
         ],
-        'rhel-9.6': [
-            # that branch does not yet have storage tests enabled for bootc
-            *contexts('centos-9-bootc', COCKPIT_SCENARIOS - {'storage'}),
-            *contexts('rhel-9-6', COCKPIT_SCENARIOS),
-        ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [
             'fedora-rawhide',


### PR DESCRIPTION
This isn't active or useful any more, we just had it for translation backporting.