### PR TITLE
lib/aws: add 'infractl costs'

### DIFF
--- a/lib/aws/ensure_resource.py
+++ b/lib/aws/ensure_resource.py
@@ -269,10 +269,14 @@ def ensure_bucket(
         else:
             s3.create_bucket(Bucket=name)
 
-    # Tags
+    # Tags — Name is included so Cost Explorer can group S3 costs by bucket.
     s3.put_bucket_tagging(
         Bucket=name,
-        Tagging={"TagSet": [{"Key": k, "Value": v} for k, v in TAGS.items()]},
+        Tagging={
+            "TagSet": [
+                {"Key": k, "Value": v} for k, v in {**TAGS, "Name": name}.items()
+            ]
+        },
     )
 
     # Ownership controls (disable ACLs)

--- a/lib/aws/infra_definitions.py
+++ b/lib/aws/infra_definitions.py
@@ -259,6 +259,7 @@ def sync_iam() -> None:
                 [
                     "ec2:DescribeInstances",
                     "autoscaling:DescribeAutoScalingGroups",
+                    "ce:GetCostAndUsage",
                 ],
                 "*",
             ),

--- a/lib/aws/infractl.py
+++ b/lib/aws/infractl.py
@@ -10,14 +10,16 @@ import logging
 import os
 import sys
 from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import boto3
 
 from ..aio.jsonutil import get_str
 from ..github import GitHub
-from .account import CI_RUNNER_REGION, DISPATCHER_ASG, DISPATCHER_NAME
+from .account import CI_RUNNER_REGION, DISPATCHER_ASG, DISPATCHER_NAME, MANDATORY_TAGS
 from .ec2 import (
     describe_runner_instances,
     get_instance_ip,
@@ -35,6 +37,7 @@ from .infra_definitions import (
 )
 
 if TYPE_CHECKING:
+    from types_boto3_ce.type_defs import ExpressionTypeDef, GroupTypeDef
     from types_boto3_ec2.type_defs import InstanceTypeDef
 
 logger = logging.getLogger(__name__)
@@ -192,6 +195,85 @@ def cmd_dispatcher_console(_args: argparse.Namespace) -> None:
     if not instances:
         sys.exit("no dispatcher instance found")
     print_console_output(ec2, instances[0])
+
+
+# --- costs ---
+
+
+def cmd_costs(args: argparse.Namespace) -> None:
+    today = datetime.now(tz=timezone.utc).date()
+
+    granularity: Literal["DAILY", "MONTHLY"]
+    if args.days is not None:
+        start = today - timedelta(days=args.days)
+        granularity = "DAILY"
+    else:
+        start = today.replace(day=1)  # first of the month
+        for _ in range(args.months - 1):
+            start = (start - timedelta(days=1)).replace(day=1)  # first of the previous
+        granularity = "MONTHLY"
+
+    ce = boto3.client("ce")
+    logger.debug(
+        "querying costs from %r to %r with granularity %r", start, today, granularity
+    )
+
+    @cache
+    def query(service: str | None = None) -> dict[str, list[GroupTypeDef]]:
+        group_by: list[tuple[Literal["DIMENSION", "TAG"], str]]
+        match service:
+            case None:
+                group_by = [("DIMENSION", "SERVICE")]
+            case "Amazon Elastic Compute Cloud - Compute":
+                group_by = [("DIMENSION", "INSTANCE_TYPE")]
+            case "Amazon Simple Storage Service":
+                group_by = [("TAG", "Name"), ("DIMENSION", "USAGE_TYPE")]
+            case _:
+                group_by = [("DIMENSION", "USAGE_TYPE")]
+
+        filter_expr: ExpressionTypeDef = {
+            "Tags": {"Key": "app-code", "Values": [MANDATORY_TAGS["app-code"]]}
+        }
+        if service is not None:
+            filter_expr = {
+                "And": [
+                    filter_expr,
+                    {"Dimensions": {"Key": "SERVICE", "Values": [service]}},
+                ]
+            }
+
+        logger.debug("ce.get_cost_and_usage service=%r, group_by=%r", service, group_by)
+
+        result = ce.get_cost_and_usage(
+            TimePeriod={"Start": start.isoformat(), "End": today.isoformat()},
+            Granularity=granularity,
+            Metrics=["UnblendedCost", "UsageQuantity"],
+            Filter=filter_expr,
+            GroupBy=[{"Type": t, "Key": k} for t, k in group_by],
+        )["ResultsByTime"]
+
+        return {p["TimePeriod"]["Start"]: p["Groups"] for p in result}
+
+    for period_start, groups in query().items():
+        print(f"\n## From {period_start} ({granularity.lower()})")
+        total = 0.0
+        for group in groups:
+            (service,) = group["Keys"]
+            amount = float(group["Metrics"]["UnblendedCost"]["Amount"])
+            total += amount
+            if args.verbose >= 1:
+                print(f"  {service:<45}  ${amount:>8.2f}")
+            if args.verbose >= 2:
+                for sub in query(service).get(period_start, []):
+                    cost = float(sub["Metrics"]["UnblendedCost"]["Amount"])
+                    if cost < 0.10 and args.verbose < 3:
+                        continue
+                    name = " / ".join(sub["Keys"])
+                    quantity = float(sub["Metrics"]["UsageQuantity"]["Amount"])
+                    unit = sub["Metrics"]["UsageQuantity"]["Unit"]
+                    usage = f"  {quantity:.2f} {unit}" if unit != "N/A" else ""
+                    print(f"    {name:<43}  ${cost:>8.2f}{usage}")
+        print(f"  {'Total':<45}  ${total:>8.2f}")
 
 
 # --- runner ---
@@ -375,6 +457,18 @@ def main() -> None:
         help="Show EC2 console output for a runner")
     runner_console.add_argument("slug")
     runner_console.set_defaults(func=cmd_runner_console)
