### PR TITLE
lib: consolidate S3 signing logic

### DIFF
--- a/lib/aio/s3.py
+++ b/lib/aio/s3.py
@@ -16,10 +16,8 @@
 import asyncio
 import contextlib
 import hashlib
-import hmac
 import logging
 import mimetypes
-import time
 from collections.abc import Collection, Mapping
 from types import TracebackType
 from typing import NamedTuple, Self
@@ -27,16 +25,12 @@ from typing import NamedTuple, Self
 import httpx
 from yarl import URL
 
+from ..s3 import S3Key, s3_sign
 from .base import Destination, LogDriver
 from .jsonutil import JsonError, JsonObject, get_nested, get_str
 from .util import AsyncQueue, create_http_session
 
 logger = logging.getLogger(__name__)
-
-
-class S3Key(NamedTuple):
-    access: str
-    secret: str
 
 
 class HttpRequest(NamedTuple):
@@ -56,7 +50,11 @@ class HttpQueue:
 
     async def request_once(self, request: HttpRequest, checksum: str) -> None:
         # NB: Re-sign each attempt.  Time's arrow neither stands still nor reverses.
-        headers = s3_sign(request.url, request.method, request.headers, checksum, self._s3_key)
+        assert request.url.host is not None
+        headers = s3_sign(
+            request.url.host, request.url.raw_path, request.url.query_string,
+            request.method, request.headers, checksum, self._s3_key,
+        )
         logger.log(self._level, '%s %s', request.method, request.url)
         response = await self.session.request(request.method, str(request.url), content=request.data, headers=headers)
         response.raise_for_status()
@@ -112,48 +110,6 @@ class HttpQueue:
         self.request_soon(HttpRequest('DELETE', url, {}))
 
 
-def s3_sign(
-    url: URL, method: str, headers: Mapping[str, str], checksum: str, keys: S3Key
-) -> Mapping[str, str]:
-    """Signs an AWS request using the AWS4-HMAC-SHA256 algorithm
-
-    Returns a dictionary of extra headers which need to be sent along with the request.
-    If the method is PUT then the checksum of the data to be uploaded must be provided.
-    @headers, if given, are a dict of additional headers to be signed (eg: `x-amz-acl`)
-    """
-    amzdate = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
-    assert url.host is not None
-
-    # Extract region from hostname for AWS S3 (e.g., 's3.us-east-1.amazonaws.com' -> 'us-east-1')
-    # AWS requires the actual region; other S3-compatible services accept 'any'
-    region = 'any'
-    if url.host.endswith('.amazonaws.com'):
-        # Format: [bucket.]s3.REGION.amazonaws.com - region is third-last component
-        region = url.host.split('.')[-3]
-
-    # Header canonicalisation demands all header names in lowercase
-    headers = {key.lower(): value for key, value in headers.items()}
-    headers.update({'host': url.host, 'x-amz-content-sha256': checksum, 'x-amz-date': amzdate})
-    headers_str = ''.join(f'{k}:{v}\n' for k, v in sorted(headers.items()))
-    headers_list = ';'.join(sorted(headers))
-
-    credential_scope = f'{amzdate[:8]}/{region}/s3/aws4_request'
-    signing_key = f'AWS4{keys.secret}'.encode('ascii')
-    for item in credential_scope.split('/'):
-        signing_key = hmac.new(signing_key, item.encode('ascii'), hashlib.sha256).digest()
-
-    algorithm = 'AWS4-HMAC-SHA256'
-    canonical_request = f'{method}\n{url.raw_path}\n{url.query_string}\n{headers_str}\n{headers_list}\n{checksum}'
-    request_hash = hashlib.sha256(canonical_request.encode('ascii')).hexdigest()
-    string_to_sign = f'{algorithm}\n{amzdate}\n{credential_scope}\n{request_hash}'
-    signature = hmac.new(signing_key, string_to_sign.encode('ascii'), hashlib.sha256).hexdigest()
-    headers['Authorization'] = (
-        f'{algorithm} Credential={keys.access}/{credential_scope},SignedHeaders={headers_list},Signature={signature}'
-    )
-
-    return headers
-
-
 class S3Destination(Destination, contextlib.AsyncExitStack):
     def __init__(self, session: httpx.AsyncClient, url: URL, proxy_url: URL, key: S3Key, acl: str) -> None:
         super().__init__()
