### PR TITLE
issue-comment: fix dedent problem

### DIFF
--- a/issue-comment
+++ b/issue-comment
@@ -7,7 +7,6 @@ import asyncio
 import json
 import logging
 import sys
-import textwrap
 import time
 from collections.abc import Sequence
 from typing import Literal, assert_never, cast
@@ -91,18 +90,18 @@ async def process_comment(
                 await forge.post(
                     f'repos/{repo}/issues/{issue_nr}/comments',
                     {
-                        'body': textwrap.dedent(f"""\
-                            **Task scheduled:** issue-{issue_nr} {job['context']}
+                        'body': f"""\
+**Task scheduled:** issue-{issue_nr} {job['context']}
 
-                            Testing Farm link: {artifacts_url}
+Testing Farm link: {artifacts_url}
 
-                            <details>
-                            <summary>Job JSON</summary>
+<details>
+<summary>Job JSON</summary>
 
-                            ```json
-                            {json.dumps(job, indent=2)}
-                            ```
-                            </details>""")
+```json
+{json.dumps(job, indent=2)}
+```
+</details>"""
                     },
                 )
 


### PR DESCRIPTION
Adding the JSON of the job into the text like we do, with indents (which adds newlines), prevents .dedent() from doing its job.  Let's just shove to the entire paragraph to the left, regardless of how ugly it is.