### PR TITLE
image-download-rhel: new image-download replacement

### DIFF
--- a/image-download
+++ b/image-download
@@ -1,305 +1,251 @@
 #!/usr/bin/env python3
 
-# This file is part of Cockpit.
-#
-# Copyright (C) 2013 Red Hat, Inc.
-#
-# Cockpit is free software; you can redistribute it and/or modify it
-# under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation; either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# Cockpit is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+"""Download images from S3 stores.
 
-#
-# Download images or other state
-#
-# Images usually have a name specific link committed to git. These
-# are referred to as 'committed'
-#
-# Other state is simply referenced by name without a link in git
-# This is referred to as 'state'
-#
-# The stores are places to look for images or other state
-#
+Probes configured stores via HEAD, picks the fastest, and downloads with
+resume support, progress reporting, and SHA256 verification.
+
+For RHEL images on the AWS cockpit-ci-images bucket, authenticates via
+Kerberos → SAML → STS (requires kinit and the gssapi package).
+"""
 
 import argparse
 import contextlib
-import email
-import fcntl
+import hashlib
 import io
+import logging
 import os
-import shutil
-import stat
-import subprocess
+import re
 import sys
 import time
+import urllib.error
 import urllib.parse
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
+from pathlib import Path
 
-from lib import s3
+from lib import gssapi_saml_sts, s3
+from lib.ansi import BLUE, GREEN, RED, RESET
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
-from lib.network import get_curl_ca_arg
+from lib.locking import file_locked
+from lib.progressbar import ProgressBar
+from lib.s3 import S3Key
 from lib.stores import IMAGE_STORES, LOCAL_STORES
-from lib.testmap import get_test_image
 
-EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
-
-if os.isatty(1):
-    SYMBOLS = {'present': ' ✔', 'absent': ' ⨯', 'selected': '❯❯'}  # noqa: RUF001
-else:
-    SYMBOLS = {'present': ' >', 'absent': ' x', 'selected': '=>'}
+logger = logging.getLogger(__name__)
 
 
-def show_status(quiet: bool, status: str, *args: str, prefix: str = '') -> None:
-    if not quiet:
-        message = ' '.join(args)
-        sys.stderr.write(f'{prefix}{SYMBOLS[status]} {message}\n')
+def resolve_key(url: urllib.parse.ParseResult, use_cache: bool = True) -> S3Key | None:
+    """Determine the S3 key for a store URL, or None for unauthenticated access."""
+    return s3.get_key(url) or gssapi_saml_sts.try_key(url.geturl(), use_cache=use_cache)
 
 
-def curl_cmd(args: Sequence[str]) -> Sequence[str]:
-    return ['curl', '--connect-timeout', '10', '--fail', *args]
-
-
-def check_curl_args(args: Sequence[str]) -> tuple[str, float] | None:
-    head_args = ['--silent', '--head']  # only used for this check
-
-    try:
-        start = time.time()
-        output = subprocess.check_output(curl_cmd((*args, *head_args)), text=True)
-        duration = time.time() - start
-        return output, duration
-    except subprocess.CalledProcessError:
-        return None
-
-
-def find(name: str, stores: Sequence[str], latest: float, quiet: bool) -> tuple[list[str], str] | None:
-    found = []
+def find_store(
+    name: str, stores: Sequence[str], use_cache: bool = True, quiet: bool = False,
+) -> tuple[urllib.parse.ParseResult, S3Key | None, int] | None:
+    """HEAD-probe stores to find the image.  Returns (url, key, total) or None."""
+    best: tuple[urllib.parse.ParseResult, S3Key | None, int] | None = None
+    best_elapsed = float('inf')
 
     for store in stores:
         url = urllib.parse.urlparse(urllib.parse.urljoin(store, name))
 
-        args = get_curl_ca_arg(url.netloc)
-
-        key = s3.get_key(url)
-        result = check_curl_args((*args, *s3.sign_curl(url, method='HEAD', key=key)))
-        if result:
-            show_status(quiet, 'present', store, '(authenticated)' if key else '')
-            found.append(([*args, *s3.sign_curl(url, key=key)], result, store))  # GET
-            continue
-
-        show_status(quiet, 'absent', store)
-
-    # If we couldn't find the file, but it exists, we're good
-    if not found:
-        return None
-
-    # Find the most recent version of this file
-    def header_date(args: tuple[Sequence[str], tuple[str, float], str]) -> str | float:
-        _, (output, _duration), _message = args
         try:
-            _reply_line, headers_alone = output.split('\n', 1)
-            last_modified = email.message_from_file(io.StringIO(headers_alone)).get("Last-Modified", "")
-            return time.mktime(time.strptime(last_modified, '%a, %d %b %Y %H:%M:%S %Z'))
-        except ValueError:
-            return ""
+            key = resolve_key(url, use_cache=use_cache)
+            auth = '' if key is None else ' 🎫' if key[2] else ' 🔑'  # key[2] is session_token
+            start = time.monotonic()
+            with s3.urlopen(url, method='HEAD', key=key) as response:
+                total = int(response.headers['Content-Length'])
+            elapsed = time.monotonic() - start
+            logger.debug('HEAD %r: %r bytes, %.3fs', store, total, elapsed)
+            symbol = f'{GREEN}✔{RESET}'
+            detail = f' {elapsed * 1000:.0f}ms'
+            if elapsed < best_elapsed:
+                best = (url, key, total)
+                best_elapsed = elapsed
+        except (urllib.error.URLError, OSError, gssapi_saml_sts.AuthError) as exc:
+            logger.debug('HEAD %r failed: %s', store, exc)
+            symbol = f'{RED}✗{RESET}'
+            auth = ''
+            detail = f' {exc}'
 
-    if latest:
-        # if we depend on getting the latest info, only download it from that one store
-        found.sort(reverse=True, key=header_date)
-    else:
-        found.sort(reverse=False, key=lambda x: x[1][1])
+        if not quiet:
+            sys.stderr.write(f'  {symbol} {store}{auth}{detail}\n')
 
-    return found[0][0], found[0][2]
-
-
-def download(dest: str, force: bool, state: bool, quiet: bool, stores: Sequence[str]) -> None:
-    name = os.path.basename(dest)
-
-    if not stores:
-        stores = [*LOCAL_STORES, *IMAGE_STORES]
-        image_upload_store = os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE')
-        if image_upload_store:
-            # NB: This is an *addition* to the built-in stores, used for
-            # testing.  Compare with image-upload which *only* uploads to this
-            # store, if it's present.
-            stores += [image_upload_store]
-
-    # The time condition for If-Modified-Since
-    exists = not force and os.path.exists(dest)
-    if exists:
-        since = dest
-    else:
-        since = EPOCH
-
-    result = find(name, stores, latest=state, quiet=quiet)
-
-    # If we couldn't find the file, but it exists, we're good
-    if result is None:
-        if exists:
-            return
-        raise RuntimeError(f"image-download: couldn't find file anywhere: {name}")
-
-    args, message = result
-    show_status(quiet, 'selected', urllib.parse.urljoin(message, name))
-
-    temp = dest + ".partial"
-
-    # Adjust the arguments above that worked to make it visible and download real stuff
-    args.append("--show-error")
-    if not quiet and os.isatty(sys.stdout.fileno()):
-        args.append("--progress-bar")
-    else:
-        args.append("--silent")
-    args.append("--remote-time")
-    args.append("--time-cond")
-    args.append(since)
-    args.append("--output")
-    args.append(temp)
-    if os.path.exists(temp):
-        if force:
-            os.remove(temp)
-        else:
-            args.append("-C")
-            args.append("-")
-
-    # Always create the destination file (because --state)
-    else:
-        open(temp, 'a').close()
-
-    curl = subprocess.Popen(curl_cmd(args))
-    ret = curl.wait()
-    if ret != 0:
-        raise RuntimeError(f"curl: unable to download {message} (returned: {ret})")
-
-    os.chmod(temp, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-
-    # Due to time-cond the file size may be zero
-    # A new file downloaded, put it in place
-    if not exists or os.path.getsize(temp) > 0:
-        shutil.move(temp, dest)
+    if not quiet and best is not None:
+        sys.stderr.write(f'\n  Using: {BLUE}{best[0].geturl()}{RESET}\n\n')
+    return best
 
 
-# Calculate a place to put images where links are not committed in git
-def state_target(path: str) -> str:
-    data_dir = get_images_data_dir()
-    os.makedirs(data_dir, mode=0o775, exist_ok=True)
-    return os.path.join(data_dir, path)
+# --- Download ---
 
 
-# Calculate a place to put images where links are committed in git
-def committed_target(image: str) -> str:
-    link = os.path.join(IMAGES_DIR, image)
-    if not os.path.islink(link):
-        raise RuntimeError("image link does not exist: " + image)
+def download_to(
+    url: urllib.parse.ParseResult, key: S3Key | None, total: int, fp: io.BufferedRandom,
+) -> str:
+    """Download an image into an open file, returning the sha256 hex digest."""
+    sha = hashlib.sha256()
+    offset = 0
 
-    dest = os.readlink(link)
-    relative_dir = os.path.dirname(os.path.abspath(link))
-    full_dest = os.path.join(relative_dir, dest)
-    while os.path.islink(full_dest):
-        link = full_dest
-        dest = os.readlink(link)
-        relative_dir = os.path.dirname(os.path.abspath(link))
-        full_dest = os.path.join(relative_dir, dest)
+    with ProgressBar(total) as progress:
+        # Hash existing partial data for resume
+        progress.status = 'hashing partial file content'
+        while block := os.pread(fp.fileno(), 256 * 1024, offset):
+            sha.update(block)
+            offset += len(block)
+            progress.update(len(block))
+        logger.debug('partial file: hashed %r existing bytes', offset)
 
-    dest = os.path.join(get_images_data_dir(), dest)
+        progress.track_rate()
+        if offset < total:
+            request_headers = {'Range': f'bytes={offset}-{total - 1}'}
+            with s3.urlopen(url, headers=request_headers, key=key) as response:
+                while True:
+                    chunk = response.read(256 * 1024)
+                    if not chunk:
+                        break
+                    written = 0
+                    while written < len(chunk):
+                        written += os.pwrite(fp.fileno(), chunk[written:], offset + written)
+                    offset += len(chunk)
+                    sha.update(chunk)
+                    progress.update(len(chunk))
 
-    # We have the file but there is not valid link
-    if os.path.exists(dest):
-        try:
-            os.symlink(dest, os.path.join(IMAGES_DIR, os.readlink(link)))
-        except FileExistsError:
-            # can happen in unclean trees and deleting the image in the cache dir directly
-            pass
+    if offset != total:
+        raise RuntimeError(f'short read: got {offset} bytes, expected {total}')
 
-    # The image file in the images directory, may be same as dest
-    image_file = os.path.join(IMAGES_DIR, os.readlink(link))
-
-    # Double check that symlink in place
-    if os.path.abspath(dest) != os.path.abspath(image_file):
-        try:
-            os.symlink(os.path.abspath(dest), image_file)
-        except FileExistsError:
-            # .. but never make a cycle
-            pass
-
-    return dest
+    return sha.hexdigest()
 
 
-@contextlib.contextmanager
-def wait_lock(target: str) -> Iterator[None]:
-    lockfile = os.path.join(os.path.dirname(target), ".lock." + os.path.basename(target))
+def download(
+    name: str, dest: Path, sha256: str,
+    stores: Sequence[str],
+    use_cache: bool = True, quiet: bool = False,
+) -> bool:
+    """Find an image across stores and download it.  Returns True on success."""
+    temp = dest.with_suffix(dest.suffix + '.partial')
 
-    # we need to keep the lock fd open throughout the entire runtime, so remember it in a global-scoped variable
-    with open(lockfile, "w") as file:
-        for retry in range(360):
+    with file_locked(dest):
+        if dest.exists():
+            logger.debug('%r already downloaded', dest)
+            return True
+
+        sys.stderr.write(f'\nDownloading {GREEN}{name}{RESET}\n\n')
+
+        result = find_store(name, stores, use_cache=use_cache, quiet=quiet)
+        if result is None:
+            sys.stderr.write(f"{RED}couldn't find {name} in any store{RESET}\n")
+            return False
+        url, key, total = result
+
+        with open(os.open(temp, os.O_CREAT | os.O_RDWR, 0o666), 'r+b') as fp:
+            orig_stat = os.fstat(fp.fileno())
             try:
-                fcntl.flock(file, fcntl.LOCK_NB | fcntl.LOCK_EX)
-                break
-            except BlockingIOError:
-                if retry == 0:
-                    print("Waiting for concurrent image-download of %s..." % os.path.basename(target))
-                time.sleep(10)
-        else:
-            raise TimeoutError("timed out waiting for concurrent downloads of %s\n" % target)
+                actual_hash = download_to(url, key, total, fp)
+            except (urllib.error.HTTPError, OSError) as exc:
+                if os.fstat(fp.fileno()).st_size == 0:
+                    temp.unlink(missing_ok=True)
+                sys.stderr.write(f'{RED}{exc}{RESET}\n')
+                return False
 
-        yield
+        if actual_hash != sha256:
+            temp.unlink()
+            sys.stderr.write(f'{RED}sha256 mismatch: expected {sha256}, got {actual_hash}{RESET}\n')
+            return False
+        sys.stderr.write(f'  🔒 sha256 verified [{actual_hash}]\n')
+        logger.debug('sha256 verified: %r', actual_hash)
 
-        # clean up lock file
-        try:
-            os.unlink(lockfile)
-        except FileNotFoundError:
-            # parallel runs may remove it already
-            pass
+        temp.chmod(orig_stat.st_mode & 0o444)
+        temp.rename(dest)
+        logger.debug('downloaded %r to %r', name, dest)
+        sys.stderr.write('\n')
+
+    return True
 
 
-def download_images(image_list: Sequence[str], force: bool, quiet: bool, state: bool, stores: Sequence[str]) -> None:
-    data_dir = get_images_data_dir()
-    os.makedirs(data_dir, exist_ok=True)
+def committed_target(image: str) -> tuple[Path, str] | None:
+    """Resolve an image name to its versioned destination path in the data dir.
 
