### PR TITLE
anaconda-comps: add custom-environment so software selection works

### DIFF
--- a/images/fedora-rawhide-anaconda-payload
+++ b/images/fedora-rawhide-anaconda-payload
@@ -1,1 +1,1 @@
-fedora-rawhide-anaconda-payload-6fd935c58fba49f783ab82b81ee801276dada649ab4890d6752b6eb25080ca04.tar.gz
+fedora-rawhide-anaconda-payload-9d740caf7c28bd0481caddf25ae07667f1bd98c7e2d09796883a693a50dd7bab.tar.gz

--- a/images/scripts/create-anaconda-dnf-payload
+++ b/images/scripts/create-anaconda-dnf-payload
@@ -62,6 +62,7 @@ def build_dnf_payload(image: str, output: str) -> None:
     machine = testvm.VirtMachine(image=image, memory_mb=4096)
     try:
         machine.boot()
+        machine.execute("rm -f /usr/share/dnf5/repos.d/fedora-cisco-openh264.repo")
         machine.execute("dnf install -y createrepo_c", timeout=300)
 
         # Ensure target repo directory exists

--- a/images/scripts/create-anaconda-liveimg-payload
+++ b/images/scripts/create-anaconda-liveimg-payload
@@ -76,6 +76,9 @@ def build_payload(image: str, output: str) -> None:
             timeout=1200
         )
 
+        # dirinstall labels files using the host's SELinux policy; relabel with the target's
+        machine.execute("chroot /mnt/sysimage restorecon -R /", timeout=600)
+
         # Change directory to /mnt/sysimage/ and create archive
         machine.execute("""
             cd /mnt/sysimage

--- a/images/scripts/create-anaconda-liveimg-payload
+++ b/images/scripts/create-anaconda-liveimg-payload
@@ -63,6 +63,7 @@ def build_payload(image: str, output: str) -> None:
     machine = testvm.VirtMachine(image=image, memory_mb=4096)
     try:
         machine.boot()
+        machine.execute("rm -f /usr/share/dnf5/repos.d/fedora-cisco-openh264.repo")
         machine.execute("dnf install -y anaconda", timeout=300)
 
         # anaconda dirinstall can break host SELinux labels, preventing new SSH logins

--- a/images/scripts/lib/anaconda-comps.xml
+++ b/images/scripts/lib/anaconda-comps.xml
@@ -64,4 +64,17 @@
       <packagereq type="mandatory">kernel</packagereq>
     </packagelist>
   </group>
+
+  <environment>
+    <id>custom-environment</id>
+    <name>Custom Operating System</name>
+    <description>Basic building block for a custom operating system.</description>
+    <display_order>99</display_order>
+    <grouplist>
+      <groupid>core</groupid>
+    </grouplist>
+    <optionlist>
+      <groupid>anaconda-tools</groupid>
+    </optionlist>
+  </environment>
 </comps>


### PR DESCRIPTION
The anaconda webui software selection screen requires at least one environment to be available. Without it the screen stays disabled and blocks the installation.