### PR TITLE
s3streamer: remove some old code

### DIFF
--- a/lib/aio/s3streamer.py
+++ b/lib/aio/s3streamer.py
@@ -14,9 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-import codecs
 import json
-import locale
 import logging
 import os
 import textwrap
@@ -94,8 +92,6 @@ class LogStreamer:
     send_at: float | None
 
     def __init__(self, index: Index, proxy_url: URL | None = None) -> None:
-        assert locale.getpreferredencoding() == 'UTF-8'
-        self.input_decoder = codecs.getincrementaldecoder('UTF-8')(errors='replace')
         self.suffixes = {'chunks'}
         self.chunks = []
         self.index = index


### PR DESCRIPTION
`lib/aio/s3streamer.py` was originally `s3-streamer`: a non-async script acting as a wrapper around directly spawned subprocesses.  At the time we wrote that we cared a lot about ensuring that the processes that we spawned would be generating utf-8 output.

Fast-forward and this code lives in job-runner which is using podman to spawn processes.  Our locale.getpreferredencoding() check is no longer effective.  What's worse: a recent change in Testing Farm resulted in this no longer returning 'UTF-8'.  Let's kill this pointless (and now harmful) assertion.

Additionally, s3streamer.py is now entirely based on strings and no longer has a need for an incremental decoder: the adjacent assignment in __init__() has been unused for years.  Drop it.  We handle the partial characters case via the `read_utf8()` wrapper in `util.py` these days.