### PR TITLE
distributed_queue: Create durable AMQP queues

### DIFF
--- a/lib/distributed_queue.py
+++ b/lib/distributed_queue.py
@@ -113,7 +113,10 @@ class DistributedQueue:
 
         for queue in queues:
             try:
-                result = self.channel.queue_declare(queue=queue, arguments=arguments.get(queue, None), **kwargs)
+                result = self.channel.queue_declare(queue=queue,
+                                                    durable=True,
+                                                    arguments=arguments.get(queue, None),
+                                                    **kwargs)
                 assert result.method.message_count is not None
                 self.queue_counts[queue] = result.method.message_count
             except pika.exceptions.ChannelClosedByBroker as e:


### PR DESCRIPTION
RabbitMQ deprecated non-durable (transient) non-exclusive queues in 2021 [1], and in 4.3.0 they finally stop working [2].

Declare our queues durable to work with current RabbitMQ again [3]. This makes little practical difference -- they will still go away with every webhook pod restart, as they are not on a persistent volume. That is what we want, as the pod does a cold GitHub scan on startup.

[1] https://www.rabbitmq.com/release-information/deprecated-features-list
[2] https://www.rabbitmq.com/docs/queues#durability
[3] https://github.com/cockpit-project/cockpituous/commit/c9fa373c5240b

----

Tested locally with reverting https://github.com/cockpit-project/cockpituous/commit/c9fa373c5240b and `COCKPIT_BOTS_BRANCH=durable-amqp pytest` in cockpituous. After this lands, we can revert the tag pin, see https://github.com/cockpit-project/cockpituous/pull/696
