### PR TITLE
store-tests: Avoid Anubis

### DIFF
--- a/store-tests
+++ b/store-tests
@@ -22,6 +22,7 @@ import logging
 import re
 import sqlite3
 import sys
+import urllib.parse
 import urllib.request
 from datetime import datetime
 
@@ -151,7 +152,9 @@ def main():
                 raw_log = url[:-5] if url.endswith(".html") else url
                 logging.debug("scanning log %s", raw_log)
 
-                with urllib.request.urlopen(raw_log,
+                # Set headers to avoid getting blocked by Anubis
+                req = urllib.request.Request(raw_log, headers={'Accept': 'text/plain'})
+                with urllib.request.urlopen(req,
                                             context=host_ssl_context(urllib.parse.urlparse(raw_log).netloc)) as fp:
                     data = fp.readlines()
                     for (testname, failed, retry_reason, seconds) in find_tests(data):


### PR DESCRIPTION
Set `Accept` header so that downloading the log actually works. Otherwise it gets blocked by Anubis.

This fixes our test-results.db and the weather report.

https://issues.redhat.com/browse/COCKPIT-1373

---

Tested with
```
rm -f /tmp/test-results.db; ./store-tests --db /tmp/test-results.db --repo cockpit-project/cockpit b311bb32af7b677fd5b3f9376c20d32a50d03b13 --verbose
sqlite3 /tmp/test-results.db 'select * from Tests'
```

This previously left the `Tests` table empty, now it works again.