### PR TITLE
testingfarm: move environment constraints into fmf plan

### DIFF
--- a/lib/aio/testingfarm.py
+++ b/lib/aio/testingfarm.py
@@ -106,6 +106,7 @@ class TestingFarmClient(contextlib.AsyncExitStack):
         job: JobSpecification | JsonObject,  # TODO: PEP 728
         *,
         git_url_ref: tuple[str, str] | None = None,
+        compose: str = 'Fedora-44',
     ) -> str:
         """Submit a job to Testing Farm for remote execution.
 
@@ -113,6 +114,7 @@ class TestingFarmClient(contextlib.AsyncExitStack):
             ctx: JobContext with configuration (will be serialized)
             job: Job specification as JSON object
             git_url_ref: Git repository URL and ref (default: from @{upstream})
+            compose: Fedora compose to use (default: Fedora-44)
 
         Returns:
             Testing Farm request ID
@@ -141,6 +143,7 @@ class TestingFarmClient(contextlib.AsyncExitStack):
             'environments': [
                 {
                     'arch': 'x86_64',
+                    'os': {'compose': compose},
                     'variables': {
                         'JOB_JSON': job_json,
                     },

--- a/lib/aio/testingfarm.py
+++ b/lib/aio/testingfarm.py
@@ -106,7 +106,6 @@ class TestingFarmClient(contextlib.AsyncExitStack):
         job: JobSpecification | JsonObject,  # TODO: PEP 728
         *,
         git_url_ref: tuple[str, str] | None = None,
-        compose: str = 'Fedora-Rawhide',
     ) -> str:
         """Submit a job to Testing Farm for remote execution.
 
@@ -114,7 +113,6 @@ class TestingFarmClient(contextlib.AsyncExitStack):
             ctx: JobContext with configuration (will be serialized)
             job: Job specification as JSON object
             git_url_ref: Git repository URL and ref (default: from @{upstream})
-            compose: Fedora compose to use (default: Fedora-Rawhide)
 
         Returns:
             Testing Farm request ID
@@ -142,27 +140,14 @@ class TestingFarmClient(contextlib.AsyncExitStack):
             },
             'environments': [
                 {
-                    'arch': 'x86_64',
-                    'os': {'compose': compose},
                     'variables': {
                         'JOB_JSON': job_json,
                     },
                     'secrets': {
                         'JOB_RUNNER_CONFIG_JSON': config_json,
                     },
-                    'hardware': {
-                        'virtualization': {
-                            'is-virtualized': True,
-                            'is-supported': True,
-                        }
-                    },
                 }
             ],
-            'settings': {
-                'pipeline': {
-                    'timeout': 120,
-                }
-            },
         }
 
         url = f'{self.api_url}/requests'

--- a/lib/aio/testingfarm.py
+++ b/lib/aio/testingfarm.py
@@ -140,6 +140,7 @@ class TestingFarmClient(contextlib.AsyncExitStack):
             },
             'environments': [
                 {
+                    'arch': 'x86_64',
                     'variables': {
                         'JOB_JSON': job_json,
                     },

--- a/plans/job-runner.fmf
+++ b/plans/job-runner.fmf
@@ -8,7 +8,6 @@ provision:
         disk:
           - size: ">= 60 GiB"
         virtualization:
-            #is-virtualized: true
             is-supported: true
 
 prepare:

--- a/plans/job-runner.fmf
+++ b/plans/job-runner.fmf
@@ -1,4 +1,16 @@
 summary: Run job-runner task remotely
+provision:
+    how: virtual
+    arch: x86_64
+    image: Fedora-44
+    hardware:
+        memory: ">= 4 GB"
+        disk:
+          - size: ">= 60 GiB"
+        virtualization:
+            #is-virtualized: true
+            is-supported: true
+
 prepare:
     how: install
     package:
@@ -16,4 +28,4 @@ execute:
 /job-runner:
     summary: Run job-runner task
     test: ../job-runner json "$JOB_JSON"
-    duration: 2h
+    duration: 4h

--- a/plans/job-runner.fmf
+++ b/plans/job-runner.fmf
@@ -4,8 +4,6 @@ provision:
     image: Fedora-44
     hardware:
         memory: ">= 4 GB"
-        disk:
-          - size: ">= 60 GiB"
         virtualization:
             is-supported: true
 

--- a/plans/job-runner.fmf
+++ b/plans/job-runner.fmf
@@ -1,6 +1,5 @@
 summary: Run job-runner task remotely
 provision:
-    how: virtual
     arch: x86_64
     image: Fedora-44
     hardware:


### PR DESCRIPTION
Env constraints should be inside FMF plan file instead of hard-coding them in the API request, it is intended to override these values inside plan.
 - arch
 - compose (Fedora-44)
 - virtualization support
 - hardware requirements (memory >= 4 GB, disk >= 60 GiB) . 
  
 Drop these parameters from submit_job() and remove the explicit pipeline timeout, relying on Testing Farm defaults.