### PR TITLE
image-trigger: Label image-refresh issues

### DIFF
--- a/image-trigger
+++ b/image-trigger
@@ -126,7 +126,7 @@ def scan(api: github.GitHub, force: str | None, verbose: bool, dry: bool = False
             sys.stderr.write(f'#{issues[title]}: {title} (already open)\n')
             continue
 
-        data = {"title": title, "body": body, "labels": ["bot"]}
+        data = {"title": title, "body": body, "labels": ["bot", "image-refresh"]}
         if dry:
             print(f'** Would open issue on {api.repo}', json.dumps(data, indent=4))
         else:


### PR DESCRIPTION
Introduce a custom "image-refresh" label for all open image-refresh issues. This allows them to be easily added to the pilot issues board.