### PR TITLE
infractl: add 'dispatcher set amqp-server'

### DIFF
--- a/lib/aws/infra_definitions.py
+++ b/lib/aws/infra_definitions.py
@@ -497,6 +497,10 @@ def update_bots_urls(
         ensure_parameter(f"{DISPATCHER_PARAMS}/runner-url", cockpit_bots_url)
 
 
+def update_amqp_server(server: str) -> None:
+    ensure_parameter(f"{DISPATCHER_PARAMS}/amqp-server", server)
+
+
 def update_max_jobs(count: int) -> None:
     ensure_parameter(f"{DISPATCHER_PARAMS}/max-active", str(count))
 
@@ -514,17 +518,11 @@ def upload_secrets(secrets: Mapping[str, str]) -> None:
 
 def sync_ssm(*, cockpit_bots_url: str, secrets: Mapping[str, str]) -> None:
     print("\n## SSM")
-    ensure_parameter(
-        f"{DISPATCHER_PARAMS}/amqp-server",
-        "amqp-cockpit.apps.ocp.cloud.ci.centos.org:443",
-    )
+    update_amqp_server("amqp-cockpit.apps.ocp.cloud.ci.centos.org:443")
     update_bots_urls(cockpit_bots_url)
-    ensure_parameter(f"{DISPATCHER_PARAMS}/max-active", "50")
-    ensure_parameter(f"{DISPATCHER_PARAMS}/max-awaiting-logs", "20")
-    for name, value in sorted(secrets.items()):
-        ensure_parameter(
-            f"{DISPATCHER_PARAMS}/secrets/{name}", value, param_type="SecureString"
-        )
+    update_max_jobs(50)
+    update_max_awaiting_logs(20)
+    upload_secrets(secrets)
 
 
 def sync_infra(*, cockpit_bots_url: str, secrets: Mapping[str, str]) -> set[str]:

--- a/lib/aws/infractl.py
+++ b/lib/aws/infractl.py
@@ -27,6 +27,7 @@ from .ec2 import (
 )
 from .infra_definitions import (
     sync_infra,
+    update_amqp_server,
     update_bots_urls,
     update_max_awaiting_logs,
     update_max_jobs,
@@ -122,6 +123,12 @@ def cmd_dispatcher_ssh(_args: argparse.Namespace) -> None:
             ssh_to_instance(instance, "admin")
             return
     sys.exit("no running dispatcher instance found")
+
+
+def cmd_dispatcher_set_amqp_server(args: argparse.Namespace) -> None:
+    logger.debug("setting amqp-server to %r", args.server)
+    update_amqp_server(args.server)
+    remind_restart(args.prog)
 
 
 def cmd_dispatcher_set_max_jobs(args: argparse.Namespace) -> None:
@@ -316,6 +323,12 @@ def main() -> None:
 
     dispatcher_set = dispatcher_cmds.add_parser("set", help="Configure dispatcher")
     dispatcher_set_cmds = dispatcher_set.add_subparsers(required=True)
+
+    dispatcher_set_amqp_server = dispatcher_set_cmds.add_parser("amqp-server",
+        help="Set the AMQP server address")
+    dispatcher_set_amqp_server.add_argument("server",
+                                            help="AMQP server address (host:port)")
+    dispatcher_set_amqp_server.set_defaults(func=cmd_dispatcher_set_amqp_server)
 
     dispatcher_set_max_jobs = dispatcher_set_cmds.add_parser("max-jobs",
         help="Set the maximum number of concurrently active jobs")


### PR DESCRIPTION
This allows live switching of the amqp-server parameter used by the dispatcher.

This is supported via new update_amqp_server() function in `infra_definitions.py` which is what all of the existing `set` verbs have.

While we're at it, update `sync_ssm()` to use the `update_*` functions for everything instead of duplicating that logic.