### PR TITLE
lib/stores.py: retire us-east-1.linodeobjects.com

### DIFF
--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -26,7 +26,7 @@ jobs:
           cat > ~/.config/cockpit-dev/job-runner.toml << EOF
           [secrets.inline]
           github-token = '${{ secrets.COCKPITUOUS_TOKEN }}'
-          s3-keys = {"eu-central-1.linodeobjects.com"='${{ secrets.S3_KEY_EU }}', "us-east-1.linodeobjects.com"='${{ secrets.S3_KEY_US }}', "s3.us-east-1.amazonaws.com"='${{ secrets.AWS_KEY_LOGS }}'}
+          s3-keys = {"eu-central-1.linodeobjects.com"='${{ secrets.S3_KEY_EU }}', "s3.us-east-1.amazonaws.com"='${{ secrets.AWS_KEY_LOGS }}'}
 
           [logs]
           driver = 's3'

--- a/image-download
+++ b/image-download
@@ -47,7 +47,7 @@ from lib import s3
 from lib.constants import IMAGES_DIR
 from lib.directories import get_images_data_dir
 from lib.network import get_curl_ca_arg
-from lib.stores import LOCAL_STORES, PRIVATE_STORES, PUBLIC_STORES
+from lib.stores import IMAGE_STORES, LOCAL_STORES
 from lib.testmap import get_test_image
 
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
@@ -124,7 +124,7 @@ def download(dest: str, force: bool, state: bool, quiet: bool, stores: Sequence[
     name = os.path.basename(dest)
 
     if not stores:
-        stores = [*LOCAL_STORES, *PUBLIC_STORES, *PRIVATE_STORES]
+        stores = [*LOCAL_STORES, *IMAGE_STORES]
         image_upload_store = os.environ.get('COCKPIT_IMAGE_UPLOAD_STORE')
         if image_upload_store:
             # NB: This is an *addition* to the built-in stores, used for

--- a/image-upload
+++ b/image-upload
@@ -29,7 +29,7 @@ from lib import s3
 from lib.constants import BOTS_DIR, IMAGES_DIR
 from lib.directories import get_images_data_dir
 from lib.network import get_curl_ca_arg
-from lib.stores import LOCAL_STORES, PRIVATE_STORES, PUBLIC_STORES
+from lib.stores import IMAGE_STORES, LOCAL_STORES
 
 
 def upload(store: str, source: str, prune: bool = False) -> bool:
@@ -102,12 +102,7 @@ def main() -> None:
                 # adds this to the list, if it's present.
                 stores = [image_upload_store]
         if not stores:
-            stores = [*LOCAL_STORES, *PRIVATE_STORES]
-            if not os.path.basename(source).startswith('rhel'):
-                # NB: We currently have a well-known S3 token which is capable
-                # of accessing all data uploaded to these buckets, regardless
-                # of ACL.  Only upload non-RHEL images here.
-                stores += PUBLIC_STORES
+            stores = [*LOCAL_STORES, *IMAGE_STORES]
         success = False
         for store in stores:
             success |= upload(store, source, prune=args.prune_s3)

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -57,15 +57,6 @@ def get_key(url: urllib.parse.ParseResult) -> S3Key | None:
             pass
         _, _, hostname = hostname.partition('.')  # strip a leading component
 
-    # Fallback to the "public" secret key if no other keys are configured.
-    # This key will work only for the cockpit-images.us-east-1 bucket.
-    if url.hostname == 'cockpit-images.us-east-1.linodeobjects.com':
-        return (
-            '2RI8J2WQEIC8NI5YS85Z',
-            'V6N8xbuIIDUGXlkHtIXRnje2e9HpIdCGK9nmxaM4',
-            None,
-        )
-
     return None
 
 

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -19,13 +19,8 @@ from collections.abc import Sequence
 
 from lib.directories import xdg_config_home
 
-# hosted on public internet
-PUBLIC_STORES: Sequence[str] = (
-    "https://cockpit-images.us-east-1.linodeobjects.com/",
-)
-
 # hosted on the public internet, requires a private token for some/all images
-PRIVATE_STORES: Sequence[str] = (
+IMAGE_STORES: Sequence[str] = (
     "https://cockpit-images.eu-central-1.linodeobjects.com/",
     "https://cockpit-ci-images.s3.us-east-1.amazonaws.com/",
 )

--- a/lib/stores.py
+++ b/lib/stores.py
@@ -22,6 +22,7 @@ from lib.directories import xdg_config_home
 # hosted on the public internet, requires a private token for some/all images
 IMAGE_STORES: Sequence[str] = (
     "https://cockpit-images.eu-central-1.linodeobjects.com/",
+    "https://cockpit-ci-images-fra.s3.eu-central-1.amazonaws.com/",
     "https://cockpit-ci-images.s3.us-east-1.amazonaws.com/",
 )
 

--- a/prometheus-stats
+++ b/prometheus-stats
@@ -199,7 +199,7 @@ merged_failures {merged_failures}
 
     # S3 space usage
     space_usage = {}
-    for uri in stores.PUBLIC_STORES:
+    for uri in stores.IMAGE_STORES:
         url = urllib.parse.urlparse(uri)
 
         if key := s3.get_key(url):


### PR DESCRIPTION
We're slowly moving away from Linode and this is the next step: this mirror is the one that lets anyone download non-RHEL images, but the AWS mirror now fills that role.

The eu-central-1 Linode mirror will remain online for now because of the large number of people who have an S3 key issued there which allows them to download the RHEL images.  We're going to slowly migrate to #9071 for that, but it's not there yet.

Dropping us-east-1 also lets us get rid of our special "public secret" key.