### PR TITLE
testmap: Fix backport branches contexts

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -70,6 +70,8 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         ],
         'rhel-9.8': [
             *contexts('rhel-9-8', COCKPIT_SCENARIOS),
+        ],
+        'rhel-10.2': [
             *contexts('rhel-10-2', COCKPIT_SCENARIOS),
         ],
         # These can be triggered manually with bots/tests-trigger


### PR DESCRIPTION
Trigger the specific rhel images only on required backport branch.