### PR TITLE
workflows: Fix AWS S3 log ACL

### DIFF
--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -34,6 +34,7 @@ jobs:
           [logs.s3]
           url = 'https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/'
           key = '${{ secrets.AWS_KEY_LOGS }}'
+          acl = '' # BucketOwnerEnforced - bucket policy handles public access, ACLs disabled
 
           [forge.github]
           post = true


### PR DESCRIPTION
Our AWS logs bucket has `BucketOwnerEnforced`. Disable the explicit ACL setting.

---

Should fix [this failure](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/image-refresh-cirros-ca01c497-20260512-073521/log.html) from #9017