-    # A default set of images are all links in git.  These links have
-    # no directory part.  Other links might exist, such as the
-    # auxiliary links created by committed_target above, and we ignore
-    # them.
-    if not image_list:
-        image_list = []
-        if not state:
-            for filename in os.listdir(IMAGES_DIR):
-                link = os.path.join(IMAGES_DIR, filename)
-                if os.path.islink(link) and os.path.dirname(os.readlink(link)) == "":
-                    image_list.append(filename)
+    If image is a short name (e.g. 'rhel-10'), reads the symlink in
+    IMAGES_DIR to get the versioned filename.  If it's already versioned
+    (e.g. 'rhel-10-abc123.qcow2'), uses it directly.
 
-    for image in image_list:
-        image = get_test_image(image)
-        if state:
-            target = state_target(image)
-        else:
-            target = committed_target(image)
+    Ensures the symlink images/versioned-name → /cache/.../versioned-name exists.
+    Returns (dest, expected_sha256) or None.
+    """
+    link = Path(IMAGES_DIR) / image
+    try:
+        target_name = os.readlink(link)
+    except OSError:
+        # not a symlink — assume it's already a versioned filename
+        target_name = image
 
-        # don't download the same thing multiple times in parallel
-        with wait_lock(target):
-            if force or state or not os.path.exists(target):
-                download(target, force, state, quiet, stores)
+    dest = Path(get_images_data_dir()) / target_name
+
+    # Ensure images/rhel-10-abc123.qcow2 → /cache/.../rhel-10-abc123.qcow2
+    image_file = Path(IMAGES_DIR) / target_name
+    if not image_file.is_symlink():
+        with contextlib.suppress(FileExistsError):
+            image_file.symlink_to(dest)
+
+    match = re.search(r'-([0-9a-f]{64})\.', target_name)
+    if not match:
+        sys.stderr.write(f'\n{RED}no sha256 hash in image name: {target_name}{RESET}\n')
+        return None
+    return dest, match.group(1)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description='Download a bot state or images')
-    parser.add_argument("--force", action="store_true", help="Force unnecessary downloads")
-    parser.add_argument("--store", action="append", help="Where to find state or images")
-    parser.add_argument("--quiet", action="store_true", help="Make downloading quieter")
-    parser.add_argument("--state", action="store_true", help="Images or state not recorded in git")
-    parser.add_argument('image', nargs='*')
+    parser = argparse.ArgumentParser(description='Download images from S3 stores')
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug logging')
+    parser.add_argument('-q', '--quiet', action='store_true', help='Quieter output')
+    parser.add_argument('--no-cache', action='store_true', help='Ignore cached credentials')
+    parser.add_argument('--store', action='append', help='Store URL to search')
+    parser.add_argument('image', nargs='*', help='Image name(s) to download (default: all)')
     args = parser.parse_args()
 
-    download_images(args.image, args.force, args.quiet, args.state, args.store)
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format='%(name)s: %(message)s',
+    )
+
+    data_dir = Path(get_images_data_dir())
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    images = args.image
+    if not images:
+        # Default: all symlinks in IMAGES_DIR with no directory component
+        images = [
+            entry.name for entry in Path(IMAGES_DIR).iterdir()
+            if entry.is_symlink() and '/' not in os.readlink(entry)
+        ]
+
+    stores = args.store
+    if not stores:
+        stores = [*LOCAL_STORES, *IMAGE_STORES]
+        if upload_store := os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE'):
+            # NB: This is an *addition* to the built-in stores, used for
+            # testing.  Compare with image-upload which *only* uploads to this
+            # store, if it's present.
+            stores.append(upload_store)
+
+    failures = 0
+    for image in images:
+        image = image.replace('-distropkg', '')
+        result = committed_target(image)
+        if result is None:
+            failures += 1
+            continue
+        dest, sha256 = result
+        if not download(dest.name, dest, sha256, stores=stores,
+                        use_cache=not args.no_cache, quiet=args.quiet):
+            failures += 1
+
+    sys.exit(f'\n{RED}Some downloads failed.{RESET}' if failures else None)
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit('Aborted by user')

--- a/lib/ansi.py
+++ b/lib/ansi.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+import sys
+
+IS_TTY = os.isatty(sys.stderr.fileno())
+USE_COLOR = 'FORCE_COLOR' in os.environ or (IS_TTY and 'NO_COLOR' not in os.environ)
+
+RED = '\033[31m' if USE_COLOR else ''
+GREEN = '\033[32m' if USE_COLOR else ''
+BLUE = '\033[34m' if USE_COLOR else ''
+RESET = '\033[0m' if USE_COLOR else ''
+CLEAR_LINE = '\033[2K\r' if IS_TTY else ''

--- a/lib/gssapi_saml_sts.py
+++ b/lib/gssapi_saml_sts.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Kerberos → SAML → STS authentication for AWS.
+
+Authenticates via SPNEGO/Negotiate to an IdP, exchanges the SAML assertion
+for temporary AWS credentials via STS AssumeRoleWithSAML, and caches
+credentials to disk.
+"""
+
+import base64
+import dataclasses
+import fnmatch
+import html.parser
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from lib.directories import xdg_cache_home
+from lib.s3 import S3Key
+
+logger = logging.getLogger(__name__)
+
+
+# https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html
+_STS_URL = 'https://sts.amazonaws.com/'
+_STS_VERSION = '2011-06-15'
+_STS_NS = f'https://sts.amazonaws.com/doc/{_STS_VERSION}/'
+
+
+class AuthError(Exception):
+    """Raised when Kerberos/SAML/STS authentication fails."""
+
+
+def _negotiate_header(idp_url: str) -> str:
+    """Create a Negotiate auth header using Kerberos."""
+    try:
+        import gssapi
+        import gssapi.raw.misc
+    except ImportError as exc:
+        raise AuthError('🐍 no python3-gssapi') from exc
+
+    hostname = urllib.parse.urlparse(idp_url).hostname
+    assert hostname is not None
+    # fixed in python-gssapi 1.9.0: https://github.com/pythongssapi/python-gssapi/pull/338
+    server_name = gssapi.Name(f'HTTP@{hostname}', gssapi.NameType.hostbased_service)  # type: ignore[attr-defined]
+    try:
+        # fixed in python-gssapi 1.9.0: https://github.com/pythongssapi/python-gssapi/pull/338
+        ctx = gssapi.SecurityContext(usage='initiate', name=server_name)  # type: ignore[attr-defined]
+        token = base64.b64encode(ctx.step()).decode()
+    except gssapi.raw.misc.GSSError as exc:
+        statuses = '  '.join(exc.get_all_statuses(exc.min_code, is_maj=False))
+        raise AuthError(f'🐕 {statuses}.  Try kinit.') from exc
+    logger.debug('obtained SPNEGO token for %r', hostname)
+    return f'Negotiate {token}'
+
+
+def _get_saml_assertion(idp_url: str) -> str:
+    """Authenticate via Kerberos and return the base64 SAML assertion."""
+    logger.debug('requesting SAML assertion from %r', idp_url)
+
+    request = urllib.request.Request(idp_url)
+    request.add_header('Authorization', _negotiate_header(idp_url))
+    response = urllib.request.urlopen(request)
+    body = response.read().decode()
+    logger.debug('IdP response status: %r', response.status)
+    logger.debug('IdP response: %d bytes', len(body))
+
+    result: list[str] = []
+
+    class Parser(html.parser.HTMLParser):
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            # <input name="SAMLResponse" value="(capture this)">
+            if tag == 'input' and ('name', 'SAMLResponse') in attrs:
+                result.extend(v for k, v in attrs if v and k == 'value')
+
+    Parser().feed(body)
+    if len(result) != 1:
+        logger.debug('response body: %r', body[:500])
+        raise AuthError('🤔 Failed to find SAMLResponse in IdP response')
+
+    return result[0]
+
+
+def aws_sts_assume_role(role_arn: str, provider_arn: str, saml_assertion: str) -> str:
+    """Exchange a SAML assertion for temporary AWS credentials via STS.
+
+    Returns the raw XML response body.
+    """
+    logger.debug('assuming role %r via STS', role_arn)
+
+    params = urllib.parse.urlencode({
+        'Action': 'AssumeRoleWithSAML',
+        'Version': _STS_VERSION,
+        'RoleArn': role_arn,
+        'PrincipalArn': provider_arn,
+        'SAMLAssertion': saml_assertion,
+    }).encode()
+
+    request = urllib.request.Request(_STS_URL, data=params, method='POST')
+    request.add_header('Content-Type', 'application/x-www-form-urlencoded')
+
+    try:
+        response = urllib.request.urlopen(request)
+    except urllib.error.HTTPError as exc:
+        try:
+            tree = ET.parse(exc)
+            message = tree.findtext(f'.//{{{_STS_NS}}}Message', '') or tree.findtext(
+                './/Message', ''
+            )
+        except ET.ParseError:
+            message = ''
+        raise AuthError(
+            f'🐕 STS AssumeRoleWithSAML failed: {message or exc}\n'
+            'Are you in the correct Rover group for cockpit-ci-images access?'
+        ) from exc
+
+    with response:
+        return response.read().decode()
+
+
+def _parse_sts_response(xml: str) -> tuple[S3Key, datetime]:
+    """Parse an STS AssumeRoleWithSAML XML response.
+
+    Returns (S3Key, expiration).  Raises AuthError if the XML is malformed
+    or missing fields.
+    """
+    try:
+        tree = ET.fromstring(xml)
+
+        def text(tag: str) -> str:
+            if val := tree.findtext(f'.//{{{_STS_NS}}}Credentials/{{{_STS_NS}}}{tag}'):
+                return val
+            raise AuthError(f'🤔 STS XML response missing {tag}')
+
+        expiration = datetime.fromisoformat(text('Expiration'))
+        key = (text('AccessKeyId'), text('SecretAccessKey'), text('SessionToken'))
+        return key, expiration
+
+    except (ET.ParseError, ValueError, TypeError) as exc:
+        raise AuthError('🤔 failed to parse STS response') from exc
+
+
+def cache_path(role_name: str) -> Path:
+    """Return the cache file path for STS credentials."""
+    return Path(xdg_cache_home('cockpit-dev', 'sts-credentials', f'{role_name}.xml'))
+
+
+def save_to_cache(role_name: str, xml: str) -> tuple[S3Key, datetime]:
+    """Parse, validate, and cache STS credentials.  Returns (key, expiration)."""
+    key, expiration = _parse_sts_response(xml)
+    path = cache_path(role_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600), 'w') as fp:
+        fp.write(xml)
+    logger.debug('cached STS credentials to %r (expires %s)', path, expiration)
+    return key, expiration
+
+
+def load_from_cache(role_name: str) -> S3Key | None:
+    """Load cached STS credentials if they exist and aren't expiring within 5 minutes."""
+    try:
+        key, expiration = _parse_sts_response(cache_path(role_name).read_text())
+    except (FileNotFoundError, AuthError) as exc:
+        logger.debug('cached credentials unusable: %r', exc)
+        return None
+    if expiration - datetime.now(timezone.utc) < timedelta(minutes=5):
+        logger.debug('cached credentials expiring soon (%s)', expiration)
+        return None
+    return key
+
+
+@dataclasses.dataclass
+class SAMLTarget:
+    idp_url: str
+    provider_arn: str
+    role_arn: str
+
+
+# Red Hat employee IdP (SAML via Kerberos) → AWS IAM role for cockpit-ci-images
+# Rover group: https://rover.redhat.com/groups/group/it-cloud-aws-727920394381-cockpit-ci-images-download
+TARGETS = {
+    'https://cockpit-ci-images*.s3.*.amazonaws.com/rhel-*': SAMLTarget(
+        idp_url='https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/saml/clients/itaws',
+        provider_arn='arn:aws:iam::727920394381:saml-provider/RedHatInternal',
+        role_arn='arn:aws:iam::727920394381:role/727920394381-cockpit-ci-images-download',
+    ),
+}
+
+
+def _find_target(url: str) -> SAMLTarget | None:
+    for pattern, target in TARGETS.items():
+        if fnmatch.fnmatch(url, pattern):
+            return target
+    return None
+
+
+def try_key(url: str, use_cache: bool = True) -> S3Key | None:
+    """Return STS credentials if the URL matches a known SAML-authenticated resource."""
+    target = _find_target(url)
+    if target is None:
+        return None
+
+    role_name = target.role_arn.rsplit('/', 1)[-1]
+
+    if use_cache:
+        if key := load_from_cache(role_name):
+            return key
+
+    saml = _get_saml_assertion(target.idp_url)
+    xml = aws_sts_assume_role(target.role_arn, target.provider_arn, saml)
+
+    key, _expiration = save_to_cache(role_name, xml)
+    return key

