### PR TITLE
lib/git: allow empty when amending for force-push

### DIFF
--- a/lib/git.py
+++ b/lib/git.py
@@ -36,6 +36,11 @@ def _git(
             env[f'GIT_CONFIG_KEY_{i}'] = key
             env[f'GIT_CONFIG_VALUE_{i}'] = value
 
+    # stdout is fully buffered when piped (eg. in GitHub Actions), so flush
+    # both streams before spawning git to keep output in execution order
+    sys.stdout.flush()
+    sys.stderr.flush()
+
     return subprocess.check_output(cmd, env=env, text=True)
 
 

--- a/lib/git.py
+++ b/lib/git.py
@@ -120,8 +120,10 @@ def push(remote: GitHub, topic: str, *, dry_run: bool = False) -> str:
     return branch
 
 
-def amend_and_forcepush(remote: GitHub, branch: str, *, closes: int, dry_run: bool = False) -> None:
-    """Amend the commit with a Closes trailer and force-push.
+def amend_and_forcepush(
+    remote: GitHub, branch: str, *, closes: int | None = None, dry_run: bool = False
+) -> None:
+    """Amend the commit (optionally with a Closes trailer) and force-push.
 
     This is needed to trigger CI: PRs created with GITHUB_TOKEN don't
     generate workflow-triggering events, but a force-push via the deploy
@@ -131,6 +133,7 @@ def amend_and_forcepush(remote: GitHub, branch: str, *, closes: int, dry_run: bo
     if dry_run:
         return
     expected = get_current_head()
-    _git("commit", "--amend", "--no-edit", "--trailer", f"Closes: #{closes}", "--")
+    trailer = ("--trailer", f"Closes: #{closes}") if closes is not None else ()
+    _git("commit", "--amend", "--no-edit", "--allow-empty", *trailer, "--")
     _git("push", f"--force-with-lease=refs/heads/{branch}:{expected}",
          "--", remote.remote, f"HEAD:refs/heads/{branch}", config=remote.config())

--- a/naughty-prune
+++ b/naughty-prune
@@ -78,7 +78,7 @@ def main() -> None:
 
         branch = git.push(github, f"naughty-prune-{number}")
         pr_number = github.create_pull_request(branch, body=body, title=title)
-        git.amend_and_forcepush(github, branch, closes=pr_number)
+        git.amend_and_forcepush(github, branch)
         github.comment(pr_number,
                        "Please comment on the upstream distro bug manually before accepting this "
                        "pull request.\n\nIf you wish to keep this known issue open, then update it")


### PR DESCRIPTION
...and flush stdout/err before subprocesses for better logging output.