### PR TITLE
cockpit-container-update: Script to update Containerfile automatically

### DIFF
--- a/cockpit-container-update
+++ b/cockpit-container-update
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Red Hat, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Update the cockpit-ws and cockpit-tasks container to the latest stable Fedora
+# automatically.
+
+import argparse
+import pathlib
+import re
+
+import fedora_distro_aliases
+
+from lib import git
+from lib.github import GitHub
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update Containerfile to latest stable Fedora")
+    parser.add_argument("-n", "--dry-run", action="store_true", help="Dry run")
+    parser.add_argument('containerfile', type=pathlib.Path)
+    args = parser.parse_args()
+
+    aliases = fedora_distro_aliases.get_distro_aliases()
+    latest_stable = aliases["fedora-latest-stable"][0].major_version
+    print(f"Latest stable Fedora: {latest_stable}")
+
+    content = args.container_file.read_text()
+    match = re.search(r"^(FROM\s+.*fedora:)(\d+)", content, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not find Fedora version in {args.containerfile}")
+
+    current = int(match.group(2))
+    print(f"Current Containerfile uses: fedora:{current}")
+
+    if current == latest_stable:
+        print("Already up to date")
+        return
+
+    content = re.sub(r"(FROM\s+.*fedora:)\d+", rf"\g<1>{latest_stable}", content)
+    args.container_file.write_text(content)
+
+    title = f"{args.containerfile.parent.name}: Update container base image to Fedora {latest_stable}"
+    body = f"Fedora {latest_stable} is now the latest stable release."
+
+    git.add(args.containerfile)
+    git.commit(f"{title}\n\n{body}")
+
+    github = GitHub()
+    branch = git.push(github, "cockpit-container-update", dry_run=args.dry_run)
+    github.create_pull_request(branch, title=title, body=body, dry_run=args.dry_run)
+    git.amend_and_forcepush(github, branch, dry_run=args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ module = [
     'boto3',
     'botocore',
     'botocore.*',
+    'fedora_distro_aliases',
     'libvirt',
     'libvirt_qemu',
     'nacl',


### PR DESCRIPTION
Automate the updating of the Fedora containers we use in CI (cockpit-tasks) and cockpit-ws to the latest stable Fedora release.

This script can be used in our GitHub workflows like `cockpit-lib-update` and gets rid of manual often forgotten tasks.

---

Depends on a tasks container update https://github.com/cockpit-project/cockpituous/pull/715

Tested on both cockpituous and cockpit main. Would either run weekly, every two weeks or monthly. Whatever is enough to make us not forget.

```
cockpit-bots/cockpit-container-update --dry-run --containerfile tasks/container/Containerfile
```