### PR TITLE
image-customize: add option to setup candlepin container

### DIFF
--- a/image-customize
+++ b/image-customize
@@ -267,6 +267,84 @@ class UploadAction(ActionBase):
         machine_instance.upload([abssrc], dest)
 
 
+def setupCandlepin(prepared_vm: testvm.Machine, network: testvm.VirtNetwork) -> None:
+    services_path = testvm.IMAGES_DIR + "/services"
+    services_vm = testvm.VirtMachine(maintain=False,
+                                 verbose=True,
+                                 networking=network.host(),
+                                 image=services_path,
+                                 cpus=2,
+                                 memory_mb=1024)
+
+    services_vm.boot()
+    CANDLEPIN_TAR = "candlepin-img.tar"
+    CANDLEPIN_PATH = "/home/admin/candlepin/" + CANDLEPIN_TAR
+    # download the candlepin container from the services VM
+    services_vm.execute(f"podman image save --output {CANDLEPIN_PATH} ghcr.io/candlepin/candlepin-unofficial:latest")
+    services_vm.download(CANDLEPIN_PATH, CANDLEPIN_TAR)
+    services_vm.download("/root/run-candlepin", "run-candlepin")
+
+    # upload the candlepin container to the image
+    prepared_vm.upload([CANDLEPIN_TAR], "/var/tmp")
+    prepared_vm.upload(["run-candlepin"], "/root/run-candlepin")
+    # create the container and check that it works
+    prepared_vm.execute(f"""
+        podman image load --input /var/tmp/{CANDLEPIN_TAR}
+        podman run -d --name candlepin \
+            -p 8443:8443 \
+            -p 8080:8080 \
+            ghcr.io/candlepin/candlepin-unofficial:latest
+        sleep 5
+        until curl --insecure --fail --head https://localhost:8443/candlepin/status; do sleep 5; done
+        curl --insecure --fail --head http://localhost:8080/RPM-GPG-KEY-candlepin
+    """)
+
+    # NOTE: Is this still needed?
+    # download product info from candlepin
+    def download_product(product):
+        filename = f"{product["id"]}.pem"
+        prepared_vm.execute(f"""
+            podman cp candlepin:/home/candlepin/generated_certs/{filename} /etc/pki/product-default/{filename}
+        """)
+
+    PRODUCT_DONALDY = {
+        "id": "7050",
+        "name": "Donaldy OS Premium Architecture Bits"
+    }
+
+    PRODUCT_SHARED = {
+        "id": "88888",
+        "name": "Shared File System Bits (no content)"
+    }
+    prepared_vm.execute(["mkdir", "-p", "/etc/pki/product-default"])
+    download_product(PRODUCT_DONALDY)
+    download_product(PRODUCT_SHARED)
+
+    # copy the ceritificate from candlepin container to the image and add it to the trust store
+    prepared_vm.execute(f"""
+        podman cp candlepin:/etc/candlepin/certs/candlepin-ca.crt /etc/rhsm/ca/candlepin-ca.pem
+        ln -s /etc/rhsm/ca/candlepin-ca.pem /etc/pki/ca-trust/source/anchors/candlepin-ca.pem
+        update-ca-trust
+        chown root:root /etc/rhsm/ca/candlepin-ca.pem
+        restorecon -v /etc/rhsm/ca/candlepin-ca.pem
+    """)
+
+    CANDLEPIN_ADDR = "127.0.0.1"
+    CANDLEPIN_HOSTNAME = "candlepin.local"
+    CANDLEPIN_URL = f"https://{CANDLEPIN_HOSTNAME}:8443/candlepin"
+    prepared_vm.write("/etc/hosts", f"{CANDLEPIN_ADDR} {CANDLEPIN_HOSTNAME}\n", append=True)
+    prepared_vm.execute(f"until curl --fail --silent --show-error {CANDLEPIN_URL}/status; do sleep 1; done")
+
+    # Setup the repositories properly using the Candlepin RPM GPG key
+    prepared_vm.execute(f"""
+        curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin http://{CANDLEPIN_HOSTNAME}:8080/RPM-GPG-KEY-candlepin
+        restorecon -R /etc/pki/rpm-gpg/
+        subscription-manager config --rhsm.baseurl http://{CANDLEPIN_HOSTNAME}:8080
+    """)
+
+    services_vm.stop()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=('Run command inside or install packages into a Cockpit virtual machine. '
@@ -301,6 +379,7 @@ def main() -> None:
                         help='Disable tests during package build with --build')
     parser.add_argument('image', help='The image to use (destination name when using --base-image)')
     parser.add_argument('--sit', action='store_true', help='Sit and wait if any VM action fails')
+    parser.add_argument('--setup-candlepin', action='store_true', help='Setup candlepin container for testing')
     args = parser.parse_args()
 
     if not args.actions and not args.resize:
@@ -328,6 +407,13 @@ def main() -> None:
                                  cpus=args.cpus,
                                  memory_mb=args.memory_mb)
     machine.boot()
+
+    # TODO: i.e. the idea was that make vm would download the services image (or the container directly),
+    # and do the podman save | podman load dance to copy it into the prepared image, so that everything remians predictable
+    if args.setup_candlepin:
+        subprocess.check_call([os.path.join(BOTS_DIR, "image-download"), "services"])
+        setupCandlepin(machine, network)
+
     try:
         for (handler, arg) in args.actions:
             handler(machine, arg)


### PR DESCRIPTION
During `make vm` copy the candlepin container from the services image in order to make tests running on subscription-manager-cockpit not rely on services VM and make them non-destructive so they can run on TF/gating.