+
+    # --- costs ---
+
+    costs = sub.add_parser("costs", help="Show AWS costs for cockpit-ci resources")
+    costs_range = costs.add_mutually_exclusive_group()
+    costs_range.add_argument("--days", type=int, metavar="N",
+        help="Show last N days (daily breakdown)")
+    costs_range.add_argument("--months", type=int, metavar="N", default=3,
+        help="Show last N months, monthly breakdown (default: 3)")
+    costs.add_argument("-v", action="count", default=0, dest="verbose",
+        help="-v: per-service, -vv: sub-items (>=0.10), -vvv: all sub-items")
+    costs.set_defaults(func=cmd_costs)
 
     # fmt: on
 

--- a/lib/aws/infractl.py
+++ b/lib/aws/infractl.py
@@ -224,6 +224,8 @@ def cmd_costs(args: argparse.Namespace) -> None:
         match service:
             case None:
                 group_by = [("DIMENSION", "SERVICE")]
+            case "Amazon Elastic Compute Cloud - Compute" if args.slugs:
+                group_by = [("TAG", "Name")]
             case "Amazon Elastic Compute Cloud - Compute":
                 group_by = [("DIMENSION", "INSTANCE_TYPE")]
             case "Amazon Simple Storage Service":
@@ -468,6 +470,8 @@ def main() -> None:
         help="Show last N days (daily breakdown)")
     costs_range.add_argument("--months", type=int, metavar="N", default=3,
         help="Show last N months, monthly breakdown (default: 3)")
+    costs.add_argument("--slugs", action="store_true",
+        help="Break down EC2 compute by instance name instead of instance type")
     costs.add_argument("-v", action="count", default=0, dest="verbose",
         help="-v: per-service, -vv: sub-items (>=0.10), -vvv: all sub-items")
     costs.set_defaults(func=cmd_costs)

--- a/lib/aws/infractl.py
+++ b/lib/aws/infractl.py
@@ -262,18 +262,20 @@ def cmd_costs(args: argparse.Namespace) -> None:
             amount = float(group["Metrics"]["UnblendedCost"]["Amount"])
             total += amount
             if args.verbose >= 1:
-                print(f"  {service:<45}  ${amount:>8.2f}")
+                print(f"  ${amount:>8.2f}  {'':19}  {service}")
             if args.verbose >= 2:
                 for sub in query(service).get(period_start, []):
                     cost = float(sub["Metrics"]["UnblendedCost"]["Amount"])
                     if cost < 0.10 and args.verbose < 3:
                         continue
-                    name = " / ".join(sub["Keys"])
+                    name = " / ".join(k.removeprefix("Name$") for k in sub["Keys"])
                     quantity = float(sub["Metrics"]["UsageQuantity"]["Amount"])
                     unit = sub["Metrics"]["UsageQuantity"]["Unit"]
-                    usage = f"  {quantity:.2f} {unit}" if unit != "N/A" else ""
-                    print(f"    {name:<43}  ${cost:>8.2f}{usage}")
-        print(f"  {'Total':<45}  ${total:>8.2f}")
+                    usage = f"{quantity:.2f} {unit}" if unit != "N/A" else ""
+                    print(f"  ${cost:>8.2f}  {usage:<19}    {name}")
+                print()
+        print(f"  ${total:>8.2f}  {'':19}  Total")
+        print()
 
 
 # --- runner ---

--- a/lib/aws/infractl.py
+++ b/lib/aws/infractl.py
@@ -6,14 +6,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 import boto3
 
@@ -200,6 +201,24 @@ def cmd_dispatcher_console(_args: argparse.Namespace) -> None:
 # --- costs ---
 
 
