### PR TITLE
sts: increase ticket duration to 12 hours

### DIFF
--- a/lib/gssapi_saml_sts.py
+++ b/lib/gssapi_saml_sts.py
@@ -100,6 +100,7 @@ def aws_sts_assume_role(role_arn: str, provider_arn: str, saml_assertion: str) -
         'RoleArn': role_arn,
         'PrincipalArn': provider_arn,
         'SAMLAssertion': saml_assertion,
+        'DurationSeconds': 43200,  # 12 hours
     }).encode()
 
     request = urllib.request.Request(_STS_URL, data=params, method='POST')


### PR DESCRIPTION
This required increasing the maximum session duration in "summary" section of the role in the AWS console.