### PR TITLE
image-refresh: remove forcepush

### DIFF
--- a/image-refresh
+++ b/image-refresh
@@ -88,7 +88,6 @@ def image_refresh(
     triggers = testmap.tests_for_image(image)
     pull = github.convert_issue_to_pull(branch, issue_nr, dry_run=dry_run)
     if pull is not None:
-        git.amend_and_forcepush(github, branch, closes=issue_nr)
         head = git.get_current_head()
 
         # Create a synthetic status to forward the log URL to the new HEAD


### PR DESCRIPTION
We don't need this because:

  - we already have the Closes line that we added ourselves (since we always know the issue number in advance).  Doing the force-push adds a second `Closes:` line.

  - we open the PR as the `cockpituous` user so we don't need the force-push as a workaround for the GitHub anti-recursion rule