### PR TITLE
images: Add centos-10-bootc

### DIFF
--- a/images/scripts/centos-10-bootc.bootstrap
+++ b/images/scripts/centos-10-bootc.bootstrap
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -eux
+exec $(dirname $0)/lib/bootc.bootstrap "$1" quay.io/centos-bootc/centos-bootc:stream10

--- a/images/scripts/centos-10-bootc.setup
+++ b/images/scripts/centos-10-bootc.setup
@@ -1,0 +1,1 @@
+bootc.setup

--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -238,6 +238,7 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
 # their non-Atomic siblings.
 OSTREE_BUILD_IMAGE = {
     "centos-9-bootc": "centos-9-stream",
+    "centos-10-bootc": "centos-10",
     "fedora-coreos": "fedora-44",
 }
 


### PR DESCRIPTION
I used that to try and reproduce our current [c10-bootc TF failures](https://artifacts.dev.testing-farm.io/1985bcc8-9483-49fb-a52a-9b4d3126122e/) with our CI. Sadly unsuccessful, our image works perfectly.

Feel free to close if that's not interesting, there's nothing surprising here.