### PR TITLE
lib/test_mock_server.py: wait for server startup

### DIFF
--- a/lib/test_mock_server.py
+++ b/lib/test_mock_server.py
@@ -53,14 +53,17 @@ class MockServer[T]:
         self.handler = handler
         self.data = data
 
-    def run(self) -> None:
+    def run(self, ready: multiprocessing.synchronize.Event) -> None:
         srv = HTTPServer[T](self.address, self.handler)
         srv.data = self.data
+        ready.set()
         srv.serve_forever()
 
     def start(self) -> None:
-        self.process = multiprocessing.Process(target=self.run)
+        ready = multiprocessing.Event()
+        self.process = multiprocessing.Process(target=self.run, args=(ready,))
         self.process.start()
+        ready.wait()
 
     def kill(self) -> None:
         self.process.terminate()


### PR DESCRIPTION
We use this in our tests that want to talk to a mock GitHub server. Unfortunately, the way it's structured, we return as soon as fork() completes and don't wait until the server is actually running.

More unfortunately, our lib/github.py code has a silent built-in retry that's been covering this bug for years.  The usual case is that the server doesn't start on time, the client hits a connection error, then sleeps and retries.  By then the server has started.

Let's fix that by making sure the server has started before running the tests.

This reduces the time taken to run `pytest` on my laptop from ~42 seconds to ~12 seconds.