### PR TITLE
machine: handle kickstart_file_name in VirtMachine

### DIFF
--- a/machine/machine_core/machine_virtual.py
+++ b/machine/machine_core/machine_virtual.py
@@ -308,6 +308,9 @@ class VirtMachine(Machine):
         if "disk_dev" in kwargs:
             self.disk_dev = str(kwargs.pop("disk_dev"))
 
+        # Optional; VirtMachine subclass (anaconda-webui) may receive a basename for test/kickstarts/
+        self.kickstart_file_name: str | None = kwargs.pop("kickstart_file_name", None)
+
         # Allocate network information about this machine
         self.networking = networking
         kwargs["address"] = networking["control"]


### PR DESCRIPTION
kickstart_file_name is only for VirtInstallMachine (Class used by anaconda WebUI tests) for spawning VMs with specified KS file.