### PR TITLE
testmap: swap anaconda efi scenario with bios

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from lib.constants import TEST_OS_DEFAULT
 
 COCKPIT_SCENARIOS = {'networking', 'storage', 'expensive', 'other'}
-ANACONDA_SCENARIOS = {'efi', 'cockpit', 'dnf', 'storage', 'expensive', 'other', 'bootopts-net1'}
+ANACONDA_SCENARIOS = {'bios', 'cockpit', 'dnf', 'storage', 'expensive', 'other', 'bootopts-net1'}
 
 
 def contexts(image: str, *scenarios: Iterable[str], repo: str | None = None) -> Sequence[str]:


### PR DESCRIPTION
Now all anaconda tests run by default under efi firmware, and we need an extra bios scenario which will run only for some of the tests.