### PR TITLE
Revert "images: Pin freeipa container to an older version"

### DIFF
--- a/image-create
+++ b/image-create
@@ -184,8 +184,8 @@ class MachineBuilder:
 
 try:
     if args.image == 'services':
-        # deploying candlepin needs oodles of memory
-        memory_mb = 3072
+        # deploying candlepin or freeipa needs oodles of memory
+        memory_mb = 4096
     else:
         memory_mb = 2048
 

--- a/image-create
+++ b/image-create
@@ -83,7 +83,7 @@ class MachineBuilder:
     def run_setup_script(self, script: str) -> None:
         """Prepare a test image further by running some commands in it."""
         try:
-            self.machine.boot(timeout_sec=300)
+            self.machine.boot(timeout_sec=480)
             self.machine.upload([os.path.join(testvm.SCRIPTS_DIR, "lib/")], "/var/lib/testvm")
             self.machine.upload([script], "/var/tmp/SETUP")
 

--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -17,7 +17,7 @@ hostnamectl set-hostname services.cockpit.lan
 #############
 
 # see https://quay.io/repository/freeipa/freeipa-server
-# we want centos-9-stream tag here, but newer versions have a time-bomb crash: https://issues.redhat.com/browse/RHEL-76748
+# and https://github.com/freeipa/freeipa-container/issues/346
 setsebool -P container_manage_cgroup 1
 mkdir /var/lib/ipa-data
 
@@ -27,7 +27,7 @@ podman run -d --rm --name freeipa -ti -h f0.cockpit.lan \
     -p $SERVER_IP:53:53/udp -p $SERVER_IP:53:53 -p 80:80 -p 443:443 -p 389:389 -p 636:636 -p 88:88 -p 464:464 -p 88:88/udp -p 464:464/udp -p 123:123/udp \
     -v /var/lib/ipa-data:/data:Z \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-    quay.io/freeipa/freeipa-server:centos-9-stream-4.12.0 \
+    quay.io/freeipa/freeipa-server:centos-9-stream \
     -U -p foobarfoo -a foobarfoo -n cockpit.lan -r COCKPIT.LAN --setup-dns --no-forwarders --no-ntp
 EOF
 chmod 755 /root/run-freeipa

--- a/images/scripts/services.setup
+++ b/images/scripts/services.setup
@@ -23,6 +23,7 @@ mkdir /var/lib/ipa-data
 
 cat <<EOF > /root/run-freeipa
 podman run -d --rm --name freeipa -ti -h f0.cockpit.lan \
+    --dns=$SERVER_IP \
     -e IPA_SERVER_IP=$SERVER_IP \
     -p $SERVER_IP:53:53/udp -p $SERVER_IP:53:53 -p 80:80 -p 443:443 -p 389:389 -p 636:636 -p 88:88 -p 464:464 -p 88:88/udp -p 464:464/udp -p 123:123/udp \
     -v /var/lib/ipa-data:/data:Z \


### PR DESCRIPTION
This reverts commit 947a0926552e6d597713df66a41cb758b652fa7b.

See https://github.com/cockpit-project/cockpit/issues/21564
and https://access.redhat.com/errata/RHBA-2025:7246

This is no longer an issue in newer c9s tags.

Also adds a DNS server to podman-run of FreeIPA

Needed since last year when image was updated and had a breaking change
with how they approach resolved.
