### PR TITLE
naughty: Add NetworkManager coredump on Ubuntu 2604

### DIFF
--- a/naughty/ubuntu-2604/9244-networkmanager-segfault
+++ b/naughty/ubuntu-2604/9244-networkmanager-segfault
@@ -1,0 +1,1 @@
+Process * (NetworkManager) of user 0 dumped core.


### PR DESCRIPTION
Happens in several NetworkManager tests and at random so the naughty matches all crashes:

See:

https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/pull-23428-7a69197a-20260703-064751-ubuntu-2604-networking/log.html