@@ -199,11 +155,11 @@ class S3LogDriver(LogDriver, contextlib.AsyncExitStack):
         self.proxy_url = URL(get_str(config, 'proxy_url', str(self.url)))
         self.acl = get_str(config, 'acl')
         try:
-            access, secret = get_str(config, 'key').split()
-            self.key = S3Key(access, secret)
-        except (ValueError, JsonError):
+            self.key = S3Key(*get_str(config, 'key').split())
+        except (TypeError, JsonError):
             with get_nested(config, 'key') as key:
-                self.key = S3Key(get_str(key, 'access'), get_str(key, 'secret'))
+                self.key = S3Key(get_str(key, 'access'), get_str(key, 'secret'),
+                                get_str(key, 'token', '') or None)
 
     def get_destination(self, slug: str) -> contextlib.AbstractAsyncContextManager[S3Destination]:
         quoted_slug = slug.replace('//', '--').replace(':', '-')

--- a/lib/gssapi_saml_sts.py
+++ b/lib/gssapi_saml_sts.py
@@ -140,7 +140,7 @@ def _parse_sts_response(xml: str) -> tuple[S3Key, datetime]:
             raise AuthError(f'🤔 STS XML response missing {tag}')
 
         expiration = datetime.fromisoformat(text('Expiration'))
-        key = (text('AccessKeyId'), text('SecretAccessKey'), text('SessionToken'))
+        key = S3Key(text('AccessKeyId'), text('SecretAccessKey'), text('SessionToken'))
         return key, expiration
 
     except (ET.ParseError, ValueError, TypeError) as exc:

--- a/lib/s3.py
+++ b/lib/s3.py
@@ -17,6 +17,7 @@ import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from collections.abc import Iterable, Mapping, Sequence
+from typing import NamedTuple
 
 from .directories import xdg_config_home
 from .network import host_ssl_context
@@ -26,12 +27,18 @@ __all__ = (
     "get_key",
     "list_bucket",
     "parse_list",
+    "s3_sign",
     "sign_curl",
     "sign_url",
     "urlopen",
 )
 
-type S3Key = tuple[str, str, str | None]
+
+class S3Key(NamedTuple):
+    access: str
+    secret: str
+    token: str | None = None
+
 
 SHA256_NIL = hashlib.sha256(b'').hexdigest()
 
@@ -49,9 +56,8 @@ def get_key(url: urllib.parse.ParseResult) -> S3Key | None:
     while '.' in hostname:
         try:
             with open(os.path.join(s3_key_dir, hostname)) as fp:
-                access, secret = fp.read().split()
-                return access, secret, None
-        except ValueError:
+                return S3Key(*fp.read().split())
+        except (TypeError, ValueError):
             print(f'ignoring invalid content of {s3_key_dir}/{hostname}', file=sys.stderr)
         except FileNotFoundError:
             pass
@@ -60,8 +66,10 @@ def get_key(url: urllib.parse.ParseResult) -> S3Key | None:
     return None
 
 
