### PR TITLE
various: drop the 'rhel' queue

### DIFF
--- a/inspect-queue
+++ b/inspect-queue
@@ -35,7 +35,7 @@ def main() -> int:
                         help='Directory with ca.pem and amqp-client.{pem,key} (default: %(default)s)')
     opts = parser.parse_args()
 
-    with distributed_queue.DistributedQueue(opts.amqp, ['public', 'rhel', 'statistics', 'webhook'],
+    with distributed_queue.DistributedQueue(opts.amqp, ['public', 'statistics', 'webhook'],
                                             secrets_dir=opts.secrets_dir, passive=True) as q:
         def print_queue(queue: str) -> None:
             message_count = q.queue_counts.get(queue, 0)
@@ -53,8 +53,6 @@ def main() -> int:
 
         print('public queue:')
         print_queue('public')
-        print('rhel queue:')
-        print_queue('rhel')
         print('statistics queue:')
         print_queue('statistics')
         print('webhook queue:')

--- a/lib/distributed_queue.py
+++ b/lib/distributed_queue.py
@@ -48,9 +48,6 @@ DEFAULT_AMQP_SERVER = 'amqp-cockpit.apps.ocp.cloud.ci.centos.org:443'
 # DEFAULT_AMQP_SERVER = 'ec2-3-228-126-27.compute-1.amazonaws.com:5671'
 
 arguments = {
-    'rhel': {
-        "x-max-priority": MAX_PRIORITY
-    },
     'public': {
         "x-max-priority": MAX_PRIORITY
     },

--- a/lib/network.py
+++ b/lib/network.py
@@ -18,9 +18,7 @@
 # Shared GitHub code. When run as a script, we print out info about
 # our GitHub interacition.
 
-import functools
 import os
-import socket
 import ssl
 
 from lib.constants import IMAGES_DIR
@@ -67,18 +65,3 @@ def host_ssl_context(hostname: str) -> ssl.SSLContext | None:
     """
     cafile = get_host_ca(hostname)
     return ssl.create_default_context(cafile=cafile) if cafile else None
-
-
-@functools.lru_cache
-def redhat_network() -> bool:
-    """Check if we can access the Red Hat network
-
-    The result gets cached, so this can be called several times.
-    """
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(10)
-        s.connect(("download.devel.redhat.com", 443))
-        return True
-    except OSError:
-        return False

--- a/run-queue
+++ b/run-queue
@@ -22,7 +22,6 @@ import json
 import logging
 import os
 import platform
-import random
 import smtplib
 import subprocess
 import sys
@@ -33,7 +32,6 @@ import pika
 
 from lib import distributed_queue
 from lib.directories import get_images_data_dir
-from lib.network import redhat_network
 from lib.stores import LOG_STORE
 
 logging.basicConfig(level=logging.INFO)
@@ -101,13 +99,6 @@ def consume_task_queue(dq: distributed_queue.DistributedQueue) -> ConsumeResult:
     elif os.path.exists('/dev/kvm') or os.getenv('JOB_RUNNER_CONFIG'):
         # only process test queues in capable environments: with KVM or job-runner support
         queue = 'public'
-        if redhat_network():
-            # Try the rhel queue if the public queue is empty
-            if dq.queue_counts['public'] == 0:
-                queue = 'rhel'
-                # If both are non-empty, shuffle
-            elif dq.queue_counts['rhel'] > 0:
-                queue = ['public', 'rhel'][random.randrange(2)]
     else:
         # nothing to do
         return None, None
@@ -149,7 +140,7 @@ def main() -> int:
                         help='The host:port of the AMQP server to consume from (default: %(default)s)')
     opts = parser.parse_args()
 
-    with distributed_queue.DistributedQueue(opts.amqp, ['webhook', 'rhel', 'public', 'statistics']) as dq:
+    with distributed_queue.DistributedQueue(opts.amqp, ['webhook', 'public', 'statistics']) as dq:
         cmd, delivery_tag = consume_webhook_queue(dq)
         if not cmd and delivery_tag:
             logging.info("Webhook message interpretation generated no command")

--- a/test/test_tests_scan.py
+++ b/test/test_tests_scan.py
@@ -254,7 +254,7 @@ class TestTestsScan(unittest.TestCase):
         args = ["--dry", "--context", self.context, "--amqp", "amqp.example.com:1234"]
         self.run_success(args, "")
 
-        mock_queue.assert_called_once_with("amqp.example.com:1234", ["rhel", "public"])
+        mock_queue.assert_called_once_with("amqp.example.com:1234", ["public"])
         channel = mock_queue.return_value.__enter__.return_value.channel
 
         channel.basic_publish.assert_called_once()
@@ -292,7 +292,7 @@ class TestTestsScan(unittest.TestCase):
         args = ["--dry", "--context", self.context, "--sha", "9988aa", "--amqp", "amqp.example.com:1234"]
         self.run_success(args, "")
 
-        mock_queue.assert_called_once_with("amqp.example.com:1234", ["rhel", "public"])
+        mock_queue.assert_called_once_with("amqp.example.com:1234", ["public"])
         channel = mock_queue.return_value.__enter__.return_value.channel
 
         channel.basic_publish.assert_called_once()
@@ -332,7 +332,7 @@ class TestTestsScan(unittest.TestCase):
                 "--sha", "112233", "--amqp", "amqp.example.com:1234"]
         self.run_success(args, "")
 
-        mock_queue.assert_called_once_with("amqp.example.com:1234", ["rhel", "public"])
+        mock_queue.assert_called_once_with("amqp.example.com:1234", ["public"])
         channel = mock_queue.return_value.__enter__.return_value.channel
 
         channel.basic_publish.assert_called_once()
@@ -372,7 +372,7 @@ class TestTestsScan(unittest.TestCase):
         args = ["--dry", "--context", self.context, "--sha", "abcdef", "--amqp", "amqp.example.com:1234"]
         self.run_success(args, "")
 
-        mock_queue.assert_called_once_with("amqp.example.com:1234", ["rhel", "public"])
+        mock_queue.assert_called_once_with("amqp.example.com:1234", ["public"])
         channel = mock_queue.return_value.__enter__.return_value.channel
 
         channel.basic_publish.assert_called_once()
@@ -415,7 +415,7 @@ class TestTestsScan(unittest.TestCase):
                 "--context", f"{self.context}@{repo_branch}"]
         self.run_success(args, "")
 
-        mock_queue.assert_called_once_with("amqp.example.com:1234", ["rhel", "public"])
+        mock_queue.assert_called_once_with("amqp.example.com:1234", ["public"])
         channel = mock_queue.return_value.__enter__.return_value.channel
 
         channel.basic_publish.assert_called_once()

--- a/tests-scan
+++ b/tests-scan
@@ -302,7 +302,7 @@ def scan_for_pull_tasks(api: github.GitHub, contexts: Sequence[str], opts: argpa
         for entry in results:
             print(json.dumps(entry['job'], indent=4))
     else:
-        with distributed_queue.DistributedQueue(opts.amqp, ['rhel', 'public']) as dq:
+        with distributed_queue.DistributedQueue(opts.amqp, ['public']) as dq:
             for entry in results:
                 queue_test(entry, dq=dq)
 


### PR DESCRIPTION
We no longer send jobs here and nothing reads from it.

Also drop the redhat_network() function because we no longer need it to determine if we should read from the rhel queue or not.