### PR TITLE
job-runner: add timestamps to log output

### DIFF
--- a/checkout-and-run
+++ b/checkout-and-run
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Sequence
+from datetime import datetime, timezone
 
 
 def log(*parts: object) -> None:
@@ -82,7 +83,7 @@ def checkout_and_run(repository: str, revision: str | None, rebase: str | None, 
 
     for cmd in commands:
         try:
-            log('\n+', shlex.join(cmd))
+            log('\n+ {datetime.now(timezone.utc):%T %F} ▶', shlex.join(cmd))
             os.execv(cmd[0], tuple(cmd))
         except FileNotFoundError as exc:
             log(exc)
@@ -104,7 +105,7 @@ def main() -> None:
     parser.add_argument('command', nargs='*', help="The command to run [default: .cockpit-ci/run]")
 
     args = parser.parse_args()
-    log('\n+ [checkout-and-run]', shlex.join(sys.argv[1:]))
+    log('\n+ {datetime.now(timezone.utc):%T %F} ▶ [checkout-and-run]', shlex.join(sys.argv[1:]))
 
     checkout_and_run(args.repository, args.revision, args.rebase, args.command)
 

--- a/lib/aio/job.py
+++ b/lib/aio/job.py
@@ -85,7 +85,7 @@ async def run_container(job: Job, subject: Subject, ctx: JobContext, log: LogStr
             ctx.default_image
         ).strip()
 
-        log.write(f'Using container image: {container_image}\n')
+        log.write(f'Using container image: {container_image}\n', stamped=True)
 
         try:
             secret_args = ctx.prepare_secrets(job.secrets, tmpdir / 'secrets')
@@ -189,7 +189,7 @@ async def run_job(job: Job, ctx: JobContext) -> None:
                 f'{title}\n\n'
                 f'Running on: {platform.node()} as {invocation_id or "(unknown invocation)"}\n'
                 f'{journal}\n'
-                f'Job({json.dumps(job, default=lambda obj: obj.__dict__, indent=4)})\n\n'
+                f'Job({json.dumps(job, default=lambda obj: obj.__dict__, indent=4)})\n'
             )
             await status.post('pending', 'In progress')
 
@@ -208,7 +208,7 @@ async def run_job(job: Job, ctx: JobContext) -> None:
             await gather_and_cancel(tasks)
 
         except Failure as exc:
-            log.write(f'\n*** Failure: {exc}\n')
+            log.write(f'*** Failure: {exc}\n', stamped=True)
             await status.post('failure', str(exc))
 
             if job.report is not None:
@@ -225,18 +225,18 @@ async def run_job(job: Job, ctx: JobContext) -> None:
 
         except asyncio.CancelledError:
             await status.post('error', 'Cancelled')
-            log.write('*** Job cancelled\n')
+            log.write('*** Job cancelled\n', stamped=True)
             raise
 
         except BaseException as exc:
             # ie: bug in this program, but let's be helpful
             await status.post('error', 'Internal error')
-            log.write('\n\n' + '\n'.join(traceback.format_exception(exc)) + '\n')
+            log.write('\n\n' + '\n'.join(traceback.format_exception(exc)) + '\n', stamped=True)
             raise
 
         else:
             await status.post('success', 'Success')
-            log.write('\n\nJob ran successfully.  :)\n')
+            log.write('Job ran successfully.  :)\n', stamped=True)
 
         finally:
             log.close()

--- a/lib/aio/s3streamer.py
+++ b/lib/aio/s3streamer.py
@@ -19,6 +19,7 @@ import logging
 import os
 import textwrap
 from collections.abc import Collection
+from datetime import datetime, timezone
 from typing import ClassVar
 
 from yarl import URL
@@ -141,7 +142,10 @@ class LogStreamer:
         self.send_pending()
         AttachmentsDirectory(self.index, f'{LIB_DIR}/s3-html').scan()
 
-    def write(self, data: str) -> None:
+    def write(self, data: str, stamped: bool = False) -> None:
+        if stamped:
+            self.pending += f"\n\n{datetime.now(timezone.utc):%F %T} ▶ ".encode()
+
         self.pending += data.encode()
 
         if len(self.pending) > LogStreamer.SIZE_LIMIT:


### PR DESCRIPTION
This prints the UTC time at the start and end of a test run.