### PR TITLE
Image refresh for centos-9-bootc

### DIFF
--- a/images/centos-9-bootc
+++ b/images/centos-9-bootc
@@ -1,1 +1,1 @@
-centos-9-bootc-0cf69050e675cd6bf2bdc50abdb3af3307c40478c7ae17d0d3a5105bca37fbd4.qcow2
+centos-9-bootc-7dfcfae82fd7744f78c16e61cccd96d78cdf70502dcb53a63c7fb07f61de504e.qcow2


### PR DESCRIPTION
Last updated in eb6a2988c4e6b147b88e342277a4a880851ef702, 7 days ago.
 * [x] image-refresh centos-9-bootc