--- a/lib/locking.py
+++ b/lib/locking.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import contextlib
+import fcntl
+import logging
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def file_locked(path: Path) -> Iterator[None]:
+    """Acquire an exclusive lockfile for the given path, with check-recheck for unlink safety."""
+    lockpath = path.with_suffix(path.suffix + '.lock')
+    waited = False
+    for _attempt in range(10):
+        with open(lockpath, 'w') as lockfile:
+            try:
+                fcntl.flock(lockfile, fcntl.LOCK_NB | fcntl.LOCK_EX)
+            except BlockingIOError:
+                if not waited:
+                    sys.stderr.write(f'Waiting for concurrent download of {path.name}...\n')
+                    waited = True
+                fcntl.flock(lockfile, fcntl.LOCK_EX)
+            # Verify we locked the file that's actually on disk, not a ghost inode
+            try:
+                if not Path(f'/proc/self/fd/{lockfile.fileno()}').samefile(lockpath):
+                    continue
+            except FileNotFoundError:
+                logger.debug('lockfile %r was deleted under us, retrying', lockpath)
+                continue
+            logger.debug('acquired lock on %r', lockpath)
+            try:
+                yield
+            finally:
+                lockpath.unlink(missing_ok=True)
+                logger.debug('released lock on %r', lockpath)
+            break
+    else:
+        raise RuntimeError(f'unable to acquire lock on {lockpath}')

