### PR TITLE
testmap: stop testing RHEL images in starter-kit

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -87,8 +87,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             'centos-10',
             'fedora-rawhide',
             'opensuse-tumbleweed',
-            'rhel-9-8',
-            'rhel-10-2',
         ],
         '_manual': [
             'centos-9-bootc',


### PR DESCRIPTION
Historically we added this to verify that the image works and starter-kit is the easiest test for it. But lately `npm install` has been hanging an awful lot and been unreliable in our CI. As RHEL images are also tested in cockpit-files which is a fast, and simple project we already have a good alternative to starter-kit.

---

See also https://github.com/cockpit-project/starter-kit/issues/1394