### PR TITLE
testmap: drop sub-man branch specification in sub-man-c

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -209,9 +209,9 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
     },
     'cockpit-project/subscription-manager-cockpit': {
         'main': [
-            'centos-9-stream/subscription-manager-1.29',
+            'centos-9-stream',
             'centos-10',
-            'rhel-9-9/subscription-manager-1.29',
+            'rhel-9-9',
             'rhel-10-3',
             'rhel-10-3/devel',
             'fedora-43',


### PR DESCRIPTION
These are not necessary because as of
https://github.com/cockpit-project/subscription-manager-cockpit/pull/312 sub-man-cockpit is tested against the distro packaged version of sub-man by default.