### PR TITLE
naughty: Add CentOS 9 Stream Kernel bitmap issue

### DIFF
--- a/naughty/rhel-9/9051-mdadm-bitmap-api-change
+++ b/naughty/rhel-9/9051-mdadm-bitmap-api-change
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-storage-mdraid", line *, in testBitmap
+    b.wait_in_text('.pf-v6-c-alert', 'This MDRAID device has no write-intent bitmap')
+*
+testlib.Error: timeout


### PR DESCRIPTION
Related: #9051

Only spotted in Testing Farm as our [centos-9-stream refresh](https://github.com/cockpit-project/bots/pull/8975) is hold back.