### PR TITLE
image-refresh: factor out some git helpers

### DIFF
--- a/image-refresh
+++ b/image-refresh
@@ -7,22 +7,15 @@ import argparse
 import json
 import os
 import platform
-import re
 import shlex
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
 
-from lib import github, testmap
-from lib.aio.jsonutil import JsonObject, get_nested, get_str, typechecked
+from lib import git, testmap
+from lib.aio.jsonutil import get_dict, get_str
 from lib.constants import BOTS_DIR, SCRIPTS_DIR
-
-api = github.GitHub()
-
-
-def would(*args: object) -> None:
-    print('\n** Would', *args)
+from lib.github import NOT_TESTED_DIRECT, GitHub
 
 
 def run(
@@ -33,7 +26,7 @@ def run(
     env: dict[str, str] | None = None,
 ) -> int:
     if dry_run:
-        would(shlex.join(cmd))
+        print('\n+ #', shlex.join(cmd))
         return 0
     if verbose:
         print('\n+', shlex.join(cmd), file=sys.stderr)
@@ -41,54 +34,12 @@ def run(
     return result.returncode
 
 
-def comment(issue_nr: int, body: str, *, dry_run: bool = False) -> None:
-    if dry_run:
-        would(f'comment on {api.repo}#{issue_nr}:', body)
-    else:
-        api.post(f"issues/{issue_nr}/comments", {"body": body})
-
-
-def commit_and_push(image: str, *, issue_nr: int, verbose: bool = False, dry_run: bool = False) -> str:
-    """Commit the updated image and push it to a new remote branch."""
-    if api.token:
-        subprocess.check_call(['git', 'config', 'credential.https://github.com.username', api.token])
-    # --allow-empty: vanishingly unlikely, but if the image didn't change we
-    # still want to record that it was successfully refreshed on this date.
-    run(
-        'git',
-        'commit',
-        '--allow-empty',
-        '-m',
-        f'images: Update {image} image\n\nCloses #{issue_nr}',
-        '--',
-        f'images/{image}',
-        verbose=verbose,
-    )
-
-    branch_name = f'image-refresh-{image}-{datetime.now(tz=timezone.utc):%Y%m%d-%H%M%S}'
-    branch_name = re.sub(r'[^A-Za-z0-9]+', '-', branch_name)
-
-    run('git', 'push', api.remote, f'HEAD:refs/heads/{branch_name}', verbose=verbose, dry_run=dry_run)
-
-    return branch_name
-
-
-def convert_issue_to_pull(issue_nr: int, branch: str, *, dry_run: bool = False) -> str | None:
-    data: JsonObject = {"head": branch, "base": "main", "issue": issue_nr}
-
-    if dry_run:
-        would(f'open PR on {api.repo}:', json.dumps(data, indent=4))
-        return None
-
-    pull = typechecked(api.post("pulls", data), dict)
-    with get_nested(pull, 'head') as head:
-        return get_str(head, 'sha')
-
-
-def image_refresh(image: str, issue_nr: int, *, verbose: bool = False, dry_run: bool = False) -> str:
+def image_refresh(
+    github: GitHub, image: str, issue_nr: int, *, verbose: bool = False, dry_run: bool = False,
+) -> str:
     """Run the image refresh. Returns the branch name."""
     log_url = os.environ.get('COCKPIT_CI_LOG_URL', None)
-    comment(
+    github.comment(
         issue_nr,
         f"image-refresh {image} started on {platform.node()}. Log: {log_url or 'unknown'}",
         dry_run=dry_run,
@@ -121,19 +72,30 @@ def image_refresh(image: str, issue_nr: int, *, verbose: bool = False, dry_run: 
         run('./image-diff', old_image, image, verbose=verbose)
 
     # create branch and push it
-    branch = commit_and_push(image, issue_nr=issue_nr, verbose=verbose, dry_run=dry_run)
+    # --allow-empty: vanishingly unlikely, but if the image didn't change we
+    # still want to record that it was successfully refreshed on this date.
+    git.add(f'images/{image}')
+    git.commit(
+        f'images: Update {image} image\n\nCloses #{issue_nr}',
+        allow_empty=True,
+        dry_run=dry_run,
+    )
+    branch = git.push(github, f"image-refresh-{image}", dry_run=dry_run)
 
     # Check if the issue is already a pull request (and do nothing if so)
-    issue = api.get(f"issues/{issue_nr}")
-    if issue and "pull_request" in issue:
+    issue = github.get_obj(f"issues/{issue_nr}", {})
+    if "pull_request" in issue:
         return branch
 
     # ... else, create a PR and trigger tests.
     triggers = testmap.tests_for_image(image)
-    if head := convert_issue_to_pull(issue_nr, branch, dry_run=dry_run):
+    pull = github.convert_issue_to_pull(branch, issue_nr, dry_run=dry_run)
+    if pull is not None:
+        head = get_str(get_dict(pull, "head"), "sha")
+
         # Create a synthetic status to forward the log URL to the new HEAD
         if log_url:
-            api.post(
+            github.post(
                 f"statuses/{head}",
                 {
                     'state': 'success',
@@ -144,12 +106,12 @@ def image_refresh(image: str, issue_nr: int, *, verbose: bool = False, dry_run: 
             )
 
         for trigger in triggers:
-            api.post(
+            github.post(
                 f"statuses/{head}",
-                {"state": "pending", "context": trigger, "description": github.NOT_TESTED_DIRECT},
+                {"state": "pending", "context": trigger, "description": NOT_TESTED_DIRECT},
             )
     else:
-        would('trigger tests:', json.dumps(triggers, indent=4))
+        print('\n** Would trigger tests:', json.dumps(triggers, indent=4))
 
     return branch
 
@@ -162,20 +124,21 @@ def main() -> None:
     parser.add_argument("image")
     args = parser.parse_args()
 
+    github = GitHub()
     start_time = time.time()
     try:
-        branch = image_refresh(args.image, args.issue, verbose=args.verbose, dry_run=args.dry_run)
+        branch = image_refresh(github, args.image, args.issue, verbose=args.verbose, dry_run=args.dry_run)
     except BaseException as exc:
         result = f"image-refresh {args.image} failed: {exc}"
         sys.stderr.write(f"\n# {result}\n# Duration: {time.time() - start_time}s\n")
         if not args.dry_run:
-            comment(args.issue, result)
+            github.comment(args.issue, result)
         raise
     else:
-        result = f"image-refresh {args.image} succeeded: https://github.com/{api.repo}/commits/{branch}"
+        result = f"image-refresh {args.image} succeeded: https://github.com/{github.repo}/commits/{branch}"
         sys.stderr.write(f"\n# {result}\n# Duration: {time.time() - start_time}s\n")
         if not args.dry_run:
-            comment(args.issue, result)
+            github.comment(args.issue, result)
 
 
 if __name__ == '__main__':

--- a/lib/git.py
+++ b/lib/git.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+import os
+import re
+import shlex
+import subprocess
+import sys
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+
+from lib.github import GitHub
+
+logger = logging.getLogger(__name__)
+
+
+def _git(
+    *args: str,
+    config: Mapping[str, str] | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Run a git command, logging and returning stdout."""
+    cmd = ["git", *args]
+    logger.debug("+ %s", shlex.join(cmd))
+
+    if dry_run:
+        print('\n** Would', shlex.join(cmd))
+        return ''
+
+    env = {**os.environ, 'GIT_TERMINAL_PROMPT': '0'}
+    if config:
+        env['GIT_CONFIG_COUNT'] = str(len(config))
+        for i, (key, value) in enumerate(config.items()):
+            env[f'GIT_CONFIG_KEY_{i}'] = key
+            env[f'GIT_CONFIG_VALUE_{i}'] = value
+
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=env, text=True)
+    sys.stderr.write(output)
+    return output
+
+
+def add(*paths: Path | str) -> None:
+    """Stage files for commit."""
+    _git("add", "--", *[str(p) for p in paths])
+
+
+def commit(message: str, *, allow_empty: bool = False, dry_run: bool = False) -> None:
+    """Commit staged changes. Returns True if a commit was created."""
+    _git("commit", *(["--allow-empty"] if allow_empty else []), "-m", message, "--")
+
+
+def push(remote: GitHub, topic: str, *, dry_run: bool = False) -> str:
+    """Generate a branch name and pushes HEAD to the remote, returning the branch name."""
+    branch = f'{topic}-{datetime.now(tz=timezone.utc):%Y%m%d-%H%M%S}'
+    branch = re.sub(r'[^A-Za-z0-9]+', '-', branch)
+
+    _git("push", "--", remote.remote, f"+HEAD:refs/heads/{branch}", config=remote.config(), dry_run=dry_run)
+
+    return branch

--- a/lib/github.py
+++ b/lib/github.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import base64
 import functools
 import http.client
 import json
@@ -175,6 +176,16 @@ class GitHub:
         self.log = Logger(self.cache.directory)
         self.log.write("")
 
+    def config(self) -> Mapping[str, str]:
+        """Git config overrides for authenticating with this remote."""
+        if self.token:
+            basic = base64.b64encode(f'x-access-token:{self.token}'.encode()).decode()
+            return {
+                'credential.helper': '',
+                'http.https://github.com/.extraHeader': f'Authorization: Basic {basic}',
+            }
+        return {}
+
     @functools.cached_property
     def remote(self) -> str:
         repo = os.environ.get("GITHUB_BASE", None) or get_repo()
@@ -295,6 +306,10 @@ class GitHub:
         self.cache.mark()
         return json.loads(response['data'])
 
+    def post_obj(self, resource: str, data: JsonValue, accept: Container[int] = ()) -> JsonObject:
+        """Like post(), but typechecks that the response is a JSON object."""
+        return typechecked(self.post(resource, data, accept), dict)
+
     def put(self, resource: str, data: JsonValue, accept: Container[int] = ()) -> JsonValue:
         response = self.request("PUT", resource, json.dumps(data), {"Content-Type": "application/json"})
         status = response['status']
@@ -413,6 +428,32 @@ class GitHub:
     def get_head(self, pr: int) -> str | None:
         pull = self.get_obj(f"pulls/{pr}", {})
         return get_str(get_dict(pull, "head", {}), "sha", None)
+
+    @functools.cached_property
+    def default_branch(self) -> str:
+        return get_str(self.get_obj(), "default_branch")
+
+    def comment(self, issue_nr: int, body: str, *, dry_run: bool = False) -> JsonObject:
+        if dry_run:
+            print(f'\n** Would comment on {self.repo}#{issue_nr}:', body)
+            return {"body": body}
+        return self.post_obj(f"issues/{issue_nr}/comments", {"body": body})
+
+    def convert_issue_to_pull(
+        self,
+        branch: str,
+        issue_nr: int,
+        *,
+        dry_run: bool = False,
+    ) -> JsonObject | None:
+        base = os.path.basename(os.getenv("GITHUB_REF", self.default_branch))
+        data: JsonObject = {"head": branch, "base": base, "issue": issue_nr}
+
+        if dry_run:
+            print(f'\n** Would open PR on {self.repo}:', json.dumps(data, indent=4))
+            return None
+
+        return self.post_obj("pulls", data)
 
 
 class Checklist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ module = [
     'lib.task',
 
     'cockpit-lib-update',
-    'image-refresh',
     'naughty-prune',
     'po-refresh',
     'tasks-container-update',


### PR DESCRIPTION
Making image-refresh self-contained helped us free ourselves from `task.py` but we also want to bring the other scripts over.  There's good code here and we'd like to share it.  The approach is approximately as follows:

 - GitHub REST API things go in github.py

 - things that involve running the `git` command on a local repository will be collected in a new file called git.py (which we will expand as we go)

An edge case is `git push` which needs to know the remote URL and secrets from the `GitHub` but is a local git command.  We keep it in `git.py` and pass `GitHub` into it to access the remote and the secrets.

This also fixes a bug: the previous code added the secrets via a `git config` command line, which meant that the secret:
 - got written to the disk; and
 - would appear in error messages as the username@; and
 - would have been briefly visible to other users on the system (via `ps`)

The new approach injects it via environment variables as an authorization header.  This should solve all of the above problems.