### PR TITLE
pyproject: Drop npm-update from mypy override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ module = [
     'cockpit-lib-update',
     'image-refresh',
     'naughty-prune',
-    'npm-update',
     'po-refresh',
     'tasks-container-update',
 ]


### PR DESCRIPTION
This was dropped in 207c73209060cac88adf9499162894c3ef489d35.