### PR TITLE
setup-deploy-keys: Add weblate deploy key for sub-man-cockpit

### DIFF
--- a/setup-deploy-keys
+++ b/setup-deploy-keys
@@ -90,6 +90,10 @@ deploy_to cockpit-project/subscription-manager-cockpit \
         cockpit-project/subscription-manager-cockpit/npm-update/SELF_DEPLOY_KEY \
         cockpit-project/subscription-manager-cockpit/self/DEPLOY_KEY
 
+deploy_to cockpit-project/subscription-manager-cockpit-weblate \
+    --deploy-from \
+        cockpit-project/subscription-manager-cockpit/subscription-manager-cockpit-weblate/DEPLOY_KEY
+
 # shared
 deploy_to cockpit-project/node-cache \
     --deploy-from \


### PR DESCRIPTION
See https://github.com/cockpit-project/subscription-manager-cockpit/pull/185

----

See the [initial failed pot sync workflow](https://github.com/cockpit-project/subscription-manager-cockpit/actions/runs/21280980499/job/61250667258#step:6:11)

I already ran the script, and [the key exists now](https://github.com/cockpit-project/subscription-manager-cockpit-weblate/settings/keys). I [ran a new workflow](https://github.com/cockpit-project/subscription-manager-cockpit/actions/runs/21281196782), it succeeded, and [created a pot update commit](https://github.com/cockpit-project/subscription-manager-cockpit-weblate/commit/4e3c1613e3b156d44ebc5ef29b6fa91469bb1cda). :heavy_check_mark: 