### PR TITLE
github.py: reset extraheader to empty

### DIFF
--- a/lib/git.py
+++ b/lib/git.py
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -17,7 +17,7 @@ from lib.github import GitHub
 
 def _git(
     *args: str,
-    config: Mapping[str, str] | None = None,
+    config: Sequence[tuple[str, str]] = (),
     dry_run: bool = False,
 ) -> str:
     """Run a git command, logging and returning stdout."""
@@ -32,7 +32,7 @@ def _git(
     env = {**os.environ, 'GIT_TERMINAL_PROMPT': '0'}
     if config:
         env['GIT_CONFIG_COUNT'] = str(len(config))
-        for i, (key, value) in enumerate(config.items()):
+        for i, (key, value) in enumerate(config):
             env[f'GIT_CONFIG_KEY_{i}'] = key
             env[f'GIT_CONFIG_VALUE_{i}'] = value
 

--- a/lib/github.py
+++ b/lib/github.py
@@ -175,15 +175,22 @@ class GitHub:
         self.log = Logger(self.cache.directory)
         self.log.write("")
 
-    def config(self) -> Mapping[str, str]:
+    def config(self) -> Sequence[tuple[str, str]]:
         """Git config overrides for authenticating with this remote."""
-        if self.token:
-            basic = base64.b64encode(f'x-access-token:{self.token}'.encode()).decode()
-            return {
-                'credential.helper': '',
-                'http.https://github.com/.extraHeader': f'Authorization: Basic {basic}',
-            }
-        return {}
+
+        # We do this the same way as GitHub's checkout action:
+        # https://github.com/actions/checkout/blob/df4cb1c069e1874edd31b4311f1884172cec0e10/src/git-auth-helper.ts#L55
+        # which means we also need to use an empty value to reset the
+        # multi-value list to empty before adding our own value, just in case
+        # we're running on such a checkout.
+        if not self.token:
+            return ()
+        basic = base64.b64encode(f'x-access-token:{self.token}'.encode()).decode()
+        return (
+            ('credential.helper', ''),
+            ('http.https://github.com/.extraheader', ''),
+            ('http.https://github.com/.extraheader', f'Authorization: Basic {basic}'),
+        )
 
     @functools.cached_property
     def remote(self) -> str:


### PR DESCRIPTION
Before we add our Authorization header make sure we reset the existing value back to empty.  This is a cumulative multi-value and our override will add to the existing value.  Since we stole this technique from GitHub's own checkout action, that's very likely to conflict.

In order to do this we need to move from a dict to a sequence of pairs to allow specifying the value more than once.