### PR TITLE
log.html: Add automatic dark mode

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -96,7 +96,21 @@
             </span>
         </script>
         <script type="text/javascript">
-            addEventListener("click", (event) => { })
+            // Automatic dark mode based on system preference
+            const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+            function applyTheme(e) {
+                const cl = document.documentElement.classList;
+                if (e.matches)
+                    cl.add('pf-v6-theme-dark');
+                else
+                    cl.remove('pf-v6-theme-dark');
+            }
+
+            // Apply theme on page load
+            applyTheme(darkModeMediaQuery);
+            // Listen for changes to the color scheme preference
+            darkModeMediaQuery.addEventListener('change', applyTheme);
         </script>
         <script id="TestEntry" type="text/template" type="x-tmpl-mustache">
             <li class="pf-v6-c-data-list__item test-entry {{#collapsed}}collapsed{{/collapsed}} {{^passed}}failed{{/passed}} {{#retried}}retried{{/retried}} {{#skipped}}skipped{{/skipped}}" id="{{id}}">


### PR DESCRIPTION
Follow the system/browser preference for light/dark mode, and set PatternFly's dark mode class accordingly.

https://www.patternfly.org/developer-resources/dark-theme-handbook/#enabling-dark-theme

----

On http://localhost:8000/log.html it now follows my light/dark desktop switches, and in dark mode looks like this:

<img width="1183" height="620" alt="image" src="https://github.com/user-attachments/assets/a5d2ff03-b301-406f-8018-717791ca2c4a" />

It's not *super* great, but then again that whole log viewer isn't great in light mode either. It at least stops stinging my eyes when I'm working at night :wink: 