### PR TITLE
lib/stores: drop eu-central-1 Linode mirror

### DIFF
--- a/lib/stores.py
+++ b/lib/stores.py
@@ -21,7 +21,6 @@ from lib.directories import xdg_config_home
 
 # hosted on the public internet, requires a private token for some/all images
 IMAGE_STORES: Sequence[str] = (
-    "https://cockpit-images.eu-central-1.linodeobjects.com/",
     "https://cockpit-ci-images-fra.s3.eu-central-1.amazonaws.com/",
     "https://cockpit-ci-images.s3.us-east-1.amazonaws.com/",
 )


### PR DESCRIPTION
This is the last bit of Linode infrastructure that we were using and it's now redundant: public images are openly available again and Red Hat developers are expected to download RHEL images via Kerberos authentication (automatic) or the `saml-login` script.