### PR TITLE
testmap: add explicit wscontainer relationship dependency

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -243,6 +243,13 @@ OSTREE_BUILD_IMAGE = {
     "fedora-coreos": "fedora-43",
 }
 
+# ws-container scenarios build RPMs for the cockpit/ws container on a different
+# image than the one being tested.  This must match the base OS version used in
+# the cockpit/ws container present in the given image.
+WSCONTAINER_BUILD_IMAGE = {
+    "rhel-8-10": "fedora-42",
+}
+
 # only put auxiliary images here; triggers for primary OS images are computed from testmap
 IMAGE_REFRESH_TRIGGERS = {
     "services": [
@@ -272,6 +279,10 @@ IMAGE_REFRESH_TRIGGERS = {
 # in fedora-X
 def get_build_image(image: str) -> str:
     return OSTREE_BUILD_IMAGE.get(image, image)
+
+
+def get_build_image_for_ws_container_inside_of(image: str) -> str | None:
+    return WSCONTAINER_BUILD_IMAGE.get(image)
 
 
 # some tests have suffixes that run the same image in different modes; map a
@@ -384,6 +395,11 @@ def tests_for_image(image: str) -> Sequence[str]:
         if image == i:
             tests.update(_direct_tests_for_image(a))
             break
+
+    # is this a build image for ws-container? then add those scenario tests
+    for test_image, build_image in WSCONTAINER_BUILD_IMAGE.items():
+        if image == build_image:
+            tests.update(_direct_tests_for_image(test_image, 'ws-container*'))
 
     return list(tests)
 

--- a/test/test_testmap.py
+++ b/test/test_testmap.py
@@ -100,3 +100,12 @@ def test_tests_for_image_ostree() -> None:
         ostree_tests = [t for t in build_image_tests if t.startswith(f"{ostree_image}/")]
         assert ostree_tests, \
             f"{build_image} refresh should trigger {ostree_image} tests"
+
+
+def test_tests_for_image_wscontainer() -> None:
+    # refreshing a ws-container build image should trigger the ws-container scenarios
+    for test_image, build_image in testmap.WSCONTAINER_BUILD_IMAGE.items():
+        build_image_tests = testmap.tests_for_image(build_image)
+        ws_container_tests = [t for t in build_image_tests if f"{test_image}/ws-container" in t]
+        assert ws_container_tests, \
+            f"{build_image} refresh should trigger {test_image}/ws-container scenarios"


### PR DESCRIPTION
A recent update of the `fedora-43` container changed the contained `quay.io/cockpit/ws` container inside of it from being based on `fedora-42` to `fedora-43`.  Since we build the container for the `rhel-8-10/ws-container@cockpit-project/cockpit` scenarios on top of it, this changed the version of Fedora (and Python) that those scenarios run on.  We don't gate `fedora-43` updates on the `rhel-8-10/ws-container` scenarios, though, so we never caught this problem as we introduced the new image.

We're going to switch to only building the RPMs on the builder image and then copying them into the container image that's already cached in the `rhel-8-10` image.  That's Fedora 42 at the moment.

Let's start by making that relationship explicit in the bots so that we can test it.  We will follow this up with a commit in the cockpit repository that makes use of the new API we add here.

The idea in the future that we'll bump this when we build a rhel-8-10 image which contains a `cockpit/ws` container based on a new Fedora image.