### PR TITLE
Improve the generated SSH command

### DIFF
--- a/machine/machine_core/machine.py
+++ b/machine/machine_core/machine.py
@@ -34,7 +34,7 @@ TTY LOGIN
 """
 REMOTE_MESSAGE = """
 SSH ACCESS
-  $ ssh -p {ssh_port} -i bots/machine/identity {ssh_user}@{ssh_address}
+  $ ssh -p {ssh_port} -i bots/machine/identity {ssh_user}@{ssh_address} {key_options}
 
 COCKPIT
   https://{web_address}:{web_port}
@@ -125,6 +125,7 @@ class Machine(ssh_connection.SSHConnection):
             "ssh_port": self.ssh_port,
             "web_address": self.web_address,
             "web_port": self.web_port,
+            "key_options": '-o "UserKnownHostsFile=/dev/null" "-o StrictHostKeyChecking=accept-new"',
         }
         message = (LOCAL_MESSAGE if tty else '') + REMOTE_MESSAGE
         return message.format(**keys)


### PR DESCRIPTION
Currently the generated SSH connection command works, but causes two main issues in its current form:
* SSH key ends up being saved persistently on the host for the ephemeral VM
* the user is asked to verify the ephemeral host key is correct, which is useless

So add two more options to the generated SSH command:
* an option no to save the key to the known-hosts file
* an option not to ask for key validation

This should improve the user experience when connecting to machines spawned by bots, as there will be no more need to manually wipe stale keys from past test VMs and being asked to validate ephemeral keys.

Instead, the user should be logged in to the VM immediately every time.