### PR TITLE
README: include debian-testing dropped packages tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ control, when this occurs:
 2. Update `OSTREE_BUILD_IMAGE` to point to the Fedora release CoreOS
    uses.
 
+#### Debian Testing
+
+Sometimes packages are dropped out of the Debian testing repositories, when
+this happens apply a temporary hack to fetch the package from `unstable` using
+this 954f12fae1d2854e14c543e333338482a012c50d as example.
+
 ####  Pixel tests
 
 The pixel tests used in Cockpit projects use `test/reference-image` to


### PR DESCRIPTION
This happened a few times with PCP and target-cli.