### PR TITLE
.github/workflows: widen scope of AWS S3 key

### DIFF
--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -26,7 +26,7 @@ jobs:
           cat > ~/.config/cockpit-dev/job-runner.toml << EOF
           [secrets.inline]
           github-token = '${{ secrets.COCKPITUOUS_TOKEN }}'
-          s3-keys = {"eu-central-1.linodeobjects.com"='${{ secrets.S3_KEY_EU }}', "s3.us-east-1.amazonaws.com"='${{ secrets.AWS_KEY_LOGS }}'}
+          s3-keys = {"eu-central-1.linodeobjects.com"='${{ secrets.S3_KEY_EU }}', "amazonaws.com"='${{ secrets.AWS_KEY_LOGS }}'}
 
           [logs]
           driver = 's3'


### PR DESCRIPTION
We added a Frankfurt mirror for images but we scope the upload credential to us-east-1.  Widen the scope so that it works for both.