### PR TITLE
naughty: Update ntfs and lvresize patterns for arch and debian-testing

### DIFF
--- a/naughty/arch/5090-lvm2-resize-ntfs-unexpected-error
+++ b/naughty/arch/5090-lvm2-resize-ntfs-unexpected-error
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "*", line *, in testResizeNtfs
-    self.checkResize("ntfs", crypto=False,
-*
-testlib.Error: timeout

--- a/naughty/arch/5090-lvresize-fails-with-stratis-signature
+++ b/naughty/arch/5090-lvresize-fails-with-stratis-signature
@@ -1,3 +1,0 @@
-> warn*: Error resizing logical volume: Process reported exit code 5:   File system device usage is not available from libblkid.
-*
-  File "check-storage-stratis", line *, in testPoolResize

--- a/naughty/arch/8982-cant-mount-resized-ntfs
+++ b/naughty/arch/8982-cant-mount-resized-ntfs
@@ -1,0 +1,4 @@
+> warn: mount: /var/lib/cockpittest/mnt/foo: wrong fs type, bad option, bad superblock on /dev/mapper/TEST-vol, missing codepage or helper program, or other error.
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#dialog")): Error: condition did not become true

--- a/naughty/debian-testing/8982-cant-mount-resized-ntfs
+++ b/naughty/debian-testing/8982-cant-mount-resized-ntfs
@@ -1,0 +1,4 @@
+> warn: mount: /var/lib/cockpittest/mnt/foo: wrong fs type, bad option, bad superblock on /dev/mapper/TEST-vol, missing codepage or helper program, or other error.
+*
+testlib.Error: timeout
+wait_js_cond(!ph_is_present("#dialog")): Error: condition did not become true


### PR DESCRIPTION
The known issue #5090 no longer happens on arch: NTFS resizing works and we don't test Stratis anymore.  (#5090 still happens on rhel-9-9.)

The old pattern for #5090 has now started triggering for a new issue tracked by #8982 that has appeared with util-linux 2.42 in arch and debian-testing.

Let's make a precise pattern for that.