### PR TITLE
further unit test speedups and cleanups

### DIFF
--- a/lib/github.py
+++ b/lib/github.py
@@ -22,7 +22,6 @@ import json
 import logging
 import os
 import re
-import socket
 import subprocess
 import time
 import urllib.parse
@@ -36,6 +35,8 @@ from lib import cache
 from lib.aio.jsonutil import JsonObject, JsonValue, get_dict, get_dictv, get_int, get_str, typechecked
 from lib.directories import xdg_cache_home, xdg_config_home
 from lib.testmap import is_valid_context
+
+logger = logging.getLogger(__name__)
 
 __all__ = (
     'NOT_TESTED',
@@ -63,20 +64,6 @@ ISSUE_TITLE_IMAGE_REFRESH = "Image refresh for {0}"
 
 _T = TypeVar('_T')
 _DT = TypeVar('_DT')
-
-
-class Logger:
-    def __init__(self, directory: str):
-        hostname = socket.gethostname().split(".")[0]
-        month = time.strftime("%Y%m")
-        self.path = os.path.join(directory, f"{hostname}-{month}.log")
-
-        os.makedirs(directory, exist_ok=True)
-
-    # Yes, we open the file each time
-    def write(self, value: str) -> None:
-        with open(self.path, 'a') as f:
-            f.write(value)
 
 
 class Response(TypedDict):
@@ -150,10 +137,12 @@ class GitHub:
         try:
             with open(xdg_config_home('cockpit-dev', 'github-token', envvar='COCKPIT_GITHUB_TOKEN_FILE')) as f:
                 self.token = f.read().strip()
+                logger.debug("github token loaded from %s", f.name)
         except FileNotFoundError:
             try:
                 with open(xdg_config_home('github-token')) as f:
                     self.token = f.read().strip()
+                    logger.debug("github token loaded from %s", f.name)
             except FileNotFoundError:
                 # fall back to GitHub's CLI token
                 try:
@@ -161,19 +150,17 @@ class GitHub:
                         match = re.search(r'oauth_token:\s*(\S+)', f.read())
                     if match:
                         self.token = match.group(1)
+                        logger.debug("github token loaded from %s", f.name)
+                    else:
+                        logger.debug("no oauth_token found in %s", f.name)
                 except FileNotFoundError:
-                    # token not found anywhere, so only reading operations are available
-                    pass
+                    logger.debug("no github token found; only reading operations are available")
 
         # default cache directory
         if not cacher:
             cacher = cache.Cache(xdg_cache_home('github'))
 
         self.cache = cacher
-
-        # Create a log for debugging our GitHub access
-        self.log = Logger(self.cache.directory)
-        self.log.write("")
 
     def config(self) -> Sequence[tuple[str, str]]:
         """Git config overrides for authenticating with this remote."""
@@ -249,7 +236,7 @@ class GitHub:
                     # success!
                     break
             except (ConnectionResetError, http.client.BadStatusLine, OSError, SSLEOFError) as e:
-                logging.warning("Transient error during GitHub request, attempt #%s: %s", retry, e)
+                logger.warning("Transient error during GitHub request, attempt #%s: %s", retry, e)
 
             self.conn = None
             time.sleep(2 ** retry)
@@ -259,8 +246,7 @@ class GitHub:
         heads = {}
         for (header, value) in response.getheaders():
             heads[header.lower()] = value
-        self.log.write(
-            f'{self.url.netloc} - - [{time.asctime()}] "{method} {resource} HTTP/1.1" {response.status} -\n')
+        logger.debug("%s %s %s → %d", self.url.netloc, method, resource, response.status)
         return {
             "status": response.status,
             "reason": response.reason,

--- a/lib/test_mock_server.py
+++ b/lib/test_mock_server.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import http.server
 import json
 import multiprocessing
-from collections.abc import Mapping
+import queue
+from collections.abc import Mapping, Sequence
+from typing import Never
 
 from lib.aio.jsonutil import JsonValue
 
@@ -40,30 +42,39 @@ from lib.aio.jsonutil import JsonValue
 # which is why we can pass in mutable state but it's never modified.
 
 
-class HTTPServer[T](http.server.HTTPServer):
+class HTTPServer[T, Q = Never](http.server.HTTPServer):
     reply_count = 0
     data: T
+    queue: multiprocessing.Queue[Q]
 
 
-class MockServer[T]:
-    def __init__(
-        self, address: tuple[str, int], handler: type[MockHandler[T]], data: T
-    ):
+class MockServer[T, Q = Never]:
+    def __init__(self, address: tuple[str, int], handler: type[MockHandler[T, Q]], data: T):
         self.address = address
         self.handler = handler
         self.data = data
+        self.queue: multiprocessing.Queue[Q] = multiprocessing.Queue()
 
-    def run(self, ready: multiprocessing.synchronize.Event) -> None:
-        srv = HTTPServer[T](self.address, self.handler)
+    def run(self, port_queue: multiprocessing.Queue[int]) -> None:
+        srv = HTTPServer[T, Q](self.address, self.handler)
         srv.data = self.data
-        ready.set()
+        srv.queue = self.queue
+        port_queue.put(srv.server_address[1])
         srv.serve_forever()
 
     def start(self) -> None:
-        ready = multiprocessing.Event()
-        self.process = multiprocessing.Process(target=self.run, args=(ready,))
+        port_queue: multiprocessing.Queue[int] = multiprocessing.Queue()
+        self.process = multiprocessing.Process(target=self.run, args=(port_queue,))
         self.process.start()
-        ready.wait()
+        self.address = (self.address[0], port_queue.get())
+
+    def drain_queue(self) -> Sequence[Q]:
+        result: list[Q] = []
+        try:
+            while True:
+                result.append(self.queue.get_nowait())
+        except queue.Empty:
+            return result
 
     def kill(self) -> None:
         self.process.terminate()
@@ -71,13 +82,13 @@ class MockServer[T]:
         assert self.process.exitcode is not None
 
 
-class MockHandler[T](http.server.BaseHTTPRequestHandler):
+class MockHandler[T, Q = Never](http.server.BaseHTTPRequestHandler):
     # This is wrong and broken and unsafe, but we kinda need to do it.  We know
     # that we'll only ever use this with the correct server type, but this
     # information doesn't get carried through the library stack (in fact, we
     # can't even be sure that .server here is even an HTTP server: it could be
     # any socket server).  So let's add it back.  It's just tests...
-    server: HTTPServer[T]
+    server: HTTPServer[T, Q]
 
     def replyData(self, value: str, headers: Mapping[str, str] = {}, status: int = 200) -> None:
         self.send_response(status)

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import AsyncIterator, Iterator, Sequence
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -159,9 +160,13 @@ async def test_github_404(service: GitHubService, api: GitHub) -> None:
 
 async def test_github_api_flakes(service: GitHubService, api: GitHub) -> None:
     # Make sure 5xx errors and network issues get retries
-    service.flake([(503, 'Busy'), httpx.ConnectError('connection failed')])
-    service.update('x', {'a': 'b'}, etag=True)
-    assert await api.get('x') == {'a': 'b'}
+    mock_sleep = AsyncMock()
+    with patch('asyncio.sleep', mock_sleep):
+        service.flake([(503, 'Busy'), httpx.ConnectError('connection failed')])
+        service.update('x', {'a': 'b'}, etag=True)
+        assert await api.get('x') == {'a': 'b'}
+    # verify exponential backoff: 2^0=1s, 2^1=2s
+    assert mock_sleep.call_args_list == [((1,),), ((2,),)]
 
 
 async def test_github_cache(service: GitHubService, api: GitHub) -> None:

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -43,27 +43,27 @@ def test_read_write(tmp_path: Path) -> None:
 
 
 def test_current(tmp_path: Path) -> None:
-    c = cache.Cache[object](f'{tmp_path}', lag=3)
+    c = cache.Cache[object](f'{tmp_path}', lag=1)
 
     c.write("resource2", {"value": 2})
     assert c.current('resource2') is True
 
-    time.sleep(2)
+    time.sleep(0.6)
     assert c.current('resource2') is True
 
-    time.sleep(2)
+    time.sleep(0.6)
     assert c.current('resource2') is False
 
 
 def test_current_mark(tmp_path: Path) -> None:
-    c = cache.Cache[object](f'{tmp_path}', lag=3)
+    c = cache.Cache[object](f'{tmp_path}', lag=1)
 
     assert c.current('resource') is False
 
     c.write("resource", {"value": 1})
     assert c.current('resource') is True
 
-    time.sleep(2)
+    time.sleep(0.5)
     assert c.current('resource') is True
 
     c.mark()

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import fnmatch
 import json
 import shutil
 import tempfile
@@ -88,21 +87,15 @@ class TestGitHub(unittest.TestCase):
         self.assertEqual(count, 1)
 
     def test_log(self) -> None:
-        self.api.get("/test/user")
-        self.api.cache.mark(time.time() + 1)
-        self.api.get("/test/user")
+        with self.assertLogs('lib.github', level='DEBUG') as logs:
+            self.api.get("/test/user")
+            self.api.cache.mark(time.time() + 1)
+            self.api.get("/test/user")
 
-        expect = (
-            '127.0.0.8:9898 - - * "GET /test/user HTTP/1.1" 200 -\n'
-            '127.0.0.8:9898 - - * "GET /test/user HTTP/1.1" 304 -\n'
-        )
-
-        with open(self.api.log.path, "r") as f:
-            data = f.read()
-
-        match = fnmatch.fnmatch(data, expect)
-        if not match:
-            self.fail(f"'{data}' did not match '{expect}'")
+        self.assertEqual(logs.output, [
+            'DEBUG:lib.github:127.0.0.8:9898 GET /test/user → 200',
+            'DEBUG:lib.github:127.0.0.8:9898 GET /test/user → 304',
+        ])
 
     def test_issues_since(self) -> None:
         issues = self.api.issues(since=1499838499)

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -27,7 +27,6 @@ import urllib.parse
 from lib import cache, github
 from lib.test_mock_server import MockHandler, MockServer
 
-ADDRESS = ("127.0.0.8", 9898)
 GITHUB_ISSUES = [{"number": "5", "state": "open", "created_at": "2011-04-22T13:33:48Z"},
                  {"number": "6", "state": "closed", "closed_at": "2011-04-21T13:33:48Z"},
                  {"number": "7", "state": "open"}]
@@ -69,10 +68,11 @@ class Handler(MockHandler[list[dict[str, str]]]):
 
 class TestGitHub(unittest.TestCase):
     def setUp(self) -> None:
-        self.server = MockServer(ADDRESS, Handler, GITHUB_ISSUES)
+        self.server = MockServer(("127.0.0.1", 0), Handler, GITHUB_ISSUES)
         self.server.start()
         self.temp = tempfile.mkdtemp()
-        self.api = github.GitHub(f"http://{ADDRESS[0]}:{ADDRESS[1]}/", cacher=cache.Cache(self.temp))
+        url = f"http://{self.server.address[0]}:{self.server.address[1]}/"
+        self.api = github.GitHub(url, cacher=cache.Cache(self.temp))
 
     def tearDown(self) -> None:
         self.server.kill()
@@ -92,9 +92,10 @@ class TestGitHub(unittest.TestCase):
             self.api.cache.mark(time.time() + 1)
             self.api.get("/test/user")
 
+        netloc = f'{self.server.address[0]}:{self.server.address[1]}'
         self.assertEqual(logs.output, [
-            'DEBUG:lib.github:127.0.0.8:9898 GET /test/user → 200',
-            'DEBUG:lib.github:127.0.0.8:9898 GET /test/user → 304',
+            f'DEBUG:lib.github:{netloc} GET /test/user → 200',
+            f'DEBUG:lib.github:{netloc} GET /test/user → 304',
         ])
 
     def test_issues_since(self) -> None:

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import tempfile
 from pathlib import Path
 from typing import Any, AsyncGenerator, Generator, NamedTuple
 from unittest.mock import AsyncMock, Mock, patch
@@ -13,11 +12,6 @@ from lib.aio.job import Failure, Job, run_job
 from lib.aio.jsonutil import JsonObject, get_str, typechecked
 from lib.aio.local import LocalLogDriver
 from lib.test_mock_server import MockHandler, MockServer
-
-ADDRESS = ("127.0.0.1", 9999)
-
-# Global path for recording POST calls across processes
-POST_CALLS_FILE = Path(tempfile.gettempdir()) / "test_job_post_calls.json"
 
 # Mock GitHub API responses
 GITHUB_DATA: JsonObject = {
@@ -35,18 +29,7 @@ GITHUB_DATA: JsonObject = {
 }
 
 
-class MockGitHubHandler(MockHandler[JsonObject]):
-    @staticmethod
-    def clear_post_calls() -> None:
-        POST_CALLS_FILE.unlink(missing_ok=True)
-
-    @staticmethod
-    def get_post_calls() -> list[tuple[str, JsonObject]]:
-        try:
-            return json.loads(POST_CALLS_FILE.read_text())
-        except FileNotFoundError:
-            return []
-
+class MockGitHubHandler(MockHandler[JsonObject, tuple[str, JsonObject]]):
     def do_GET(self) -> None:
         data = self.server.data
         if self.path in data:
@@ -60,11 +43,8 @@ class MockGitHubHandler(MockHandler[JsonObject]):
         post_body = self.rfile.read(content_length)
         post_data = typechecked(json.loads(post_body.decode('utf-8')), dict)
 
-        # Record the POST call to file
-        existing_calls = self.get_post_calls()
-        existing_calls.append((self.path, post_data))
-        with POST_CALLS_FILE.open('w') as f:
-            json.dump(existing_calls, f)
+        # Record the POST call via queue
+        self.server.queue.put((self.path, post_data))
 
         if self.path.startswith('/repos/') and '/statuses/' in self.path:
             # Mock status posting
@@ -120,16 +100,13 @@ def log_streamer_mocks() -> Generator[LogStreamerMocks, None, None]:
 async def mock_job_context(tmp_path: Path) -> AsyncGenerator[Mock, None]:
     """Mock JobContext with mock GitHub forge"""
 
-    # Clear any previous POST calls from other tests
-    MockGitHubHandler.clear_post_calls()
-
-    server = MockServer(ADDRESS, MockGitHubHandler, GITHUB_DATA)
+    server = MockServer(("127.0.0.1", 0), MockGitHubHandler, GITHUB_DATA)
     server.start()
 
     try:
         github_config: JsonObject = {
-            'clone-url': f'http://{ADDRESS[0]}:{ADDRESS[1]}/',
-            'api-url': f'http://{ADDRESS[0]}:{ADDRESS[1]}/',
+            'clone-url': f'http://{server.address[0]}:{server.address[1]}/',
+            'api-url': f'http://{server.address[0]}:{server.address[1]}/',
             'user-agent': 'test-runner',
             'post': True,  # Enable actual POST requests
             'token': 'dummy-token'  # Required when post is True
@@ -155,6 +132,7 @@ async def mock_job_context(tmp_path: Path) -> AsyncGenerator[Mock, None]:
         mock_ctx.container_run_args = ['--pull=newer']
         mock_ctx.secrets_args = {}
         mock_ctx.resolve_subject = AsyncMock(wraps=forge.resolve_subject)
+        mock_ctx.server = server
 
         yield mock_ctx
 
@@ -243,7 +221,7 @@ class TestRunJob:
         log_streamer_mocks.log_streamer_class.assert_called_once_with(log_streamer_mocks.index_instance, None)
 
         # Verify status posts were made
-        post_calls = MockGitHubHandler.get_post_calls()
+        post_calls = mock_job_context.server.drain_queue()
         assert len(post_calls) == 2
 
         # First call is the 'pending' status
@@ -279,7 +257,7 @@ class TestRunJob:
         )
 
         # Verify status posts were made
-        post_calls = MockGitHubHandler.get_post_calls()
+        post_calls = mock_job_context.server.drain_queue()
         assert len(post_calls) == 2
 
         # First call is the 'pending' status
@@ -308,7 +286,7 @@ class TestRunJob:
         await run_job(job_with_report, mock_job_context)
 
         # Verify status posts were made
-        post_calls = MockGitHubHandler.get_post_calls()
+        post_calls = mock_job_context.server.drain_queue()
         assert len(post_calls) == 3
 
         # First two are the status updates
@@ -354,7 +332,7 @@ class TestRunJob:
         )
 
         # Verify status posts were made
-        post_calls = MockGitHubHandler.get_post_calls()
+        post_calls = mock_job_context.server.drain_queue()
         assert len(post_calls) == 2
 
         # Last call is the 'error' status with 'Cancelled' message
@@ -387,7 +365,7 @@ class TestRunJob:
         )
 
         # Verify status posts were made
-        post_calls = MockGitHubHandler.get_post_calls()
+        post_calls = mock_job_context.server.drain_queue()
         assert len(post_calls) == 2
 
         # Last call is the 'failure' status with timeout message
@@ -428,7 +406,7 @@ class TestRunJob:
             )
 
             # Verify status posts were made with proxy URL