--- a/lib/progressbar.py
+++ b/lib/progressbar.py
@@ -1,0 +1,137 @@
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import collections
+import colorsys
+import os
+import sys
+import threading
+import time
+from typing import Self
+
+from lib.ansi import CLEAR_LINE, IS_TTY, RESET, USE_COLOR
+
+
+def _format_size(size: float) -> str:
+    for unit in ('B', 'kB', 'MB', 'GB'):
+        if size < 1000:
+            return f'{size:.1f} {unit}'
+        size /= 1000
+    return f'{size:.1f} TB'
+
+
+class RateTracker:
+    """Tracks download rate using a sliding window of recent samples."""
+
+    def __init__(self, start_time: float, start_offset: int) -> None:
+        self.start_time = start_time
+        self.start_offset = start_offset
+        self.window: collections.deque[tuple[float, int]] = collections.deque(maxlen=100)
+
+    @staticmethod
+    def _format_rate(bytes_per_sec: float) -> str:
+        return f'{_format_size(bytes_per_sec)}/s'
+
+    @staticmethod
+    def _format_duration(seconds: float) -> str:
+        if seconds < 60:
+            return f'{int(seconds)}s'
+        if seconds < 3600:
+            return f'{int(seconds // 60)}m{int(seconds % 60):02d}s'
+        return f'{int(seconds // 3600)}h{int(seconds % 3600 // 60):02d}m'
+
+    def sample(self, now: float, offset: int) -> None:
+        self.window.append((now, offset))
+
+    def format_progress(self, now: float, offset: int, total: int) -> list[str]:
+        progress = f'{_format_size(offset)}/{_format_size(total)}'
+        try:
+            oldest_time, oldest_bytes = self.window[0]
+            rate = (offset - oldest_bytes) / (now - oldest_time)
+            return [progress, self._format_rate(rate), f'ETA {self._format_duration((total - offset) / rate)}']
+        except (IndexError, ZeroDivisionError):
+            return [progress, 'ETA 🤷']
+
+    def format_final(self, now: float, offset: int, total: int) -> list[str]:
+        elapsed = now - self.start_time
+        downloaded = offset - self.start_offset
+        rate = downloaded / elapsed if elapsed > 0 else 0
+        parts = [_format_size(downloaded)]
+        if self.start_offset:
+            parts.append(f'(of {_format_size(total)})')
+        parts.extend([f'in {self._format_duration(elapsed)}', f'({self._format_rate(rate)})'])
+        return parts
+
+
+class ProgressBar(threading.Thread):
+    def __init__(self, total: int) -> None:
+        super().__init__()
+        self.total = total
+        self.offset = 0
+        self.status: RateTracker | str | None = None
+        self._done = threading.Event()
+
+    def track_rate(self) -> None:
+        self.status = RateTracker(start_time=time.monotonic(), start_offset=self.offset)
+
+    def update(self, n: int) -> None:
+        self.offset += n
+
+    @staticmethod
+    def _bar_color(i: int, width: int) -> str:
+        ryb = i / max(1, width - 1) * 300  # from 0° (red) to 300° (purple) RYB hue
+
+        # This color space conversion brought to you by Chromatic!
+        # https://lis.codeberg.page/chromatic/
+        rgb_hue = ryb / 2 if ryb < 120 else (ryb - 120) * 1.5 + 60 if ryb < 240 else ryb
+
+        r, g, b = colorsys.hsv_to_rgb(rgb_hue / 360, 0.4, 1.0)
+        return f'\033[38;2;{r * 255:.0f};{g * 255:.0f};{b * 255:.0f}m'
+
+    def _render(self, final: bool = False) -> None:
+        if not self.total:
+            return
+
+        parts: list[str] = [f'{self.offset * 100 // self.total:3d}%']
+        now = time.monotonic()
+
+        match self.status:
+            case RateTracker() as rt if final:
+                parts.extend(rt.format_final(now, self.offset, self.total))
+            case RateTracker() as rt:
+                rt.sample(now, self.offset)
+                parts.extend(rt.format_progress(now, self.offset, self.total))
+            case str(message):
+                progress = f'{_format_size(self.offset)}/{_format_size(self.total)}'
+                parts.extend([progress, f'[{message}]'])
+            case None:
+                pass
+
+        try:
+            width = max(0, os.get_terminal_size(sys.stderr.fileno()).columns - 60)
+        except OSError:
+            width = 0  # not a tty?  no progress bar!
+
+        bar = ('█' * (self.offset * width // self.total)).ljust(width, '░')
+        if USE_COLOR:
+            bar = ''.join(self._bar_color(i, width) + g for i, g in enumerate(bar))
+
+        sys.stderr.write(f'{CLEAR_LINE}  {bar}{RESET} {" ".join(parts)}')
+        if final:
+            sys.stderr.write('\n')
+        sys.stderr.flush()
+
+    def run(self) -> None:
+        while not self._done.wait(0.1):
+            self._render()
+
+    def __enter__(self) -> Self:
+        if IS_TTY:
+            self.start()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self._done.set()
+        if self.is_alive():
+            self.join()
+        self._render(final=True)

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -144,7 +144,7 @@ def urlopen(
             headers = sign_request(url, method, headers, hashlib.sha256(data).hexdigest(), key=key)
         request = urllib.request.Request(url.geturl(), headers=dict(headers), method=method, data=data)
         try:
-            result = urllib.request.urlopen(request, context=host_ssl_context(url.netloc))
+            result = urllib.request.urlopen(request, context=host_ssl_context(url.netloc), timeout=10)
             return result
         except urllib.error.HTTPError as exc:
             logger.debug('%s %s %s attempt #%i → %s:', method, url.geturl(), headers, retries, exc.status)

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -230,6 +230,8 @@ merged_failures {merged_failures}
     print(output)
     if opts.s3:
         key = s3.get_key(opts.s3)
+        if key is None:
+            sys.exit(f'no key is available for {opts.s3.hostname}')
         headers = {"Content-Type": "text/plain"}
         # AWS S3 buckets with BucketOwnerEnforced don't allow ACLs; bucket policy provides public access
         if not opts.s3.hostname.endswith('.amazonaws.com'):

--- a/saml-login
+++ b/saml-login
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Log in to AWS via SAML using a web browser.
+
+Opens a WebKitGTK window to the IdP, intercepts the SAML assertion,
+exchanges it for temporary AWS credentials via STS, and caches them to disk
+for use by image-download.
+"""
+
+import argparse
+import logging
+import sys
+
+import gi  # type: ignore [import-untyped]
+
+from lib.ansi import GREEN, RESET
+from lib.gssapi_saml_sts import (
+    TARGETS,
+    AuthError,
+    aws_sts_assume_role,
+    cache_path,
+    save_to_cache,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Log in to AWS via SAML using a web browser')
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug logging')
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG, format='%(name)s: %(message)s')
+
+    gi.require_version('Gtk', '4.0')
+    gi.require_version('JavaScriptCore', '6.0')
+    gi.require_version('WebKit', '6.0')
+
+    from gi.repository import GLib, Gtk, JavaScriptCore, WebKit  # type: ignore [import-untyped]
+
+    target, = TARGETS.values()  # only one for now
+    loop = GLib.MainLoop()
+
+    def on_saml_message_received(_manager: WebKit.UserContentManager, message: JavaScriptCore.Value) -> None:
+        saml_assertion = message.to_string()
+        logger.debug('captured SAML assertion (%d bytes)', len(saml_assertion))
+        xml = aws_sts_assume_role(target.role_arn, target.provider_arn, saml_assertion)
+
+        role_name = target.role_arn.rsplit('/', 1)[-1]
+        try:
+            _key, expiration = save_to_cache(role_name, xml)
+        except AuthError as exc:
+            sys.exit(str(exc))
+
+        local = expiration.astimezone()
+        print(f'\n{GREEN}STS credentials saved to {cache_path(role_name)}\nValid until {local:%c}{RESET}\n')
+        loop.quit()
+
+    content_manager = WebKit.UserContentManager()
+
+    # Monkey-patch the page to post the SAML assertion back to us
+    content_manager.register_script_message_handler('saml')
+    content_manager.connect('script-message-received::saml', on_saml_message_received)
+    content_manager.add_script(
+        WebKit.UserScript(
+            r'''
+                // Keycloak's has a 2s setTimeout before following a link
+                // to the SAML POST binding page.  Redirect immediately.
+                const finish = document.getElementById('finishLoginLink');
+                if (finish) {
+                    location.href = finish.href;
+                }
+
+                // Capture the response from the POST binding and don't redirect.
+                const input = document.querySelector('input[name="SAMLResponse"]');
+                if (input) {
+                    window.webkit.messageHandlers.saml.postMessage(input.value);
+                    input.form.action = '';
+                }
+            ''',
+            WebKit.UserContentInjectedFrames.TOP_FRAME,
+            WebKit.UserScriptInjectionTime.END,
+        )
+    )
+
+    webview = WebKit.WebView(user_content_manager=content_manager)
+    webview.load_uri(target.idp_url)
+
+    win = Gtk.Window(
+        title='SAML Login',
+        default_width=1024,
+        default_height=768,
+        child=webview,
+    )
+    win.connect('close-request', lambda _win: loop.quit())
+    win.present()
+
+    loop.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is capable of downloading RHEL images from AWS.

We identify URLs that should be STS-authenticated by using a list (currently 1) of fnmatches on URLs.  This list is only consulted if you don't have a normal static key in ~/.config/cockpit-dev/s3-keys/.

Once we've identified that we want to issue a transient key, the process goes like this:

  - you get a Kerberos ticket with kinit

  - we use gssapi to get a SPNEGO token for auth.redhat.com

  - we post a login attempt using the token and hopefully get back a SAML POST binding HTML page which we can extract the SAML assertion from

  - with the SAML assertion in hand we can use AWS STS to generate a transient token for a particular IAM Role.  If you're in the it-cloud-aws-727920394381-cockpit-ci-images-download rover group this will allow you to download RHEL images from AWS

  - we use the STS token to do the S3 signing operation

This should be more or less transparent to anyone who is in the correct group and logged in with kerberos.  There's no need for us to maintain a list of users and tokens anymore and human developers can delete their old s3-keys.

The new downloader is intended as an eventual replacement for image-download.  It's a rewrite from the ground up and has a couple of other niceties:

  - urllib instead of curl (which was getting complicated with all the extra headers)

  - checksum verification based on filename

  - improved locking vs. the old downloader: no more poll loop or subtle race conditions with deleted lockfiles

  - 🌈 rainbows!

Some features not implemented:

  - `--state` and modification times (which seems to be dead code)
  - `--force`

With S3 keys for EU Linode mirror (light mode):

<img width="1914" height="948" alt="image" src="https://github.com/user-attachments/assets/9398571b-73f3-4ec4-b9fe-2ffd537f5be5" />

Without any statically-configured S3 keys (dark mode):

<img width="1914" height="948" alt="image" src="https://github.com/user-attachments/assets/d2eb8a9c-26dd-44e8-92b2-335723abf4a3" />


 - [x] #9070 