-def sign_request(
-    url: urllib.parse.ParseResult,
+def s3_sign(
+    hostname: str,
+    path: str,
+    query: str,
     method: str,
     headers: Mapping[str, str],
     checksum: str,
@@ -73,44 +81,52 @@ def sign_request(
     If the method is PUT then the checksum of the data to be uploaded must be provided.
     @headers, if given, are a dict of additional headers to be signed (eg: `x-amz-acl`)
     """
-    assert url.hostname is not None
-    access_key, secret_key, session_token = key
-
     amzdate = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
-
-    # Header canonicalisation demands all header names in lowercase
-    headers = {k.lower(): v for k, v in headers.items()}
-    headers.update({
-        'host': url.hostname,
-        'x-amz-content-sha256': checksum,
-        'x-amz-date': amzdate,
-        **({'x-amz-security-token': session_token} if session_token is not None else {}),
-    })
-    headers_str = ''.join(f'{k}:{v}\n' for k, v in sorted(headers.items()))
-    headers_list = ';'.join(sorted(headers))
 
     # Extract region from hostname for AWS S3 (e.g., 's3.us-east-1.amazonaws.com' -> 'us-east-1')
     # AWS requires the actual region; other S3-compatible services accept 'any'
     region = 'any'
-    if url.hostname.endswith('.amazonaws.com'):
-        # Format: [bucket.]s3.REGION.amazonaws.com - region is third-last component
-        region = url.hostname.split('.')[-3]
+    if hostname.endswith('.amazonaws.com'):
+        region = hostname.split('.')[-3]
+
+    # Header canonicalisation demands all header names in lowercase
+    headers = {k.lower(): v for k, v in headers.items()}
+    headers.update({
+        'host': hostname,
+        'x-amz-content-sha256': checksum,
+        'x-amz-date': amzdate,
+        **({'x-amz-security-token': key.token} if key.token is not None else {}),
+    })
+    headers_str = ''.join(f'{k}:{v}\n' for k, v in sorted(headers.items()))
+    headers_list = ';'.join(sorted(headers))
 
     credential_scope = f'{amzdate[:8]}/{region}/s3/aws4_request'
-    signing_key = f'AWS4{secret_key}'.encode('ascii')
+    signing_key = f'AWS4{key.secret}'.encode('ascii')
     for item in credential_scope.split('/'):
         signing_key = hmac.new(signing_key, item.encode('ascii'), hashlib.sha256).digest()
 
     algorithm = 'AWS4-HMAC-SHA256'
-    canonical_request = f'{method}\n{url.path}\n{url.query}\n{headers_str}\n{headers_list}\n{checksum}'
+    canonical_request = f'{method}\n{path}\n{query}\n{headers_str}\n{headers_list}\n{checksum}'
+    logger.debug('canonical request: %r', canonical_request)
     request_hash = hashlib.sha256(canonical_request.encode('ascii')).hexdigest()
     string_to_sign = f'{algorithm}\n{amzdate}\n{credential_scope}\n{request_hash}'
     signature = hmac.new(signing_key, string_to_sign.encode('ascii'), hashlib.sha256).hexdigest()
     headers['Authorization'] = (
-        f'{algorithm} Credential={access_key}/{credential_scope},SignedHeaders={headers_list},Signature={signature}'
+        f'{algorithm} Credential={key.access}/{credential_scope},SignedHeaders={headers_list},Signature={signature}'
     )
 
     return headers
+
+
+def sign_request(
+    url: urllib.parse.ParseResult,
+    method: str,
+    headers: Mapping[str, str],
+    checksum: str,
+    key: S3Key,
+) -> dict[str, str]:
+    assert url.hostname is not None
+    return s3_sign(url.hostname, url.path, url.query, method, headers, checksum, key)
 
 
 def sign_curl(

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -14,8 +14,9 @@ from lib.aio.base import SubjectSpecification
 from lib.aio.github import GitHub
 from lib.aio.jobcontext import JobContext
 from lib.aio.jsonutil import JsonObject, JsonValue, json_merge_patch
-from lib.aio.s3 import S3Key, S3LogDriver
+from lib.aio.s3 import S3LogDriver
 from lib.aio.util import LRUCache
+from lib.s3 import S3Key
 
 
 class MockResponse:


### PR DESCRIPTION
We have two copies of the S3 signing algorithm: one in lib/ and one in lib/aio/.  Only the non-aio version supports session tokens, but the aio version uses a nice `NamedTuple` for the key.  Merge the best parts of each into `lib/` and have `lib/aio/` used it from there.

There's a subtle functionality change here: files in the s3-keys directory can now contain session keys.  This works the same way as before, but if .split() returns 3 parts, the 3rd part is considered to be the session key.