### PR TITLE
Revert "testmap: Fix backport branches contexts"

### DIFF
--- a/lib/testmap.py
+++ b/lib/testmap.py
@@ -70,8 +70,6 @@ REPO_BRANCH_CONTEXT: Mapping[str, Mapping[str, Sequence[str]]] = {
         ],
         'rhel-9.8': [
             *contexts('rhel-9-8', COCKPIT_SCENARIOS),
-        ],
-        'rhel-10.2': [
             *contexts('rhel-10-2', COCKPIT_SCENARIOS),
         ],
         # These can be triggered manually with bots/tests-trigger


### PR DESCRIPTION
This reverts commit ed71213187f8ba4a11c931907ca13829160e7014.

We maintain one backport branch for RHEL9.8/10.2