### PR TITLE
Dark mode colors

### DIFF
--- a/lib/s3-html/log.html
+++ b/lib/s3-html/log.html
@@ -29,10 +29,10 @@
         /* Filters end */
 
         .test-entry.failed .test-entry-toggle {
-            background-color: var(--pf-t--global--color--nonstatus--red--default);
+            background-color: var(--pf-t--global--icon--color--status--danger--default);
         }
         .test-entry.retried .test-entry-toggle {
-            background-color: var(--pf-t--global--color--nonstatus--orangered--default);
+            background-color: var(--pf-t--global--color--nonstatus--purple--default);
         }
         .test-entry.skipped .test-entry-toggle {
             background-color: var(--pf-t--global--color--nonstatus--orange--default);
@@ -69,6 +69,7 @@ const tap_range = /^([0-9]+)\.\.([0-9]+)$/m;
 const tap_result = /^(ok|not ok) ([0-9]+) (.*)(?: # duration: ([0-9]+s))?(?: # (?:SKIP|TODO) .*)?$/gm;
 const tap_skipped = /^ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # SKIP (.*$)/gm;
 const tap_todo = /^not ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # TODO (.*$)/gm;
+const tap_retry = /^not ok [0-9]+ ([^#].*)(?: #? ?duration: ([^#]*))? # RETRY (.*$)/gm;
 const tap_total_time = /^# (\d+ TESTS FAILED|TESTS PASSED) \[([0-9]+)s on .*\]$/m;
 
 function renderTestEntry(entry) {


### PR DESCRIPTION
The current retry /failure  color does not work well with dark mode as its not a "special PF token blah blah" color.

<img width="865" height="276" alt="image" src="https://github.com/user-attachments/assets/2d702d94-47cb-4354-84be-37a335a2b88c" />

This PR changes the retry color to purple so it matches the label group and is more distinctly different from failures. Plus it switches failures to the same color as the failure label group:

<img width="875" height="529" alt="image" src="https://github.com/user-attachments/assets/d902ecbd-b440-484b-9af8-68113a8bc626" />

As bonus marks "RETRY" to make it even more clear, we can also drop that.