### PR TITLE
images: fix asciidoctor build dependency on tumbleweed

### DIFF
--- a/images/scripts/lib/build-deps.sh
+++ b/images/scripts/lib/build-deps.sh
@@ -48,12 +48,6 @@ case "$OS_VER" in
         ;;
 esac
 
-# TEMP: asciidoctor until we add that to cockpit.spec for OpenSUSE
-# https://github.com/cockpit-project/cockpit/pull/21515
-case "$OS_VER" in
-    *suse*) EXTRA_DEPS="$EXTRA_DEPS ruby3.4-rubygem-asciidoctor" ;;
-esac
-
 # libappstream-glib-devel is needed for merging translations in AppStream XML files in starter-kit and derivatives
 # on RHEL 8 only: gettext in RHEL 8 does not know about .metainfo.xml files, and libappstream-glib-devel
 # provides /usr/share/gettext/its/appdata.{its,loc} for them


### PR DESCRIPTION
Tumbleweed is rolling release so these days its ruby 4.

 * [ ] FAIL: image-refresh opensuse-tumbleweed