### PR TITLE
testmap: Enable remaining cockpit scenarios

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -47,8 +47,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
             *contexts('debian-testing', COCKPIT_SCENARIOS),
             *contexts('debian-trixie', COCKPIT_SCENARIOS),
             *contexts('ubuntu-2404', COCKPIT_SCENARIOS),
-            # FIXME: some remaining failures
-            *contexts('ubuntu-2604', COCKPIT_SCENARIOS - {'other', 'expensive'}),
+            *contexts('ubuntu-2604', COCKPIT_SCENARIOS),
             *contexts('ubuntu-stable', COCKPIT_SCENARIOS),
             *contexts('fedora-43', COCKPIT_SCENARIOS),
             *contexts('fedora-44', COCKPIT_SCENARIOS),

--- a/naughty/ubuntu-2604/6178-pmproxy-web-crash
+++ b/naughty/ubuntu-2604/6178-pmproxy-web-crash
@@ -1,0 +1,3 @@
+TestHistoryMetrics.testPmProxySettings*
+*FAIL: Test completed, but found unexpected journal messages:
+Process * (pmproxy) of user 997 dumped core.

--- a/naughty/ubuntu-2604/6178-pmproxy-web-crash-2
+++ b/naughty/ubuntu-2604/6178-pmproxy-web-crash-2
@@ -1,0 +1,3 @@
+TestHistoryMetrics.testPmProxySettings*
+*FAIL: Test completed, but found unexpected journal messages:
+Process * (pmproxy) of user 997 terminated abnormally with signal


### PR DESCRIPTION
They got fixed in https://github.com/cockpit-project/cockpit/pull/23260

---

Plus copying the naughty for #6178 as that [still affects 26.04](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-23260-b25d156e-20260513-074239-ubuntu-2604-other/log.html)