+class CostItem(TypedDict):
+    keys: Sequence[str]
+    cost: float
+    quantity: float
+    unit: str
+
+
+class CostService(TypedDict):
+    cost: float
+    items: Sequence[CostItem]
+
+
+class CostPeriod(TypedDict):
+    granularity: str
+    total: float
+    services: Mapping[str, CostService]
+
+
 def cmd_costs(args: argparse.Namespace) -> None:
     today = datetime.now(tz=timezone.utc).date()
 
@@ -256,27 +275,56 @@ def cmd_costs(args: argparse.Namespace) -> None:
 
         return {p["TimePeriod"]["Start"]: p["Groups"] for p in result}
 
-    for period_start, groups in query().items():
-        print(f"\n## From {period_start} ({granularity.lower()})")
-        total = 0.0
-        for group in groups:
-            (service,) = group["Keys"]
-            amount = float(group["Metrics"]["UnblendedCost"]["Amount"])
-            total += amount
-            if args.verbose >= 1:
-                print(f"  ${amount:>8.2f}  {'':19}  {service}")
-            if args.verbose >= 2:
-                for sub in query(service).get(period_start, []):
-                    cost = float(sub["Metrics"]["UnblendedCost"]["Amount"])
-                    if cost < 0.10 and args.verbose < 3:
-                        continue
-                    name = " / ".join(k.removeprefix("Name$") for k in sub["Keys"])
-                    quantity = float(sub["Metrics"]["UsageQuantity"]["Amount"])
-                    unit = sub["Metrics"]["UsageQuantity"]["Unit"]
-                    usage = f"{quantity:.2f} {unit}" if unit != "N/A" else ""
-                    print(f"  ${cost:>8.2f}  {usage:<19}    {name}")
-                print()
-        print(f"  ${total:>8.2f}  {'':19}  Total")
+    periods: Mapping[str, CostPeriod] = {
+        period_start: {
+            "granularity": granularity.lower(),
+            "total": sum(
+                float(g["Metrics"]["UnblendedCost"]["Amount"]) for g in groups
+            ),
+            "services": {
+                service: {
+                    "cost": float(group["Metrics"]["UnblendedCost"]["Amount"]),
+                    "items": [
+                        {
+                            "keys": list(sub["Keys"]),
+                            "cost": float(sub["Metrics"]["UnblendedCost"]["Amount"]),
+                            "quantity": float(
+                                sub["Metrics"]["UsageQuantity"]["Amount"]
+                            ),
+                            "unit": sub["Metrics"]["UsageQuantity"]["Unit"],
+                        }
+                        for sub in query(service).get(period_start, [])
+                    ],
+                }
+                for group in groups
+                for service in (group["Keys"][0],)
+            },
+        }
+        for period_start, groups in query().items()
+    }
+
+    if args.json:
+        print(json.dumps(periods, indent=4))
+        return
+
+    for period_start, period in periods.items():
+        print(f"\n## From {period_start} ({period['granularity']})")
+        if args.verbose >= 1:
+            for service, svc in period["services"].items():
+                print(f"  ${svc['cost']:>8.2f}  {'':19}  {service}")
+                if args.verbose >= 2:
+                    for item in svc["items"]:
+                        if item["cost"] < 0.10 and args.verbose < 3:
+                            continue
+                        name = " / ".join(k.removeprefix("Name$") for k in item["keys"])
+                        usage = (
+                            f"{item['quantity']:.2f} {item['unit']}"
+                            if item["unit"] != "N/A"
+                            else ""
+                        )
+                        print(f"  ${item['cost']:>8.2f}  {usage:<19}    {name}")
+                    print()
+        print(f"  ${period['total']:>8.2f}  {'':19}  Total")
         print()
 
 
@@ -474,6 +522,8 @@ def main() -> None:
         help="Break down EC2 compute by instance name instead of instance type")
     costs.add_argument("-v", action="count", default=0, dest="verbose",
         help="-v: per-service, -vv: sub-items (>=0.10), -vvv: all sub-items")
+    costs.add_argument("--json", action="store_true",
+        help="Output raw JSON instead of human-readable text")
     costs.set_defaults(func=cmd_costs)
 
     # fmt: on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ module = [
     'libvirt_qemu',
     'nacl',
     'types_boto3_autoscaling.*',
+    'types_boto3_ce',
+    'types_boto3_ce.*',
     'types_boto3_ec2',
     'types_boto3_ec2.*',
     'types_boto3_s3.*',


### PR DESCRIPTION
This lets us see our AWS costs for the past `--months n` or `--days n` and can break things down by service (`-v`), sub-service (`-vv`) or everything (`-vvv`).
    
Add ce:GetCostAndUsage to the cockpit-ci-infractl IAM policy to support it.


Note: I already ran an `infractl sync` to add the `Name` tags to our buckets and add the GetCostAndUsage permission so it's possible to take this for a test drive already.  The buckets will show up (in `-vv`) without names still because the historical data is lacking the Name tag, but it's already slowly starting to populate (some minor charges are visible at the `-vvv` level for September 8 and starting tomorrow, the charges for today should all be properly attributed).