### PR TITLE
rhel setup: add dependencies for subscription-manager setup

### DIFF
--- a/images/scripts/rhel.setup
+++ b/images/scripts/rhel.setup
@@ -213,6 +213,14 @@ sssd \
 sssd-dbus \
 "
 
+SUB_MAN_PACKAGES="\
+python3-devel
+python3-setuptools
+openssl-devel
+intltool
+gcc
+"
+
 TEST_PACKAGES="\
 acl \
 ansible-core \
@@ -314,7 +322,7 @@ PACKAGE_SET_STRATIS="\
 stratisd
 "
 
-dnf install -y $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES
+dnf install -y $TEST_PACKAGES $COCKPIT_DEPS $IPA_CLIENT_PACKAGES $SUB_MAN_PACKAGES
 
 mkdir -p /var/lib/package-sets/clevis
 dnf download --downloaddir=/var/lib/package-sets/clevis $PACKAGE_SET_CLEVIS


### PR DESCRIPTION
Subscription-manager-cockpit needs these packages in vm.install-sub-man but since on the AWS cluster the image-customize script can't access RHEL repositories it makes it impossible to test sub-man-cockpit with a specific sub-man checkout.