-            post_calls = MockGitHubHandler.get_post_calls()
+            post_calls = mock_job_context.server.drain_queue()
             assert len(post_calls) == 2
 
             # First call is the 'pending' status

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -27,9 +27,6 @@ from lib.aio.jsonutil import JsonObject
 from lib.github import GitHub
 from lib.test_mock_server import MockHandler, MockServer
 
-ADDRESS = ("127.0.0.9", 9898)
-
-
 GITHUB_DATA: JsonObject = {
     "/repos/project/repo": {
         "default_branch": "main"
@@ -61,10 +58,10 @@ class Handler(MockHandler[JsonObject]):
 
 class TestGitHubHelpers(unittest.TestCase):
     def setUp(self) -> None:
-        self.server = MockServer(ADDRESS, Handler, GITHUB_DATA)
+        self.server = MockServer(("127.0.0.1", 0), Handler, GITHUB_DATA)
         self.server.start()
         self.temp = tempfile.mkdtemp()
-        os.environ["GITHUB_API"] = "http://127.0.0.9:9898"
+        os.environ["GITHUB_API"] = f"http://{self.server.address[0]}:{self.server.address[1]}"
         os.environ["GITHUB_BASE"] = "project/repo"
         self.github = GitHub()
 

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -34,9 +34,6 @@ from lib.aio.jsonutil import JsonValue
 from lib.constants import BOTS_DIR
 from lib.test_mock_server import MockHandler, MockServer
 
-ADDRESS = ("127.0.0.7", 9898)
-
-
 GITHUB_DATA: dict[str, JsonValue] = {
     "/repos/project/repo": {
         "default_branch": "main"
@@ -133,13 +130,13 @@ class TestTestsScan(unittest.TestCase):
         self.temp = tempfile.mkdtemp()
         self.cache_dir = os.path.join(self.temp, "cache")
         os.environ["XDG_CACHE_HOME"] = self.cache_dir
-        self.server = MockServer(ADDRESS, Handler, GITHUB_DATA)
+        self.server = MockServer(("127.0.0.1", 0), Handler, GITHUB_DATA)
         self.server.start()
         self.repo = "project/repo"
         self.pull_number = 1
         self.context = "fedora/nightly"
         self.revision = "abcdef"
-        os.environ["GITHUB_API"] = f"http://{ADDRESS[0]}:{ADDRESS[1]}"
+        os.environ["GITHUB_API"] = f"http://{self.server.address[0]}:{self.server.address[1]}"
 
         # expected human output for our standard mock PR #1 above
         self.expected_human_output = (


### PR DESCRIPTION
This is another low-hanging fruit hunt which further improves the single-threaded speed of the unit tests (now down to ~4s from an original ~42s) and makes it possible to parallelize them.  It's also a net decrease in complexity and lines of code (mostly due to removing the json logfile stuff).

Building on #9223 and conflicting #9224 due to the shared first commit.