### PR TITLE
Change image-trigger to use `/image-refresh` comment

### DIFF
--- a/.github/workflows/image-trigger.yml
+++ b/.github/workflows/image-trigger.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   maintenance:
     runs-on: ubuntu-latest
+    environment: image-build
+    permissions: {}
     steps:
       - name: Set up secrets
-        run: echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+        run: echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
         uses: actions/checkout@v5

--- a/image-trigger
+++ b/image-trigger
@@ -86,22 +86,23 @@ def main() -> int:
     return 0
 
 
-# Check if the given files that match @pathspec are stale
-# and haven't been updated in @days.
-def stale(days: int, pathspec: str, ref: str = "HEAD", verbose: bool = False) -> bool:
-    cmd = ["git", "log", "--max-count=1", "--pretty=format:%ct", ref, "--", pathspec]
+def last_update(pathspec: str, ref: str = "HEAD", verbose: bool = False) -> tuple[str, int] | None:
+    """Return (commit_sha, age_in_days) of the last commit touching pathspec, or None."""
+    cmd = ["git", "log", "--max-count=1", "--pretty=format:%ct %H", ref, "--", pathspec]
     if verbose:
         sys.stderr.write("+ " + shlex.join(cmd) + "\n")
     output = subprocess.check_output(cmd, cwd=BASE_DIR, text=True)
     if verbose:
         sys.stderr.write("> " + output + "\n")
 
+    parts = output.split(maxsplit=1)
     try:
-        timestamp = int(output)
-    except ValueError:
-        timestamp = 0
+        timestamp = int(parts[0])
+    except (ValueError, IndexError):
+        return None
+    sha = parts[1].strip() if len(parts) > 1 else ""
 
-    return timestamp < time.time() - days * 86400
+    return sha, int((time.time() - timestamp) / 86400)
 
 
 def scan(api: github.GitHub, force: str | None, verbose: bool, dry: bool = False) -> None:
@@ -114,28 +115,35 @@ def scan(api: github.GitHub, force: str | None, verbose: bool, dry: bool = False
     }
 
     for (image, options) in REFRESH.items():
-        if force:
-            perform = image == force
-        else:
-            days = options.get("refresh-days", DAYS)
-            perform = stale(days, os.path.join("images", image), "origin/main", verbose)
+        update = last_update(os.path.join("images", image), "origin/main", verbose)
 
-        if perform:
-            item = f"image-refresh {image}"
-            if item in issues:
-                sys.stderr.write(f'#{issues[item]["number"]}: {item} (already open)\n')
+        if force:
+            if image != force:
                 continue
 
-            text = f"Image refresh for {image}"
-            checklist = github.Checklist(text)
-            checklist.add(item)
-            data = {"title": text, "body": checklist.body, "labels": ["bot"]}
-            if dry:
-                print(f'** Would open issue on {api.repo}', json.dumps(data, indent=4))
-            else:
-                issue = typechecked(api.post("issues", data), dict)
-                issues[item] = issue
-                sys.stderr.write(f'#{issue["number"]}: {item}\n')
+        if update is not None:
+            sha, age = update
+            if not force and age < options.get("refresh-days", DAYS):
+                continue
+            body = f"Last updated in {sha}, {age} days ago.\n"
+        else:
+            body = "No previous image refresh found.\n"
+
+        item = f"image-refresh {image}"
+        if item in issues:
+            sys.stderr.write(f'#{issues[item]["number"]}: {item} (already open)\n')
+            continue
+
+        text = f"Image refresh for {image}"
+        checklist = github.Checklist(text)
+        checklist.add(item)
+        data = {"title": text, "body": f"{body}\n{checklist.body}", "labels": ["bot"]}
+        if dry:
+            print(f'** Would open issue on {api.repo}', json.dumps(data, indent=4))
+        else:
+            issue = typechecked(api.post("issues", data), dict)
+            issues[item] = issue
+            sys.stderr.write(f'#{issue["number"]}: {item}\n')
 
 
 if __name__ == '__main__':

--- a/image-trigger
+++ b/image-trigger
@@ -20,7 +20,6 @@
 import argparse
 import json
 import os
-import random
 import shlex
 import subprocess
 import sys
@@ -102,11 +101,7 @@ def stale(days: int, pathspec: str, ref: str = "HEAD", verbose: bool = False) ->
     except ValueError:
         timestamp = 0
 
-    # We randomize when we think this should happen over a day
-    offset = days * 86400
-    due = time.time() - random.randint(offset - 43200, offset + 43200)
-
-    return timestamp < due
+    return timestamp < time.time() - days * 86400
 
 
 def scan(api: github.GitHub, force: str | None, verbose: bool, dry: bool = False) -> None:

--- a/image-trigger
+++ b/image-trigger
@@ -26,7 +26,7 @@ import sys
 import time
 
 from lib import github
-from lib.aio.jsonutil import get_str, typechecked
+from lib.aio.jsonutil import get_int, get_str, typechecked
 from lib.constants import BASE_DIR
 
 # default for refresh-days
@@ -109,9 +109,8 @@ def scan(api: github.GitHub, force: str | None, verbose: bool, dry: bool = False
     subprocess.check_call(["git", "fetch", "origin", "main"])
 
     issues = {
-        item: issue
+        get_str(issue, "title"): get_int(issue, "number")
         for issue in api.issues(state="open")
-        for item in github.Checklist(get_str(issue, "body", None)).items
     }
 
     for (image, options) in REFRESH.items():
@@ -129,21 +128,19 @@ def scan(api: github.GitHub, force: str | None, verbose: bool, dry: bool = False
         else:
             body = "No previous image refresh found.\n"
 
-        item = f"image-refresh {image}"
-        if item in issues:
-            sys.stderr.write(f'#{issues[item]["number"]}: {item} (already open)\n')
+        title = f"Image refresh for {image}"
+        if title in issues:
+            sys.stderr.write(f'#{issues[title]}: {title} (already open)\n')
             continue
 
-        text = f"Image refresh for {image}"
-        checklist = github.Checklist(text)
-        checklist.add(item)
-        data = {"title": text, "body": f"{body}\n{checklist.body}", "labels": ["bot"]}
+        data = {"title": title, "body": body, "labels": ["bot"]}
         if dry:
             print(f'** Would open issue on {api.repo}', json.dumps(data, indent=4))
         else:
             issue = typechecked(api.post("issues", data), dict)
-            issues[item] = issue
-            sys.stderr.write(f'#{issue["number"]}: {item}\n')
+            number = get_int(issue, "number")
+            api.post(f"issues/{number}/comments", {"body": f"/image-refresh {image}"})
+            sys.stderr.write(f'#{number}: image-refresh {image}\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
...plus a bit of cleanup and a little quality of life enhancement.

This is designed to make the (*edit*)~~last~~second last commit as small as reasonably possible so we can revert it if things don't work out.  I triggered https://github.com/cockpit-project/bots/issues/8908 as a test but I don't want to do a full workflow dispatch from the branch until we're pretty sure we want to land this because otherwise the same issues will get recreated when the old workflow runs tonight and fails to find any checklist items.