### PR TITLE
testmap: enable Anaconda bootopts-net1 test scenario

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from lib.constants import TEST_OS_DEFAULT
 
 COCKPIT_SCENARIOS = {'networking', 'storage', 'expensive', 'other'}
-ANACONDA_SCENARIOS = {'efi', 'cockpit', 'dnf', 'storage', 'expensive', 'other'}
+ANACONDA_SCENARIOS = {'efi', 'cockpit', 'dnf', 'storage', 'expensive', 'other', 'bootopts-net1'}
 
 
 def contexts(image: str, *scenarios: Iterable[str], repo: str | None = None) -> Sequence[str]:


### PR DESCRIPTION
Related: INSTALLER-4524

Enabling the tests added in https://github.com/rhinstaller/anaconda-webui/pull/1087/commits/883f812b0edd9a31dd8de48e8e05194069372a33