### PR TITLE
Revert "testingfarm: Request 80GB disk space for bootc images"

### DIFF
--- a/lib/aio/testingfarm.py
+++ b/lib/aio/testingfarm.py
@@ -151,7 +151,6 @@ class TestingFarmClient(contextlib.AsyncExitStack):
                         'JOB_RUNNER_CONFIG_JSON': config_json,
                     },
                     'hardware': {
-                        'disk.size': '>= 80 GB',
                         'virtualization': {
                             'is-virtualized': True,
                             'is-supported': True,


### PR DESCRIPTION
This reverts commit 7f8acfbcbb41c0f4e2810b64dfd80d054d4da2e5.

Fails currently with:

⚠ Guest creation failed, HTTP 400: {'detail': {'message': 'Environment failed validation', 'errors': ["{'disk.size': '>= 80 GB', 'virtualization': {'is-supported': True, 'is-virtualized': True}} is not valid under any of the given schemas"]}}