### PR TITLE
naughty: Add pattern for #8929 on fedora-rawhide

### DIFF
--- a/naughty/fedora-43/8929-libblkid-breaks-stratis
+++ b/naughty/fedora-43/8929-libblkid-breaks-stratis
@@ -1,0 +1,1 @@
+*Rollback failed; causal_error: Command failed: cmd: "/usr/sbin/mkfs.xfs" "-f" "/dev/dm-*" "-m" "*" "-i" "nrext64=0", exit reason: 1 stdout:  stderr: illegal sector size 0


### PR DESCRIPTION
This happens only in TF so far.
