### PR TITLE
testingfarm: Request 80GB disk space for bootc images

### DIFF
--- a/lib/aio/testingfarm.py
+++ b/lib/aio/testingfarm.py
@@ -151,6 +151,7 @@ class TestingFarmClient(contextlib.AsyncExitStack):
                         'JOB_RUNNER_CONFIG_JSON': config_json,
                     },
                     'hardware': {
+                        'disk.size': '>= 80 GB',
                         'virtualization': {
                             'is-virtualized': True,
                             'is-supported': True,


### PR DESCRIPTION
Building CentOS-9-bootc in testing farm "No space left on device", reserving a machine with virtualisation gives a 40GB instance while the bootc image is already 24GB. 80GB should be enough for now.